### PR TITLE
[2-7] 관심있는 방 접속하기 거의 구현

### DIFF
--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -1,1 +1,31 @@
-export {};
+/* eslint-disable consistent-return */
+// eslint-disable-next-line consistent-return
+export const getRoomInfo = async (roomDocumentId: string) => {
+  try {
+    let response = await fetch(`${process.env.REACT_APP_API_URL}/api/room/${roomDocumentId}`, {
+      method: 'get',
+      headers: {
+        'Content-Typ': 'application/json',
+      },
+    });
+    response = await response.json();
+    return response;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+export const getUserInfo = async (userDocumentId: string) => {
+  try {
+    let response = await fetch(`${process.env.REACT_APP_API_URL}/api/user/${userDocumentId}`, {
+      method: 'get',
+      headers: {
+        'Content-Typ': 'application/json',
+      },
+    });
+    response = await response.json();
+    return response;
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/client/src/components/in-room-modal.tsx
+++ b/client/src/components/in-room-modal.tsx
@@ -1,17 +1,162 @@
+/* eslint-disable max-len */
 /* eslint-disable object-shorthand */
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useRecoilState } from 'recoil';
+import styled from 'styled-components';
+import {
+  FiMoreHorizontal, FiScissors, FiPlus, FiMic, FiMicOff,
+} from 'react-icons/fi';
+import io from 'socket.io-client';
 
 import userTypeState from '@atoms/user';
+import DefaultButton from '@styled-components/default-button';
+import InRoomUserBox, { IParticipant } from '@components/in-room-user-box';
+// import useConnectSocket from '@hooks/useConnectSocket';
+import { getRoomInfo } from '@api/index';
+
+export interface IRooms extends Document{
+  title: string,
+  type: string,
+  isAnonymous: boolean,
+  participants: Array<IParticipant>,
+}
+
+const InRoomHeader = styled.div`
+  position: absolute;
+  top: 10px;
+
+  display: flex;
+  flex-direction: row;
+
+  padding: 20px 10px 20px 10px;
+
+  width: 100%;
+  height: 25px;
+`;
+
+const TitleDiv = styled.div`
+  font-family: "Nunito";
+  font-style: normal;
+  font-size: 20px;
+
+  width: 70%;
+
+  margin-left: 30px;
+
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const OptionBtn = styled.div`
+  width: 30%;
+
+  text-align: center;
+  transform: translate(0px, 6px);
+`;
+
+const InRoomFooter = styled.div`
+  position: absolute;
+  bottom: 20px;
+
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+
+  width: 100%;
+`;
+
+const InRoomUserList = styled.div`
+  flex-wrap: wrap;
+`;
+
+const FooterBtnDiv = styled.div`
+  width: 32px;
+  height: 32px;
+
+  border-radius: 30px;
+  margin-top: 5px;
+
+  background-color: #58964F;
+
+  svg {
+    transform: translate(8px, 8px);
+  };
+`;
+
+const leaveEvent = () => 1;
 
 // 룸 생성 모달
 function InRoomModal() {
   const [user] = useRecoilState(userTypeState);
+  const [roomInfo, setRoomInfo] = useState<IRooms>();
+  const [socket, setSocket] = useState<any>(null);
+  const [isMic, setMic] = useState(false);
+
+  // roomId 기반으로 room 정보 불러오기
+  useEffect(() => {
+    getRoomInfo(user.roomId)
+      .then((res: any) => setRoomInfo(res));
+  }, []);
+
+  useEffect(() => {
+    if (socket === null) {
+      const url = process.env.REACT_APP_SERVER_URL as string;
+      setSocket(io(url));
+    }
+    return () => {
+      if (socket !== null) {
+        socket.disconnect();
+        setSocket(null);
+      }
+    };
+  }, [socket]);
+
+  // socket 이벤트
+  useEffect(() => {
+    socket?.emit('room:join', {
+      roomDocumentID: user.roomId, userDocumentId: user.userDocumentId,
+    });
+
+    /*
+      음성채팅 연결 로직 추가
+    */
+
+    // socket?.on('room:join', (payload) => {
+    //   const { userID, userData } = payload;
+    //   dispatch({ type: 'UPDATE_USER', payload: { userID, userData } });
+    // });
+    // socket?.on('room:leave', (payload) => {
+    //   const { userID } = payload;
+    //   dispatch({ type: 'DELETE_USER', payload: { userID } });
+    // });
+    // socket?.on('room:micOff', (payload) => {
+    //   const { userID, userData } = payload;
+    //   dispatch({ type: 'UPDATE_USER', payload: { userID, userData } });
+    // });
+    // socket?.on('room:micOn', (payload) => {
+    //   const { userID, userData } = payload;
+    //   dispatch({ type: 'UPDATE_USER', payload: { userID, userData } });
+    // });
+  }, [socket]);
+
   return (
     <>
-      <h1>
-        { user.roomId }
-      </h1>
+      <InRoomHeader>
+        <TitleDiv><span>{roomInfo?.title}</span></TitleDiv>
+        <OptionBtn><FiMoreHorizontal /></OptionBtn>
+      </InRoomHeader>
+      <InRoomUserList>
+        {roomInfo?.participants?.map((participant) => (
+          <InRoomUserBox userDocumentId={participant.userDocumentId} isMicOn={participant.isMicOn} />
+        ))}
+        <InRoomUserBox userDocumentId={user.userDocumentId} isMicOn={isMic} />
+      </InRoomUserList>
+      <InRoomFooter>
+        <DefaultButton buttonType="active" size="small" onClick={leaveEvent} />
+        <FooterBtnDiv><FiScissors /></FooterBtnDiv>
+        <FooterBtnDiv><FiPlus /></FooterBtnDiv>
+        <FooterBtnDiv>{isMic ? <FiMic onClick={() => setMic(false)} /> : <FiMicOff onClick={() => setMic(true)} />}</FooterBtnDiv>
+      </InRoomFooter>
     </>
   );
 }

--- a/client/src/components/in-room-modal.tsx
+++ b/client/src/components/in-room-modal.tsx
@@ -13,6 +13,7 @@ import DefaultButton from '@styled-components/default-button';
 import InRoomUserBox, { IParticipant } from '@components/in-room-user-box';
 // import useConnectSocket from '@hooks/useConnectSocket';
 import { getRoomInfo } from '@api/index';
+import ScrollBarStyle from '@styles/scrollbar-style';
 
 export interface IRooms extends Document{
   title: string,
@@ -66,7 +67,19 @@ const InRoomFooter = styled.div`
 `;
 
 const InRoomUserList = styled.div`
+  position: absolute;
+
+  display: flex;
   flex-wrap: wrap;
+  justify-content: space-around;
+
+  box-sizing: border-box;
+  padding: 0px 30px;
+
+  width: 100%;
+  height: 70%;
+
+  ${ScrollBarStyle}
 `;
 
 const FooterBtnDiv = styled.div`
@@ -83,11 +96,9 @@ const FooterBtnDiv = styled.div`
   };
 `;
 
-const leaveEvent = () => 1;
-
 // 룸 생성 모달
 function InRoomModal() {
-  const [user] = useRecoilState(userTypeState);
+  const [user, setUser] = useRecoilState(userTypeState);
   const [roomInfo, setRoomInfo] = useState<IRooms>();
   const [socket, setSocket] = useState<any>(null);
   const [isMic, setMic] = useState(false);
@@ -139,6 +150,11 @@ function InRoomModal() {
     // });
   }, [socket]);
 
+  const leaveEvent = () => {
+    const newUser = { ...user, roomId: '' };
+    setUser(newUser);
+  };
+
   return (
     <>
       <InRoomHeader>
@@ -152,7 +168,7 @@ function InRoomModal() {
         <InRoomUserBox userDocumentId={user.userDocumentId} isMicOn={isMic} />
       </InRoomUserList>
       <InRoomFooter>
-        <DefaultButton buttonType="active" size="small" onClick={leaveEvent} />
+        <DefaultButton buttonType="active" size="small" onClick={leaveEvent}> Leave a Quietly </DefaultButton>
         <FooterBtnDiv><FiScissors /></FooterBtnDiv>
         <FooterBtnDiv><FiPlus /></FooterBtnDiv>
         <FooterBtnDiv>{isMic ? <FiMic onClick={() => setMic(false)} /> : <FiMicOff onClick={() => setMic(true)} />}</FooterBtnDiv>

--- a/client/src/components/in-room-user-box.tsx
+++ b/client/src/components/in-room-user-box.tsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from 'react';
+import styled from 'styled-components';
+
+import { getUserInfo } from '@api/index';
+
+export interface IParticipant {
+    userDocumentId: string,
+    isMicOn: boolean,
+}
+
+const InRoomUserBoxStyle = styled.div`
+  position: relative;
+  width: 32px;
+  height: 32px;
+`;
+
+const InRoomUserProfile = styled.div`
+`;
+
+const InRoomUserMic = styled.div`
+
+`;
+
+function InRoomUserBox({ userDocumentId, isMicOn } : IParticipant) {
+  const [userInfo, setUserInfo] = useState<any>();
+  console.log('InRoomUserBox :: ', userInfo);
+
+  useEffect(() => {
+    getUserInfo(userDocumentId)
+      .then((res) => setUserInfo(res));
+  });
+
+  console.log('in room user box ::: ', userDocumentId, isMicOn);
+
+  return (
+    <InRoomUserBoxStyle>
+      <InRoomUserProfile />
+      <InRoomUserMic />
+    </InRoomUserBoxStyle>
+  );
+}
+
+export default InRoomUserBox;

--- a/client/src/components/in-room-user-box.tsx
+++ b/client/src/components/in-room-user-box.tsx
@@ -1,6 +1,11 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
+import {
+  FiMic, FiMicOff,
+} from 'react-icons/fi';
 
+import UserImage from '@styled-components/user-image';
 import { getUserInfo } from '@api/index';
 
 export interface IParticipant {
@@ -10,32 +15,45 @@ export interface IParticipant {
 
 const InRoomUserBoxStyle = styled.div`
   position: relative;
-  width: 32px;
-  height: 32px;
+  width: 80px;
+  height: 90px;
+
+  p {
+    margin: 5px;
+  }
 `;
 
-const InRoomUserProfile = styled.div`
-`;
+const InRoomUserMicDiv = styled.div`
+  position: absolute;
+  right: 10px;
+  bottom: 20px;
 
-const InRoomUserMic = styled.div`
+  width: 30px;
+  height: 30px;
 
+  background-color: #58964F;
+  border-radius: 30px;
+
+  svg {
+    transform: translate(6px, 6px);
+  }
 `;
 
 function InRoomUserBox({ userDocumentId, isMicOn } : IParticipant) {
   const [userInfo, setUserInfo] = useState<any>();
-  console.log('InRoomUserBox :: ', userInfo);
 
   useEffect(() => {
     getUserInfo(userDocumentId)
       .then((res) => setUserInfo(res));
-  });
-
-  console.log('in room user box ::: ', userDocumentId, isMicOn);
+  }, []);
 
   return (
     <InRoomUserBoxStyle>
-      <InRoomUserProfile />
-      <InRoomUserMic />
+      <UserImage profileUrl={userInfo?.profileUrl} />
+      <InRoomUserMicDiv>
+        { isMicOn ? <FiMic /> : <FiMicOff /> }
+      </InRoomUserMicDiv>
+      <p>{ userInfo?.userName }</p>
     </InRoomUserBoxStyle>
   );
 }

--- a/client/src/components/right-sidebar.tsx
+++ b/client/src/components/right-sidebar.tsx
@@ -21,6 +21,8 @@ const RoomModalLayout = styled.div`
   max-width: 400px;
   margin-bottom: 10%;
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+  position: relative;
+
 `;
 
 function RightSideBar() {

--- a/client/src/components/room-modal.tsx
+++ b/client/src/components/room-modal.tsx
@@ -55,7 +55,7 @@ function RoomModal() {
         'Content-Type': 'application/json',
       },
     }).then((res) => res.json())
-      .then((roomId) => setUser({ roomId, userDocumentId: '유저 다큐멘트 아이디' }))
+      .then((roomId) => setUser({ roomId, userDocumentId: '618238ccd24b76444a6c592f' }))
       .catch((err) => console.error(err));
   };
 

--- a/client/src/components/room-modal.tsx
+++ b/client/src/components/room-modal.tsx
@@ -35,7 +35,7 @@ const TitleInputbarLabel = styled.label`
 function RoomModal() {
   const [roomType] = useRecoilState(roomTypeState);
   const [user, setUser] = useRecoilState(userTypeState);
-  console.log('user unused 방지용 :: ', user);
+  console.log('user unused 방지용 :: ', user.roomId);
   const [isDisabled, setIsDisabled] = useState(true);
   const [isAnonymous, setIsAnonymous] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -46,6 +46,7 @@ function RoomModal() {
       type: roomType,
       title: inputRef.current?.value as string,
       userId: 'dlatqdlatq',
+      userName: 'sungbin',
       isAnonymous: isAnonymous,
     };
     fetch(`${process.env.REACT_APP_API_URL}/api/room?${generateURLQuery(roomInfo)}`, {
@@ -54,7 +55,7 @@ function RoomModal() {
         'Content-Type': 'application/json',
       },
     }).then((res) => res.json())
-      .then((roomId) => setUser({ roomId }))
+      .then((roomId) => setUser({ roomId, userDocumentId: '유저 다큐멘트 아이디' }))
       .catch((err) => console.error(err));
   };
 

--- a/client/src/components/styled-components/user-image.tsx
+++ b/client/src/components/styled-components/user-image.tsx
@@ -1,0 +1,25 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import React, { useEffect, useState } from 'react';
+import styled from 'styled-components';
+
+interface userImageProps {
+  profileUrl: string,
+}
+
+function UserImage(props : userImageProps) {
+  const ImageLayout = styled.img`
+    width: 60px;
+    min-width: 48px;
+    height: 60px;
+    border-radius: 30%;
+    overflow: hidden;
+    background-color: #6F8A87;
+  `;
+
+  return (
+    // eslint-disable-next-line react/destructuring-assignment
+    <ImageLayout src={props.profileUrl} />
+  );
+}
+
+export default UserImage;

--- a/client/src/recoil/atoms/socket.ts
+++ b/client/src/recoil/atoms/socket.ts
@@ -1,9 +1,0 @@
-import { atom } from 'recoil';
-import { Socket } from 'socket.io-client';
-
-type TSocket = Socket | null ;
-
-export default atom<TSocket>({
-  key: 'socket', // 해당 atom의 고유 key
-  default: null,
-});

--- a/client/src/recoil/atoms/user.ts
+++ b/client/src/recoil/atoms/user.ts
@@ -7,11 +7,13 @@ import { atom } from 'recoil';
 
 interface IUser {
   roomId: string,
+  userDocumentId: string,
 }
 
 export default atom<IUser>({
   key: 'user', // 해당 atom의 고유 key
   default: {
     roomId: '',
+    userDocumentId: '유저 다큐멘트 아이디 입니다.',
   },
 });

--- a/client/src/recoil/atoms/user.ts
+++ b/client/src/recoil/atoms/user.ts
@@ -14,6 +14,6 @@ export default atom<IUser>({
   key: 'user', // 해당 atom의 고유 key
   default: {
     roomId: '',
-    userDocumentId: '유저 다큐멘트 아이디 입니다.',
+    userDocumentId: '618238ccd24b76444a6c592f',
   },
 });

--- a/client/src/views/main-view.tsx
+++ b/client/src/views/main-view.tsx
@@ -1,13 +1,11 @@
 import React, {
-  UIEvent, useCallback, useRef, useState, useEffect,
+  UIEvent, useCallback, useRef, useState,
 } from 'react';
-import { useSetRecoilState, useRecoilState } from 'recoil';
-import client from 'socket.io-client';
+import { useSetRecoilState } from 'recoil';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { nowFetchingState } from '@atoms/main-section-scroll';
-import socketTypeState from '@atoms/socket';
 import LargeLogo from '@components/large-logo';
 import LeftSideBar from '@components/left-sidebar';
 import RightSideBar from '@components/right-sidebar';
@@ -74,7 +72,6 @@ const ButtonLayout = styled.div`
 function MainView() {
   const [isLoggedIn, setIsLoggedIn] = useState(true);
   const setNowFetching = useSetRecoilState(nowFetchingState);
-  const [socket, setSocket] = useRecoilState(socketTypeState);
   const nowFetchingRef = useRef<boolean>(false);
 
   const scrollBarChecker = useCallback((e : UIEvent<HTMLDivElement>) => {
@@ -89,19 +86,6 @@ function MainView() {
   }, []);
 
   if (isLoggedIn) {
-    useEffect(() => {
-      if (socket === null) {
-        const url = process.env.REACT_APP_SERVER_URL as string;
-        setSocket(client(url));
-      }
-      return () => {
-        if (socket !== null) {
-          socket.disconnect();
-          setSocket(null);
-        }
-      };
-    }, [socket]);
-
     return (
       <>
         <HeaderRouter />

--- a/server/package.json
+++ b/server/package.json
@@ -17,7 +17,6 @@
     "helmet": "^4.6.0",
     "module-alias": "^2.2.2",
     "mongoose": "^6.0.12",
-    "redis": "^3.1.2",
     "socket.io": "^4.3.2"
   },
   "devDependencies": {

--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -1,11 +1,13 @@
 import { Router } from 'express';
 import room from '@routes/room';
 import event from '@routes/event';
+import user from '@routes/user';
 
 // guaranteed to get dependencies
 export default () => {
   const app = Router();
   room(app);
   event(app);
+  user(app);
   return app;
 };

--- a/server/src/api/routes/room.ts
+++ b/server/src/api/routes/room.ts
@@ -18,11 +18,22 @@ export default (app: Router) => {
   route.get('/', async (req: Request, res: Response) => {
     try {
       const {
-        title, type, userId, isAnonymous,
+        title, type, isAnonymous,
       } = req.query as unknown as Query;
 
-      const roomId = await RoomService.setRoom(title, type, userId, isAnonymous);
+      const roomId = await RoomService.setRoom(title, type, isAnonymous);
       res.status(200).json(roomId);
+    } catch (error) {
+      console.error(error);
+    }
+  });
+
+  route.get('/:roomDocumentId', async (req: Request, res: Response) => {
+    try {
+      const { roomDocumentId } = req.params;
+
+      const roomInfo = await RoomService.findRoom(roomDocumentId);
+      res.status(200).json(roomInfo);
     } catch (error) {
       console.error(error);
     }

--- a/server/src/api/routes/user.ts
+++ b/server/src/api/routes/user.ts
@@ -1,0 +1,22 @@
+import {
+  Router, Request, Response,
+} from 'express';
+
+import usersService from '@services/users-service';
+
+const userRouter = Router();
+
+export default (app: Router) => {
+  app.use('/user', userRouter);
+
+  userRouter.get('/:userDocumentId', async (req: Request, res: Response) => {
+    try {
+      const { userDocumentId } = req.params;
+
+      const userInfo = await usersService.findUser(userDocumentId);
+      res.status(200).json(userInfo);
+    } catch (error) {
+      console.error(error);
+    }
+  });
+};

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,17 +1,22 @@
 import 'module-alias/register';
 import express from 'express';
 import dotenv from 'dotenv';
+import http from 'http';
+import io from '@sockets/index';
 
 import config from '@config/index';
 import init from '@loaders/index';
 
 async function startServer() {
-  const app = express();
   dotenv.config();
+  const app = express();
+
+  const server = http.createServer(app);
+  io.attach(server);
 
   await init({ app });
 
-  app.listen(config.port, () => {
+  server.listen(config.port, () => {
     console.info(`
       ################################################
       🛡️  Server listening on port: ${config.port} 🛡️

--- a/server/src/interfaces/index.ts
+++ b/server/src/interfaces/index.ts
@@ -1,5 +1,0 @@
-export interface IEventChatUser {
-    userId: string,
-    userName : string,
-    profileUrl : string,
-}

--- a/server/src/models/chats.ts
+++ b/server/src/models/chats.ts
@@ -1,26 +1,24 @@
 import { Schema, Document, model } from 'mongoose';
-import { IEventChatUser } from '@interfaces/index';
 
-interface IChattingLog extends IEventChatUser{
+interface IChattingLog {
     message: string,
     date: Date,
 }
 
 interface IChatTypesModel extends Document {
-  users: Array<IEventChatUser>,
+  participants: Array<string>,
   chattingLog: Array<IChattingLog>
 }
 
 const chatSchema = new Schema({
-  users: {
-    type: [Object],
+  participants: {
+    type: [String],
     required: true,
   },
   chattingLog: {
     type: [Object],
     required: true,
   },
-
 });
 
 export default model<IChatTypesModel>('chats', chatSchema);

--- a/server/src/models/events.ts
+++ b/server/src/models/events.ts
@@ -1,16 +1,15 @@
 import { Schema, Document, model } from 'mongoose';
-import { IEventChatUser } from '@interfaces/index';
 
 export interface IEventsTypesModel extends Document{
   date: Date,
-  participants: Array<IEventChatUser>,
+  participants: Array<string>,
   title: string,
   description: string,
 }
 
 const eventsSchema = new Schema({
   date: { type: Date, required: true },
-  participants: { type: [Object], required: true },
+  participants: { type: [String], required: true },
   title: { type: String, required: true },
   description: { type: String, default: '' },
 });

--- a/server/src/models/rooms.ts
+++ b/server/src/models/rooms.ts
@@ -1,10 +1,15 @@
 import { Schema, Document, model } from 'mongoose';
 
+interface IParticipant {
+  userDocumentId: string,
+  isMicOn: boolean,
+}
+
 export interface IRooms extends Document{
   title: string,
   type: string,
   isAnonymous: boolean,
-  participants: Array<String>,
+  participants: Array<IParticipant>,
 }
 
 const roomSchema = new Schema({
@@ -21,7 +26,7 @@ const roomSchema = new Schema({
     required: true,
   },
   participants: {
-    type: [String],
+    type: [Object],
     default: [],
   },
 });

--- a/server/src/models/users.ts
+++ b/server/src/models/users.ts
@@ -38,6 +38,7 @@ export interface IUsers {
     activity: Array<IActivity>
     recentSearch: Array<IRecentSearch>,
     recentListenTo: Array<IRecentListenTo>
+    profileUrl: string
 }
 
 export interface IUserTypesModel extends IUser, Document { }
@@ -92,6 +93,10 @@ const usersSchema = new Schema({
   recentSearch: {
     type: [Object],
     default: [],
+  },
+  profileUrl: {
+    type: String,
+    default: 'https://kr.object.ncloudstorage.com/nogarihouse/profile/default-user-image.png',
   },
 });
 

--- a/server/src/services/events-service.ts
+++ b/server/src/services/events-service.ts
@@ -1,3 +1,5 @@
+/* eslint-disable consistent-return */
+/* eslint-disable no-underscore-dangle */
 import Events, { IEventsTypesModel } from '@models/events';
 
 export default {
@@ -10,7 +12,8 @@ export default {
     }
   },
 
-  get10EventItemsFromUser: async (userId: string, count : number) => {
+  // myEvent 구현시 해당 함수에서 추가적으로 구현해서 사용하실건지 아니면 따로 함수를 만들어주실건지 ...
+  get10EventItemsFromUser: async (userDocumentId: string, count : number) => {
     try {
       const items = await Events.find().skip(count).limit(10);
       return items;

--- a/server/src/services/rooms-service.ts
+++ b/server/src/services/rooms-service.ts
@@ -1,7 +1,6 @@
 /* eslint-disable no-underscore-dangle */
+/* eslint-disable max-len */
 import Rooms from '@models/rooms';
-import Users from '@models/users';
-import redis from 'redis';
 
 let instance: any = null;
 class RoomService {
@@ -11,33 +10,24 @@ class RoomService {
   }
 
   // eslint-disable-next-line class-methods-use-this
-  async insertUser(userId: string, roomId: string) {
-    // userId 현재 아이디 가져와야 함
-    const profileUrlObject : any = await Users.findOne({ userId: 'dlatqdlatq' }).select('profileUrl');
-    const { profileUrl } = profileUrlObject.toObject();
-
-    const redisClient = redis.createClient();
-
-    redisClient.hset(userId, 'roomId', `${roomId}`);
-    redisClient.hset(userId, 'profileUrl', `${profileUrl}`);
-    redisClient.hset(userId, 'mic', 'true');
-
-    redisClient.quit();
-  }
-
-  async addParticipant(roomId: string, userId: string) {
-    await Rooms.findOneAndUpdate({ _id: roomId }, { $push: { participants: userId } });
-    await this.insertUser(userId, roomId);
+  async addParticipant(roomDocumentId: string, userDocumentId: string) {
+    await Rooms.findOneAndUpdate({ _id: roomDocumentId }, { $push: { participants: userDocumentId } });
   }
 
   // eslint-disable-next-line class-methods-use-this
-  async setRoom(title: string, type: string, userId: string, isAnonymous: boolean) {
+  async setRoom(title: string, type: string, isAnonymous: boolean) {
     const newRoom = new Rooms({
       title, type, isAnonymous,
     });
     await newRoom.save();
 
     return newRoom._id;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  async findRoom(roomDocumentId: string) {
+    const result = await Rooms.findOne({ _id: roomDocumentId });
+    return result;
   }
 }
 

--- a/server/src/services/users-service.ts
+++ b/server/src/services/users-service.ts
@@ -1,0 +1,22 @@
+/* eslint-disable class-methods-use-this */
+/* eslint-disable consistent-return */
+// import jwt from 'jsonwebtoken';
+
+import Users from '@models/users';
+
+let instance:any = null;
+
+class UserService {
+  constructor() {
+    if (instance) return instance;
+    instance = this;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  async findUser(userDocumentId: string) {
+    const result = await Users.findOne({ _id: userDocumentId });
+    return result;
+  }
+}
+
+export = new UserService();

--- a/server/src/sockets/index.ts
+++ b/server/src/sockets/index.ts
@@ -11,4 +11,4 @@ const handleConnection = (socket : Socket) => {
 
 server.on('connection', handleConnection);
 
-module.exports = server;
+export default server;

--- a/server/src/sockets/room.ts
+++ b/server/src/sockets/room.ts
@@ -18,16 +18,15 @@ export default function registerRoomHandler(socket : Socket) {
     users[socket.id] = { roomDocumentID, userDocumentId };
 
     const userData = await RoomService.addParticipant(roomDocumentID, userDocumentId);
-    console.log('socket :: ', users);
     socket.to(roomDocumentID).emit('room:join', { userDocumentId, userData });
   };
 
   const handleRoomLeave = () => {
-    const { spaceID, userID } = users[socket.id];
+    const { roomDocumentID, userDocumentId } = users[socket.id];
     delete users[socket.id];
 
     // room service에서 나간 유저 제거 코드 추가하기
-    socket.to(spaceID).emit('space:leave', { userID });
+    socket.to(roomDocumentID).emit('space:leave', { userDocumentId });
   };
 
   socket.on('room:join', handleRoomJoin);

--- a/server/src/sockets/room.ts
+++ b/server/src/sockets/room.ts
@@ -2,16 +2,34 @@ import { Socket } from 'socket.io';
 
 import RoomService from '@services/rooms-service';
 
+interface IUsers {
+  [id: string]: any,
+}
+
+const users: IUsers = {};
+
 export default function registerRoomHandler(socket : Socket) {
   const handleRoomJoin = async (payload : any) => {
     const {
-      roomID, userID,
+      roomDocumentID, userDocumentId,
     } = payload;
-    socket.join(roomID);
+    socket.join(roomDocumentID);
 
-    const userData = await RoomService.addParticipant(roomID, userID);
-    socket.to(roomID).emit('space:join', { userID, userData });
+    users[socket.id] = { roomDocumentID, userDocumentId };
+
+    const userData = await RoomService.addParticipant(roomDocumentID, userDocumentId);
+    console.log('socket :: ', users);
+    socket.to(roomDocumentID).emit('room:join', { userDocumentId, userData });
+  };
+
+  const handleRoomLeave = () => {
+    const { spaceID, userID } = users[socket.id];
+    delete users[socket.id];
+
+    // room service에서 나간 유저 제거 코드 추가하기
+    socket.to(spaceID).emit('space:leave', { userID });
   };
 
   socket.on('room:join', handleRoomJoin);
+  socket.on('disconnect', handleRoomLeave);
 }

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -1592,11 +1592,6 @@ delayed-stream@~1.0.0:
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
-denque@^1.5.0:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/denque/-/denque-1.5.1.tgz#07f670e29c9a78f8faecb2566a1e2c11929c5cbf"
-  integrity sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==
-
 denque@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/denque/-/denque-2.0.1.tgz#bcef4c1b80dc32efe97515744f21a4229ab8934a"
@@ -3968,33 +3963,6 @@ readdirp@~3.6.0:
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
-
-redis-commands@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/redis-commands/-/redis-commands-1.7.0.tgz#15a6fea2d58281e27b1cd1acfb4b293e278c3a89"
-  integrity sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==
-
-redis-errors@^1.0.0, redis-errors@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/redis-errors/-/redis-errors-1.2.0.tgz#eb62d2adb15e4eaf4610c04afe1529384250abad"
-  integrity sha1-62LSrbFeTq9GEMBK/hUpOEJQq60=
-
-redis-parser@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-3.0.0.tgz#b66d828cdcafe6b4b8a428a7def4c6bcac31c8b4"
-  integrity sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=
-  dependencies:
-    redis-errors "^1.0.0"
-
-redis@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/redis/-/redis-3.1.2.tgz#766851117e80653d23e0ed536254677ab647638c"
-  integrity sha512-grn5KoZLr/qrRQVwoSkmzdbw6pwF+/rwODtrOr6vuBRiR/f3rjSTGupbF90Zpqm2oenix8Do6RV7pYEkGwlKkw==
-  dependencies:
-    denque "^1.5.0"
-    redis-commands "^1.7.0"
-    redis-errors "^1.2.0"
-    redis-parser "^3.0.0"
 
 regexp-clone@1.0.0, regexp-clone@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## 개요
[2-7] 관련 API 및 컴포넌트 구현
## 작업사항
- 불필요한 코드 삭제 및 mongoDB 리팩토링
- 방 생성 이후 Room에 접속 시 유저 아이콘 구현
- 방 생성 이후 Room 접속 시 소켓 연결
- 방 내부 Header, Footer 구현
- user 정보 가져오는 API 구현
- 방 정보 가져오는 API 구현
## 변경로직
- Redis 를 일단 사용하지 않고, mongoDB로만 구현을 하고, 필요하다고 느낄 때 사용하는 것이 좋다고 생각하여 일단은 mongoDB만으로 구현을 하였습니다.
- chat이나 Room에 userId로 넣어주는 경우 userId 가 변경되었을때, 해당 부분도 모두 업데이트 해줘야하는 불편함이 있어서 userId가 아닌 users collection의 object id를 넣어주는 것으로 구현 하였습니다.
- 이에 따라 변수명에 있어서 userId로 사용하게 되는 경우 userId 와 users collection의 object id와 혼동될 우려가 있어 users collection의 object id는 userDocumentId 로 사용하여 구현하였습니다.
### 변경후


https://user-images.githubusercontent.com/55152516/140927647-4a561180-268c-4f54-b9a6-d737386ca5f3.mov

## 사용방법
- right side bar 에서 type 설정하고 title 입력하고 let's go 버튼 클릭하면 방이 생성되고, 해당 방에 사용자가 들어가게 됩니다.
- 마이크를 누르면 자신의 아이콘과 Footer의 아이콘이 사라지는 것 까지 확인 하실수 있습니다.
- 이때 마이크를 누를때마다 폰트가 다시 받아와지는 이슈가 발생하였습니다.
    - https://github.com/boostcampwm-2021/WEB27-NogariHouse/issues/40#issue-1048556920