### PR TITLE
💄 메인 템플릿 레이아웃 간격 설정

### DIFF
--- a/client/src/components/right-sidebar.tsx
+++ b/client/src/components/right-sidebar.tsx
@@ -15,6 +15,8 @@ const CreatRoomModal = styled.div`
   border-radius: 30px;
   width: 100%;
   height: 100%;
+  min-width: 350px;
+  max-width: 400px;
   margin-bottom: 10%;
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
 `;

--- a/client/src/components/styled-components/room-card.tsx
+++ b/client/src/components/styled-components/room-card.tsx
@@ -87,7 +87,7 @@ const RoomCardInfo = styled.div`
 const RoomCardLayout = styled.div`
   background-color: #FFFFFF;
   border-radius: 25px;
-  width: 600px;
+  width: 100%;
 `;
 
 export default function RoomCard({ title, users } : roomCardProps) {

--- a/client/src/views/main-view.tsx
+++ b/client/src/views/main-view.tsx
@@ -21,7 +21,26 @@ const MainLayout = styled.div`
 const SectionLayout = styled.div`
   position: relative;
   display: flex;
+  width: 100vw;
   height: 500px;
+`;
+
+const ActiveFollowingLayout = styled.div`
+  flex-grow : 1;
+  margin: 10px;
+  @media (min-width: 768px) and (max-width: 1024px) {
+    display: none;
+  }
+`;
+const MainSectionLayout = styled.div`
+  width: 100%;
+  min-width: 500px;
+  flex-grow : 3;
+  margin: 10px;
+`;
+const RoomLayout = styled.div`
+  flex-grow : 2;
+  margin: 10px;
 `;
 
 const ButtonLayout = styled.div`
@@ -40,9 +59,15 @@ function MainView() {
       <>
         <HeaderRouter />
         <SectionLayout>
-          <LeftSideBar />
-          <MainRouter />
-          <RightSideBar />
+          <ActiveFollowingLayout>
+            <LeftSideBar />
+          </ActiveFollowingLayout>
+          <MainSectionLayout>
+            <MainRouter />
+          </MainSectionLayout>
+          <RoomLayout>
+            <RightSideBar />
+          </RoomLayout>
         </SectionLayout>
       </>
     );


### PR DESCRIPTION
### 작업내용
- 각 섹션의 넓이를 100%로 조정
- 메인 뷰에서 flex-grow를 통해 간격 설정 1:3:2
- 섹션별 마진값 설정 : 10px
- 테블릿 이하 환경 시 활동중인 팔로워 목록 안보이게 임시 조치..