### PR TITLE
유저 전역상태 관리 구현

### DIFF
--- a/client/src/components/common/default-header.tsx
+++ b/client/src/components/common/default-header.tsx
@@ -5,8 +5,10 @@ import { IconType } from 'react-icons';
 import {
   HiOutlinePaperAirplane, HiSearch, HiOutlineMail, HiOutlineCalendar, HiOutlineBell,
 } from 'react-icons/hi';
+import { useRecoilValue } from 'recoil';
 
 import { makeIconToLink } from '@utils/index';
+import userState from '@atoms/user';
 
 const CustomDefaultHeader = styled.nav`
   position: relative;
@@ -60,6 +62,7 @@ interface IconAndLink {
 }
 
 function DefaultHeader() {
+  const user = useRecoilValue(userState);
   const leftSideIcons: IconAndLink[] = [
     { Component: HiSearch, link: '/search', key: 'search' },
     { Component: HiOutlinePaperAirplane, link: '/chat', key: 'chat' },
@@ -77,7 +80,7 @@ function DefaultHeader() {
       <LogoTitle to="/"> NogariHouse </LogoTitle>
       <IconContainer>
         {rightSideIcons.map(makeIconToLink)}
-        <Link to="/profile"><ImageLayout src="https://avatars.githubusercontent.com/u/59464537?v=4" alt="사용자" /></Link>
+        <Link to="/profile"><ImageLayout src={user.profileUrl} alt="사용자" /></Link>
       </IconContainer>
     </CustomDefaultHeader>
   );

--- a/client/src/recoil/atoms/user.ts
+++ b/client/src/recoil/atoms/user.ts
@@ -14,10 +14,10 @@ interface IUser {
 }
 
 export default atom<IUser>({
-  key: 'user', // 해당 atom의 고유 key
+  key: 'userState', // 해당 atom의 고유 key
   default: {
     isLoggedIn: false,
-    userDocumentId: '618238ccd24b76444a6c592f',
+    userDocumentId: '',
     userName: '',
     userId: '',
     profileUrl: '',

--- a/server/src/api/middlewares/auth.ts
+++ b/server/src/api/middlewares/auth.ts
@@ -8,13 +8,14 @@ const authJWT = async (req:Request, res:Response, next:NextFunction) => {
   if (accessToken) {
     const result = jwtUtils.verify(accessToken); // token을 검증합니다.
     if (result.ok) {
+      req.body.accessToken = accessToken;
       req.body.userDocumentId = result.id;
       next();
     } else {
       const refreshResult = await usersService.tokenRefresh(accessToken);
       if (!refreshResult.ok) {
         res.status(401).json({
-          result: false,
+          ok: false,
           msg: refreshResult.msg,
         });
       } else {
@@ -24,6 +25,9 @@ const authJWT = async (req:Request, res:Response, next:NextFunction) => {
       }
     }
   }
+  else {
+    res.json({ ok: false })
+  }
 };
 
-module.exports = authJWT;
+export default authJWT;

--- a/server/src/api/middlewares/auth.ts
+++ b/server/src/api/middlewares/auth.ts
@@ -7,23 +7,19 @@ const authJWT = async (req:Request, res:Response, next:NextFunction) => {
   const { accessToken } = req.cookies;
   if (accessToken) {
     const result = jwtUtils.verify(accessToken); // token을 검증합니다.
-    if (result.ok) { // token이 검증되었으면 req에 값을 세팅하고, 다음 콜백함수로 갑니다.
+    if (result.ok) {
+      req.body.userDocumentId = result.id;
       next();
-    } else { // 검증에 실패하거나 토큰이 만료되었다면 클라이언트에게 메세지를 담아서 응답합니다.
+    } else {
       const refreshResult = await usersService.tokenRefresh(accessToken);
-
-      if (refreshResult.ok) {
+      if (!refreshResult.ok) {
         res.status(401).json({
           result: false,
-          msg: refreshResult.msg, // jwt가 만료되었다면 메세지는 'jwt expired'입니다.
-        });
-      } else {
-        res.status(200).json({
-          accessToken: refreshResult.accessToken,
-          result: refreshResult.ok,
           msg: refreshResult.msg,
         });
-
+      } else {
+        req.body.accessToken = refreshResult.accessToken;
+        req.body.userDocumentId = result.id;
         next();
       }
     }

--- a/server/src/api/middlewares/auth.ts
+++ b/server/src/api/middlewares/auth.ts
@@ -19,7 +19,7 @@ const authJWT = async (req:Request, res:Response, next:NextFunction) => {
         });
       } else {
         req.body.accessToken = refreshResult.accessToken;
-        req.body.userDocumentId = result.id;
+        req.body.userDocumentId = refreshResult.userDocumentId;
         next();
       }
     }

--- a/server/src/api/routes/user.ts
+++ b/server/src/api/routes/user.ts
@@ -3,16 +3,23 @@ import {
 } from 'express';
 
 import usersService from '@services/users-service';
+import authJWT from '@middlewares/auth'
 
 const userRouter = Router();
 
 export default (app: Router) => {
   app.use('/user', userRouter);
 
-  userRouter.get('/', async (req: Request, res: Response) => {
-    const { accessToken } = req.cookies;
-    const result = await usersService.verifyAccessToken(accessToken);
-    res.json(result);
+  userRouter.get('/', authJWT, async (req: Request, res: Response) => {
+    const { accessToken, userDocumentId } = req.body;
+    const user = await usersService.findUser(userDocumentId);
+    if (user) {
+      const { _id, profileUrl, userName, userId } = user;
+      res.json({ ok: true, accessToken, userDocumentId : _id, profileUrl, userName, userId });
+    }
+    else {
+      res.json({ ok: false })
+    }
   });
 
   userRouter.get('/:userDocumentId', async (req: Request, res: Response) => {

--- a/server/src/services/users-service.ts
+++ b/server/src/services/users-service.ts
@@ -7,6 +7,7 @@ import jwt from 'jsonwebtoken';
 import Users from '@models/users';
 import RefreshTokens from '@models/refresh-token';
 import jwtUtils from '@utils/jwt-util';
+import { decode } from 'punycode';
 
 interface ISignupUserInfo {
   loginType: string;
@@ -121,7 +122,6 @@ class UserService {
     }
     return {
       ok: true,
-      accessToken,
       msg: 'Acess token is not expired!',
     };
   }

--- a/server/src/services/users-service.ts
+++ b/server/src/services/users-service.ts
@@ -116,10 +116,12 @@ class UserService {
       return {
         ok: true,
         accessToken: newAccessToken,
+        userDocumentId: decoded.id,
       };
     }
     return {
       ok: true,
+      accessToken,
       msg: 'Acess token is not expired!',
     };
   }


### PR DESCRIPTION
## 개요
- 유저 전역상태 관리 구현

## 작업사항
- auth 미들웨어 수정 -> api 로직에 접근하기 전에 현재 cookie에 들어있는 토큰이 유효한지 검사해줌
-> 유효하다면 접근한 유저의 documentId를 넘겨주어서 api에서 로직에 사용하도록 하였습니다.

- GET : api/user API 수정 -> auth 미들웨어에서 사용자 인증이 성공했다면 로그인이 올바른 정보로 되었다는 것이므로 미들웨어에서 넘겨받은 documentId 를 통해서 user정보를 DB에서 조회
-> 클라이언트에서 전역으로 관리할 자주 변하지 않는 데이터 `{ _id, profileUrl, userName, userId }` 들을 조회해서 클라이언트에게 넘겨줍니다.

- 클라이언트에서는 응답이 ok: true면 `{ _id, profileUrl, userName, userId }` 데이터를 전역상태로 저장하고, ok: false면 로그인 상태를 해제하고 데이터를 전부 default로 reset해줍니다..

- 현재 유저 정보를 바탕으로 default 헤더에 profileUrl을 반영하도록 했습니다