### PR TITLE
방 생성하기 DB 연동 (#6)

### DIFF
--- a/client/src/components/right-sidebar.tsx
+++ b/client/src/components/right-sidebar.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable object-shorthand */
 import React, { useState, useRef } from 'react';
 import styled from 'styled-components';
 import { useRecoilState } from 'recoil';
@@ -52,10 +53,9 @@ function RightSideBar() {
     const roomInfo = {
       type: roomType,
       title: inputRef.current?.value,
-      participants: ['test'],
-      isAnonymous,
+      participants: 'dlatqdlatq',
+      isAnonymous: isAnonymous,
     };
-
     fetch(`${process.env.REACT_APP_API_URL}/api/room`, {
       method: 'post',
       headers: {

--- a/client/src/components/right-sidebar.tsx
+++ b/client/src/components/right-sidebar.tsx
@@ -50,10 +50,11 @@ function RightSideBar() {
   const [isAnonymous, setIsAnonymous] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const submitButtonHandler = () => {
+    // userId 현재 아이디 가져와야함
     const roomInfo = {
       type: roomType,
       title: inputRef.current?.value,
-      participants: 'dlatqdlatq',
+      userId: 'dlatqdlatq',
       isAnonymous: isAnonymous,
     };
     fetch(`${process.env.REACT_APP_API_URL}/api/room`, {

--- a/server/package.json
+++ b/server/package.json
@@ -10,12 +10,14 @@
     "ts-node": "ts-node -r tsconfig-paths/register ./src/app.ts"
   },
   "dependencies": {
+    "@types/redis": "^2.8.32",
     "cors": "^2.8.5",
     "dotenv": "^10.0.0",
     "express": "^4.17.1",
     "helmet": "^4.6.0",
     "module-alias": "^2.2.2",
-    "mongoose": "^6.0.12"
+    "mongoose": "^6.0.12",
+    "redis": "^3.1.2"
   },
   "devDependencies": {
     "@types/cors": "^2.8.12",

--- a/server/src/api/routes/room.ts
+++ b/server/src/api/routes/room.ts
@@ -1,6 +1,7 @@
 import {
   Router, Request, Response,
 } from 'express';
+import roomService from '@services/rooms-service';
 
 const route = Router();
 
@@ -10,8 +11,10 @@ export default (app: Router) => {
   route.post('/', (req: Request, res: Response) => {
     try {
       const {
-        type, title, participants, isAnonymus,
+        title, type, userId, isAnonymous,
       } = req.body;
+
+      roomService.setRoom(title, type, userId, isAnonymous);
 
       res.status(200).send('success!');
     } catch (error) {

--- a/server/src/models/rooms.ts
+++ b/server/src/models/rooms.ts
@@ -20,7 +20,7 @@ const roomSchema = new Schema({
     type: Boolean,
     required: true,
   },
-  userList: {
+  participants: {
     type: [String],
     default: [],
   },

--- a/server/src/models/rooms.ts
+++ b/server/src/models/rooms.ts
@@ -26,4 +26,4 @@ const roomSchema = new Schema({
   },
 });
 
-export default model<IRooms>('events', roomSchema);
+export default model<IRooms>('rooms', roomSchema);

--- a/server/src/models/rooms.ts
+++ b/server/src/models/rooms.ts
@@ -1,0 +1,29 @@
+import { Schema, Document, model } from 'mongoose';
+
+export interface IRooms extends Document{
+  title: string,
+  type: string,
+  isAnonymous: boolean,
+  userList: Array<String>,
+}
+
+const roomSchema = new Schema({
+  title: {
+    type: String,
+    required: true,
+  },
+  type: {
+    type: String,
+    required: true,
+  },
+  isAnonymous: {
+    type: Boolean,
+    required: true,
+  },
+  userList: {
+    type: [String],
+    default: [],
+  },
+});
+
+export default model<IRooms>('events', roomSchema);

--- a/server/src/services/rooms-service.ts
+++ b/server/src/services/rooms-service.ts
@@ -5,13 +5,13 @@ import redis from 'redis';
 
 export default {
   setRoom: async (title: string, type: string, userId: string, isAnonymous: boolean) => {
-    const roomUserList = [userId];
+    const participants = [userId];
     // userId 현재 아이디 가져와야 함
     const profileUrlObject : any = await Users.findOne({ userId: 'dlatqdlatq' }).select('profileUrl');
     const { profileUrl } = profileUrlObject.toObject();
 
     const newRoom = new Rooms({
-      title, type, isAnonymous, roomUserList,
+      title, type, isAnonymous, participants,
     });
     const redisClient = redis.createClient();
 

--- a/server/src/services/rooms-service.ts
+++ b/server/src/services/rooms-service.ts
@@ -1,0 +1,24 @@
+/* eslint-disable no-underscore-dangle */
+import Rooms from '@models/rooms';
+import Users from '@models/users';
+import redis from 'redis';
+
+export default {
+  setRoom: async (title: string, type: string, userId: string, isAnonymous: boolean) => {
+    const roomUserList = [userId];
+    // userId 현재 아이디 가져와야 함
+    const profileUrlObject : any = await Users.findOne({ userId: 'dlatqdlatq' }).select('profileUrl');
+    const { profileUrl } = profileUrlObject.toObject();
+
+    const newRoom = new Rooms({
+      title, type, isAnonymous, roomUserList,
+    });
+    const redisClient = redis.createClient();
+
+    redisClient.hset(userId, 'roomId', `${newRoom._id}`);
+    redisClient.hset(userId, 'profileUrl', `${profileUrl}`);
+    redisClient.hset(userId, 'mic', 'true');
+
+    return newRoom.save();
+  },
+};

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -761,6 +761,13 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
+"@types/redis@^2.8.32":
+  version "2.8.32"
+  resolved "https://registry.yarnpkg.com/@types/redis/-/redis-2.8.32.tgz#1d3430219afbee10f8cfa389dad2571a05ecfb11"
+  integrity sha512-7jkMKxcGq9p242exlbsVzuJb57KqHRhNl4dHoQu2Y5v9bCAbtIXXH0R3HleSQW4CTOqpHIYUW3t6tpUj4BVQ+w==
+  dependencies:
+    "@types/node" "*"
+
 "@types/serve-static@*":
   version "1.13.10"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.10.tgz#f5e0ce8797d2d7cc5ebeda48a52c96c4fa47a8d9"
@@ -1547,6 +1554,11 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
+
+denque@^1.5.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-1.5.1.tgz#07f670e29c9a78f8faecb2566a1e2c11929c5cbf"
+  integrity sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==
 
 denque@^2.0.1:
   version "2.0.1"
@@ -3896,6 +3908,33 @@ readdirp@~3.6.0:
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
+
+redis-commands@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/redis-commands/-/redis-commands-1.7.0.tgz#15a6fea2d58281e27b1cd1acfb4b293e278c3a89"
+  integrity sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==
+
+redis-errors@^1.0.0, redis-errors@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/redis-errors/-/redis-errors-1.2.0.tgz#eb62d2adb15e4eaf4610c04afe1529384250abad"
+  integrity sha1-62LSrbFeTq9GEMBK/hUpOEJQq60=
+
+redis-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-3.0.0.tgz#b66d828cdcafe6b4b8a428a7def4c6bcac31c8b4"
+  integrity sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=
+  dependencies:
+    redis-errors "^1.0.0"
+
+redis@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/redis/-/redis-3.1.2.tgz#766851117e80653d23e0ed536254677ab647638c"
+  integrity sha512-grn5KoZLr/qrRQVwoSkmzdbw6pwF+/rwODtrOr6vuBRiR/f3rjSTGupbF90Zpqm2oenix8Do6RV7pYEkGwlKkw==
+  dependencies:
+    denque "^1.5.0"
+    redis-commands "^1.7.0"
+    redis-errors "^1.2.0"
+    redis-parser "^3.0.0"
 
 regexp-clone@1.0.0, regexp-clone@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## 작업사항

- Room 관련 DB 설계
- room 생성 버튼 클릭시 DB에 데이터 추가
    - 이때, 유저 배열에 빈 배열이 들어가는 이슈 발생

### Room DB 관련 부분

- Redis 의 hash data type의 경우 value는 string형으로만 값을 받을수 있습니다.
- room에 있는 유저들의 배열을 만들어주려면 redis의 다른 DB를 선택해서 join과 같은 방법으로 구현하는 수밖에 없는데 이렇게 되면 redis를 사용하는 이유가 없어진다고 생각을 해서 room 자체는 mongoDB에 데이터를 저장하고, 접속한 유저만 redis에 저장을 하는 방식을 생각해봤습니다
- 이렇게 하게되면 방에 접속을 할때 redis에 해당 유저 정보가 들어가기 때문에 추후에 socket 부분을 구현하는 경우 큰 리팩토링 없이 추가적으로 구현해줄수 있을것 같습니다.
- 현재 생각한 room DB 구조
![스크린샷 2021-11-07 오후 11 20 25](https://user-images.githubusercontent.com/51700274/140648899-def63d46-a431-49b0-8f8e-beec176358d1.png)
