### PR TITLE
로그인 회원가입 구현

### DIFF
--- a/client/src/assets/styles/keyframe.ts
+++ b/client/src/assets/styles/keyframe.ts
@@ -17,3 +17,8 @@ to{
     transform: translateY(${to}px);
 }
 `;
+
+export const spinner = () => keyframes`
+    from {transform: rotate(0deg); }
+    to {transform: rotate(360deg);}
+`;

--- a/client/src/components/styled-components/loading-spinner.tsx
+++ b/client/src/components/styled-components/loading-spinner.tsx
@@ -1,0 +1,19 @@
+import styled from 'styled-components';
+
+import { spinner } from '@styles/keyframe';
+
+export default styled.div`
+  box-sizing: border-box;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 64px;
+  height: 64px;
+  margin-top: -32px;
+  margin-left: -32px;
+  border-radius: 50%;
+  border: 8px solid transparent;
+  border-top-color: #c4c0ae;
+  border-bottom-color: #c4c0ae;
+  animation: ${spinner()} .8s ease infinite;
+`;

--- a/client/src/utils/index.tsx
+++ b/client/src/utils/index.tsx
@@ -20,3 +20,7 @@ export const makeIconToLink = ({
 
 // Date객체 -> 시간 : 분 string 으로 변환
 export const makeDateToHourMinute = (date : Date) => `${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
+
+const emailRule = /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$/i;
+
+export const testEmailValidation = (string: string): boolean => emailRule.test(string);

--- a/client/src/views/main-view.tsx
+++ b/client/src/views/main-view.tsx
@@ -15,6 +15,7 @@ import MainRouter from '@routes/main';
 import DefaultButton from '@styled-components/default-button';
 import ScrollBarStyle from '@styles/scrollbar-style';
 import EventRegisterModal from '@components/event-register-modal';
+import LoadingSpinner from '@styled-components/loading-spinner';
 
 const MainLayout = styled.div`
   display: flex;
@@ -72,7 +73,7 @@ const ButtonLayout = styled.div`
 
 function MainView() {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
-  // const [cookies] = useCookies(['jwt']);
+  const [loading, setLoading] = useState(true);
   const setNowFetching = useSetRecoilState(nowFetchingState);
   const nowFetchingRef = useRef<boolean>(false);
 
@@ -94,11 +95,15 @@ function MainView() {
     })
       .then((res) => res.json())
       .then((json) => {
-        console.log(json);
         if (json.ok) setIsLoggedIn(true);
         else setIsLoggedIn(false);
-      });
+      })
+      .then(() => { setLoading(false); });
   }, []);
+
+  if (loading) {
+    return <LoadingSpinner />;
+  }
 
   if (isLoggedIn) {
     return (

--- a/client/src/views/signup-info-view.tsx
+++ b/client/src/views/signup-info-view.tsx
@@ -92,7 +92,7 @@ function SignupInfoView() {
               <CustomInputBar key="id" ref={inputIdRef} onChange={inputOnChange} type="text" placeholder="Nick name" />
             </CustomInputBox>
             <DefaultButton buttonType="secondary" size="medium" onClick={() => { onClickInputViewNextButton(); }} isDisabled={isDisabled}>
-              NEXT2
+              NEXT
             </DefaultButton>
           </>
         ) : (

--- a/client/src/views/signup-info-view.tsx
+++ b/client/src/views/signup-info-view.tsx
@@ -2,6 +2,8 @@
 import React, {
   MouseEvent, useCallback, useRef, useState,
 } from 'react';
+import styled from 'styled-components';
+import { useHistory, useLocation } from 'react-router-dom';
 
 import SignHeader from '@components/sign-header';
 import SignTitle from '@components/styled-components/sign-title';
@@ -10,16 +12,32 @@ import DefaultButton from '@components/styled-components/default-button';
 import { CustomInputBox, CustomInputBar } from '@styled-components/custom-inputbar';
 import InterestItem from '@styled-components/interest-item';
 
+const InterestItemWarapper = styled.div`
+  width: 50%;
+  display: flex;
+  flex-wrap: wrap;
+  div {
+    margin-right: 5%;
+    margin-bottom: 5%;
+  }
+  margin-top: 5%;
+  margin-right: -5%;
+`;
+
 function SignupInfoView() {
   const inputPasswordRef = useRef<HTMLInputElement>(null);
   const inputFullNameRef = useRef<HTMLInputElement>(null);
-  const inputNickNameRef = useRef<HTMLInputElement>(null);
+  const inputIdRef = useRef<HTMLInputElement>(null);
   const [isDisabled, setIsDisabled] = useState(true);
   const [isInputBarView, setIsInputBarView] = useState(true);
-  const selectedItems = useRef<Set<string>>(new Set());
+  const history = useHistory();
+  const location = useLocation();
+
+  const selectedItems = new Set();
+  const userInput = useRef<{ id: string, password: string, name: string}>({ id: '', password: '', name: '' });
 
   const inputOnChange = useCallback(() => {
-    if (inputPasswordRef.current?.value && inputFullNameRef.current?.value && inputNickNameRef.current?.value) {
+    if (inputPasswordRef.current?.value && inputFullNameRef.current?.value && inputIdRef.current?.value) {
       setIsDisabled(false);
     } else {
       setIsDisabled(true);
@@ -28,7 +46,35 @@ function SignupInfoView() {
 
   const onClickInterestItem = (e: MouseEvent) => {
     const interestName = e.currentTarget?.textContent?.slice(2);
-    if (typeof interestName === 'string') selectedItems.current.add(interestName);
+    if (typeof interestName === 'string') selectedItems.add(interestName);
+  };
+
+  const onClickInputViewNextButton = () => {
+    userInput.current.id = inputIdRef.current?.value as string;
+    userInput.current.password = inputPasswordRef.current?.value as string;
+    userInput.current.name = inputFullNameRef.current?.value as string;
+    setIsInputBarView(false);
+  };
+
+  const onClickInterestViewNextButton = () => {
+    const postSignupUserInfoConfig = {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        loginType: 'normal',
+        userId: userInput.current.id,
+        password: userInput.current.password,
+        userName: userInput.current.name,
+        userEmail: (location.state as {email: string}).email,
+        interesting: Array.from(selectedItems),
+      }),
+    };
+
+    fetch(`${process.env.REACT_APP_API_URL}/api/user/signup/userInfo`, postSignupUserInfoConfig)
+      .then((res) => res.json())
+      .then(() => { history.replace('/'); });
   };
 
   return (
@@ -42,19 +88,38 @@ function SignupInfoView() {
               <CustomInputBar key="password" ref={inputPasswordRef} onChange={inputOnChange} type="text" placeholder="Password" />
               <SignTitle title="what’s your full name?" />
               <CustomInputBar key="fullName" ref={inputFullNameRef} onChange={inputOnChange} type="text" placeholder="Full name" />
-              <SignTitle title="what’s your nickname?" />
-              <CustomInputBar key="nickName" ref={inputNickNameRef} onChange={inputOnChange} type="text" placeholder="Nick name" />
+              <SignTitle title="what’s your id?" />
+              <CustomInputBar key="id" ref={inputIdRef} onChange={inputOnChange} type="text" placeholder="Nick name" />
             </CustomInputBox>
-            <DefaultButton buttonType="secondary" size="medium" onClick={() => { setIsInputBarView(false); }} isDisabled={isDisabled}>
-              NEXT
+            <DefaultButton buttonType="secondary" size="medium" onClick={() => { onClickInputViewNextButton(); }} isDisabled={isDisabled}>
+              NEXT2
             </DefaultButton>
           </>
         ) : (
           <>
             <CustomInputBox>
               <SignTitle title="what’s your interests?" />
-              <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
+              <InterestItemWarapper>
+                <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
+                <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
+                <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
+                <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
+                <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
+                <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
+                <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
+                <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
+                <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
+                <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
+                <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
+                <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
+                <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
+                <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
+                <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
+              </InterestItemWarapper>
             </CustomInputBox>
+            <DefaultButton buttonType="secondary" size="medium" onClick={() => { onClickInterestViewNextButton(); }} isDisabled={isDisabled}>
+              NEXT
+            </DefaultButton>
           </>
         )}
       </SignBody>

--- a/client/src/views/signup-view.tsx
+++ b/client/src/views/signup-view.tsx
@@ -3,18 +3,31 @@ import React, { useCallback, useRef, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 
-import SignHeader from '@src/components/sign-header';
-import SignTitle from '@src/components/styled-components/sign-title';
-import SignBody from '@src/components/styled-components/sign-body';
-import DefaultButton from '@src/components/styled-components/default-button';
+import SignHeader from '@components/sign-header';
+import { BackgroundWrapper } from '@styled-components/modal';
+import LoadingSpinner from '@styled-components/loading-spinner';
+import SignTitle from '@styled-components/sign-title';
+import SignBody from '@styled-components/sign-body';
+import DefaultButton from '@styled-components/default-button';
 import { CustomInputBox, CustomInputBar } from '@styled-components/custom-inputbar';
+import { testEmailValidation } from '@utils/index';
+
+const CustomBackgroundWrapper = styled(BackgroundWrapper)`
+  opacity: 0.4;
+`;
 
 function SignUpView() {
   const inputEmailRef = useRef<HTMLInputElement>(null);
   const inputVerificationRef = useRef<HTMLInputElement>(null);
+  const verificationNumber = useRef<number>();
   const [isEmailInputView, setIsEmailInputView] = useState(true);
   const [isDisabled, setIsDisabled] = useState(true);
+  const [loading, setLoading] = useState(false);
   const history = useHistory();
+
+  const setVerificationNumber = useCallback((number: number) => {
+    verificationNumber.current = number;
+  }, []);
 
   const inputOnChange = useCallback(() => {
     if (inputEmailRef.current?.value
@@ -26,16 +39,46 @@ function SignUpView() {
   }, []);
 
   const onClickEmailNextButton = () => {
-    setIsDisabled(true);
-    setIsEmailInputView(false);
+    const inputEmailValue = inputEmailRef.current?.value as string;
+
+    if (testEmailValidation(inputEmailValue)) {
+      setLoading(true);
+
+      const postSignupMailConfig = {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ email: inputEmailValue }),
+      };
+
+      fetch(`${process.env.REACT_APP_API_URL}/api/user/signup/mail`, postSignupMailConfig)
+        .then((res) => res.json())
+        .then((json) => json.verificationNumber)
+        .then(setVerificationNumber)
+        .then(() => {
+          setLoading(false);
+          setIsDisabled(true);
+          setIsEmailInputView(false);
+        });
+    } else {
+      alert('올바른 이메일을 입력해주세요');
+    }
   };
 
   const onClickVerificationNextButton = () => {
-    history.replace('/signup/info');
+    const inputVerificationValue = inputVerificationRef.current?.value as string;
+
+    if (inputVerificationValue === (verificationNumber.current?.toString())) {
+      history.replace('/signup/info');
+    } else {
+      alert('인증번호를 확인하세요.');
+    }
   };
 
   return (
     <>
+      {loading && <CustomBackgroundWrapper><LoadingSpinner /></CustomBackgroundWrapper>}
       <SignHeader />
       <SignBody>
         {isEmailInputView

--- a/client/src/views/signup-view.tsx
+++ b/client/src/views/signup-view.tsx
@@ -23,6 +23,7 @@ function SignUpView() {
   const [isEmailInputView, setIsEmailInputView] = useState(true);
   const [isDisabled, setIsDisabled] = useState(true);
   const [loading, setLoading] = useState(false);
+  const emailState = useRef<string>();
   const history = useHistory();
 
   const setVerificationNumber = useCallback((number: number) => {
@@ -57,6 +58,7 @@ function SignUpView() {
         .then((json) => json.verificationNumber)
         .then(setVerificationNumber)
         .then(() => {
+          emailState.current = inputEmailValue;
           setLoading(false);
           setIsDisabled(true);
           setIsEmailInputView(false);
@@ -70,7 +72,7 @@ function SignUpView() {
     const inputVerificationValue = inputVerificationRef.current?.value as string;
 
     if (inputVerificationValue === (verificationNumber.current?.toString())) {
-      history.replace('/signup/info');
+      history.replace('/signup/info', { email: emailState.current });
     } else {
       alert('인증번호를 확인하세요.');
     }

--- a/server/package.json
+++ b/server/package.json
@@ -21,6 +21,7 @@
     "jsonwebtoken": "^8.5.1",
     "module-alias": "^2.2.2",
     "mongoose": "^6.0.12",
+    "nodemailer": "^6.7.0",
     "redis": "^3.1.2"
   },
   "devDependencies": {
@@ -32,6 +33,7 @@
     "@types/jsonwebtoken": "^8.5.5",
     "@types/mongoose": "^5.11.97",
     "@types/node": "^16.11.6",
+    "@types/nodemailer": "^6.4.4",
     "@typescript-eslint/eslint-plugin": "^5.2.0",
     "@typescript-eslint/parser": "^5.2.0",
     "eslint": "^7.32.0",

--- a/server/src/api/routes/user.ts
+++ b/server/src/api/routes/user.ts
@@ -34,8 +34,11 @@ export default (app: Router) => {
 
   userRouter.post('/signup/userInfo', async (req: Request, res: Response) => {
     const info = req.body;
-    const result = await usersService.signup(info);
-    console.log(result)
-    res.json({ ok: true });
+    try {
+      await usersService.signup(info);
+      res.json({ok: true, msg: 'signup success' });
+    } catch(e) {
+      res.json({ ok: false, msg: 'signup error' })
+    }
   })
 };

--- a/server/src/api/routes/user.ts
+++ b/server/src/api/routes/user.ts
@@ -24,4 +24,12 @@ export default (app: Router) => {
       res.status(400).json({ result: result?.result, msg: result?.msg });
   });
 
+  userRouter.post('/signup/mail', async (req: Request, res: Response) => {
+    const { email } = req.body;
+
+    const verificationNumber = await usersService.sendVerificationMail(email);
+    
+    res.json({ verificationNumber });
+  })
+
 };

--- a/server/src/api/routes/user.ts
+++ b/server/src/api/routes/user.ts
@@ -30,6 +30,12 @@ export default (app: Router) => {
     const verificationNumber = await usersService.sendVerificationMail(email);
     
     res.json({ verificationNumber });
-  })
+  });
 
+  userRouter.post('/signup/userInfo', async (req: Request, res: Response) => {
+    const info = req.body;
+    const result = await usersService.signup(info);
+    console.log(result)
+    res.json({ ok: true });
+  })
 };

--- a/server/src/services/users-service.ts
+++ b/server/src/services/users-service.ts
@@ -5,7 +5,21 @@ import Users from '@models/users';
 import RefreshTokens from '@models/refresh-token';
 import jwt from '@utils/jwt-util';
 
+interface ISignupUserInfo {
+  loginType: string,
+  userId: string,
+  password: string,
+  userName: string,
+  userEmail: string,
+  interesting: string[]
+}
+
 export default {
+  signup: (info: ISignupUserInfo) => {
+    const newResult = new Users(info);
+    return newResult.save();
+  },
+
   signIn: async (email: string, password: string) => {
     const user = await Users.findOne({ userEmail: email });
 

--- a/server/src/services/users-service.ts
+++ b/server/src/services/users-service.ts
@@ -1,10 +1,12 @@
 /* eslint-disable consistent-return */
+import nodemailer from 'nodemailer';
+
 import Users from '@models/users';
 import RefreshTokens from '@models/refresh-token';
 import jwt from '@utils/jwt-util';
 
 export default {
-  signIn: async (email: string, password:string) => {
+  signIn: async (email: string, password: string) => {
     const user = await Users.findOne({ userEmail: email });
 
     if (!user) {
@@ -31,5 +33,32 @@ export default {
       return null;
     }
     return refreshToken.token;
+  },
+
+  sendVerificationMail: async (email: string) => {
+    const transporter = nodemailer.createTransport({
+      service: 'gmail',
+      port: 587,
+      host: 'smtp.gmail.com',
+      secure: false,
+      requireTLS: true,
+      auth: {
+        user: 'hyunee169@gmail.com',
+        pass: 'nogari159',
+      },
+    });
+
+    const VerificationNumber = String(Math.floor(Math.random() * 999999)).padStart(6, '0');
+
+    const send = await transporter.sendMail({
+      from: 'hyunee169@gmail.com',
+      to: email,
+      subject: '인증번호입니다.',
+      text: VerificationNumber,
+    });
+
+    console.log(send);
+
+    return VerificationNumber;
   },
 };

--- a/server/src/services/users-service.ts
+++ b/server/src/services/users-service.ts
@@ -31,7 +31,6 @@ export default {
 
     if (isMatch) {
       const accessToken = await jwt.sign(user.userId, user.userEmail);
-      console.log(accessToken);
       return { token: accessToken, result: true, msg: 'ok' };
     }
     return { token: null, result: false, msg: 'wrong password' };
@@ -58,7 +57,7 @@ export default {
       requireTLS: true,
       auth: {
         user: 'hyunee169@gmail.com',
-        pass: 'nogari159',
+        pass: process.env.GMAIL_PASS,
       },
     });
 
@@ -70,8 +69,6 @@ export default {
       subject: '인증번호입니다.',
       text: VerificationNumber,
     });
-
-    console.log(send);
 
     return VerificationNumber;
   },

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -782,6 +782,13 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.6.tgz#6bef7a2a0ad684cf6e90fcfe31cecabd9ce0a3ae"
   integrity sha512-ua7PgUoeQFjmWPcoo9khiPum3Pd60k4/2ZGXt18sm2Slk0W0xZTqt5Y0Ny1NyBiN1EVQ/+FaF9NcY4Qe6rwk5w==
 
+"@types/nodemailer@^6.4.4":
+  version "6.4.4"
+  resolved "https://registry.yarnpkg.com/@types/nodemailer/-/nodemailer-6.4.4.tgz#c265f7e7a51df587597b3a49a023acaf0c741f4b"
+  integrity sha512-Ksw4t7iliXeYGvIQcSIgWQ5BLuC/mljIEbjf615svhZL10PE9t+ei8O9gDaD3FPCasUJn9KTLwz2JFJyiiyuqw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/prettier@^2.1.5":
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.4.1.tgz#e1303048d5389563e130f5bdd89d37a99acb75eb"
@@ -3741,6 +3748,11 @@ node-releases@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.1.tgz#3d1d395f204f1f2f29a54358b9fb678765ad2fc5"
   integrity sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==
+
+nodemailer@^6.7.0:
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-6.7.0.tgz#86614722c4e0c33d1b5b02aecb90d6d629932b0d"
+  integrity sha512-AtiTVUFHLiiDnMQ43zi0YgkzHOEWUkhDgPlBXrsDzJiJvB29Alo4OKxHQ0ugF3gRqRQIneCLtZU3yiUo7pItZw==
 
 nodemon@^2.0.14:
   version "2.0.14"


### PR DESCRIPTION
## 개요
로그인 / 회원가입 기능 #32 #31 
## 작업사항
JWT 인증 로직을 제외한 부분 작업입니다.
커밋 단위로 내용을 설명드리면

1. loading-spinner 스타일 컴포넌트를 작성해서 fetch 요청을 기다려야하는 부분에서 사용했습니다. 
loading이라는 내부 상태를 만들어서 로딩 화면을 보여줄지 아닌지 관리하였습니다.
2. nodemailer 패키지 설치
3. 회원가입  시 email을 입력했을 때 유효한 형식인지 확인해주는 util 함수를 작성했습니다.
이 부분은 password나 다른 부분에서도 적용할 수 있도록 추후에 기능 추가를 해보겠습니다.
4. 인증번호를 Math를 통해서 난수생성을 해주었고, 이 난수를 email과 클라이언트에게 동시에 발송합니다.
5. 클라이언트는 받은 난수와 사용자가 입력한 난수가 일치하는지 체크하고 다음 화면으로 넘어갑니다.
6. 입력값들을 바탕으로 회원등록을 마무리합니다.

우선 normal Type의 회원가입은 모두 마무리 되었습니다!

## 사용방법
loading-spinner 스타일 컴포넌트 : css keyframe을 통한 애니메이션으로 그냥 빙글빙글 도는 화면입니다. 사용한 컴포넌트 내부에 loading 상태를 따로 정의해서 상태에 따라서 어떠한 화면을 보여줄 지 결정해야합니다.

## 기타

1. nodemailer : 현재 임시로 제 구글 계정으로 보내고 있습니다. 시간 날 때 팀 계정을 만들어 볼게요!

2. 코드 리팩토링이 필요한 부분이 있어서 이슈에 등록해놓겠습니다.

3. 예외처리
- 로그인이 되어있어도 주소창이 /signup, /singup/info, /signin 등을 직접 입력해주면 해당 페이지로 이동하게 됩니다. 라우터에서 리다이렉트 처리를 해주어야 할 것 같은데 어떻게 해야할지 고민입니다!

4. 클라이언트에서 유저 상태 관리
- 유저상태를 전역 state로 관리할지 vs 쿠키에 있는 토큰을 이용해서 필요 시마다 조회할지
- 전역 state로 관리해도 상태가 많이 변경되는 것이 아니기 때문에 불필요한 렌더링이 적을 것 같다고 생각했었는데 쿠키를 사용하니 굳이 해줘야하나 싶기도 합니다 의견이 궁금해요! 

5. alert 창 관련
- 예외나 알림이 발생하면 일단 alert을 띄워주고 있는데 브라우저의 alert를 계속 사용하는 게 괜찮을지 궁금합니다