### PR TITLE
여러가지 버그 수정 및 유저 Room 접속 관련 추가 구현 

### DIFF
--- a/client/src/components/room/in-room-modal.tsx
+++ b/client/src/components/room/in-room-modal.tsx
@@ -160,7 +160,7 @@ function InRoomModal() {
       </InRoomHeader>
       <InRoomUserList>
         {state.participants.map((participant) => (
-          <InRoomUserBox userDocumentId={participant.userDocumentId} isMicOn={participant.isMicOn} />
+          <InRoomUserBox key={participant.userDocumentId} userDocumentId={participant.userDocumentId} isMicOn={participant.isMicOn} />
         ))}
         {/* {roomInfo?.participants?.map((participant) => (
           <InRoomUserBox userDocumentId={participant.userDocumentId} isMicOn={participant.isMicOn} />

--- a/client/src/components/room/in-room-modal.tsx
+++ b/client/src/components/room/in-room-modal.tsx
@@ -123,13 +123,21 @@ function InRoomModal() {
     socket?.on('room:join', async (payload: any) => {
       const { userDocumentId, userData } = payload;
       dispatch({
-        type: 'UPDATE_USER',
+        type: 'JOIN_USER',
         payload: { userDocumentId, userData },
       });
 
       const offer = await myPeerConnection.current?.createOffer();
       myPeerConnection.current?.setLocalDescription(offer);
       socket.emit('room:offer', offer);
+    });
+
+    socket?.on('room:leave', async (payload: any) => {
+      const { userDocumentId } = payload;
+      dispatch({
+        type: 'LEAVE_USER',
+        payload: { userDocumentId },
+      });
     });
 
     socket?.on('room:offer', async (offer: RTCSessionDescriptionInit) => {

--- a/client/src/components/room/in-room-reducer.tsx
+++ b/client/src/components/room/in-room-reducer.tsx
@@ -15,7 +15,7 @@ export const reducer = (state: TState, action: Action): TState => {
     case 'UPDATE_USER': {
       const { userDocumentId, userData } = action.payload;
       const newParticipants = deepCopy(state.participants);
-      newParticipants[userDocumentId] = userData;
+      newParticipants.push({ userDocumentId, userData });
 
       return { ...state, participants: newParticipants };
     }

--- a/client/src/components/room/in-room-reducer.tsx
+++ b/client/src/components/room/in-room-reducer.tsx
@@ -1,6 +1,7 @@
+/* eslint-disable max-len */
 import { deepCopy } from '@src/utils';
 
-export type Action = { type: 'UPDATE_USER', payload: any } | { type: 'SET_USERS', payload: any }
+export type Action = { type: 'JOIN_USER', payload: any } | { type: 'SET_USERS', payload: any } | { type: 'LEAVE_USER', payload: any };
 
 export type TState = {
     participants: Array<any>,
@@ -12,10 +13,17 @@ export const initialState = {
 
 export const reducer = (state: TState, action: Action): TState => {
   switch (action.type) {
-    case 'UPDATE_USER': {
+    case 'JOIN_USER': {
       const { userDocumentId, userData } = action.payload;
       const newParticipants = deepCopy(state.participants);
       newParticipants.push({ userDocumentId, userData });
+
+      return { ...state, participants: newParticipants };
+    }
+
+    case 'LEAVE_USER': {
+      const { userDocumentId } = action.payload;
+      const newParticipants = state.participants.filter((user) => user.userDocumentId !== userDocumentId);
 
       return { ...state, participants: newParticipants };
     }

--- a/client/src/recoil/atoms/room-document-id.ts
+++ b/client/src/recoil/atoms/room-document-id.ts
@@ -1,11 +1,6 @@
-/*
- * user 정보 전역 상태관리
- * roomId :: 현재 접속해 있는 방 , 접속해 있는 방이 없다면 ''
-*/
-
 import { atom } from 'recoil';
 
 export default atom<string>({
   key: 'roomDocumentIdState', // 해당 atom의 고유 key
-  default: '618bd220c76493eb2eb68e6a',
+  default: '',
 });

--- a/server/src/services/rooms-service.ts
+++ b/server/src/services/rooms-service.ts
@@ -20,6 +20,7 @@ class RoomService {
     const roomInfo = await Rooms.findById(roomDocumentId).select('participants');
     const newParticipants = roomInfo!.participants.filter((participant) => (participant.userDocumentId !== userDocumentId));
     await Rooms.updateOne({ _id: roomDocumentId }, { $set: { participants: newParticipants } });
+    if (!newParticipants.length) await Rooms.deleteOne({ _id: roomDocumentId });
   }
 
   async setRoom(title: string, type: string, isAnonymous: boolean) {


### PR DESCRIPTION
## 개요
- 기존 이슈 사항 해결 및 Room 접속 실시간 반영 구현
## 작업사항
- recoil room-document-id 부분 기존에 있던 default 부분 삭제
- 마지막으로 남은 사람이 나가게 되면 DB에서 해당 Room 사라지게끔 구현
- Room 내부 유저들 프로필 key값 등록
- 유저가 Room에 접속시 다른 유저들이 실시간으로 해당 유저의 프로필을 확인할수 없었던 이슈 해결
- 유저가 방을 떠나는 경우 다른 유저가 실시간으로 확인할수 있게끔 구현
## 변경로직
- in-room-reducer의 경우 UPDATE_USER 에서 JOIN_USER로 명칭을 변경해주었습니다.
    - 해당 부분은 유저가 들어오는 경우를 처리하는 함수인데 유저가 방을 떠났을때도 UPDATE는 맞으니까 좀 더 명확하게 용어를 구분해주었습니다.
- room 접속시 dispatch 자체는 잘 동작하는데 내부 로직에서 배열 부분과 Object를 약간 혼동하신 부분이 있으신것 같아 해당 부분때문에 오류가 발생하는것을 확인하고 고쳐주었습니다.
### 변경후

https://user-images.githubusercontent.com/51700274/141314775-c42a6387-3891-40ca-b32c-d4ac036d163c.mov

## 사용방법
- 시크릿 탭이나 다른 브라우저를 이용해서 서로 다른 아이디로 로그인 한 후 아무 방이나 들어가시고, 나오시면 기능을 확인하실수 있습니다.
- 추가로 방 내부에 접속했을때 key값 관련하여 console에 에러가 발생한 부분도 없어진 것을 확인할수 있습니다.
## 기타
- reducer 로직에서 deepcopy를 사용하는 이유가 궁금합니다 
- reducer에서 state에는 participant 리스트 하나밖에 없는데 state를 object로 두고 그 안에 participants를 넣어주신 이유도 궁금해요 !
- 유저1 에서 방을 생성하고 유저2 에서 방을 확인 한 후 유저1이 방에서 나가서 방이 없어졌을때 유저2가 해당방에 들어가려고 시도하면 존재하지 않는 roomDocumentId 를 검색하고, 결국 null값을 바탕으로 in-room-modal을 만들어주게 되서 오류가 발생하는 이슈가 있습니다.
    - 이 부분을 해결하려면 in-room-modal에 들어가기전에 즉, room-view-type이 바뀌기 전에 해당 room이 유효한지 검사를 해야합니다.
    - 그런데 room 정보를 가져와서 저장해주는 부분은 in-room-modal 부분인데 해당 부분에서는 useState로 상태를 관리해주고 있어서 in-room-modal에 들어가기 전에 유효한지 검사를 해주려면 fetch 요청을 추가로 보내주거나, room 상태를 전역으로 관리해줘서 Room을 클릭을 했을때 유효한지 검사하고, 유효하다면 전역상태에 저장해주고, 유효하지 않다면 room-view-type과 room 상태를 바꿔주지 않는 방식으로 구현해야합니다.
    - 해당 부분을 제가 구현한 부분이 아니라서 이렇게 바꾸는게 어떤지 아니면 방 유효성 검사에 있어서 다른 방법이 있는지 이야기를 해보는게 좋을것 같아서 일단은 해당 부분은 고치지 않았습니다.
    - 추가로 전역상태로 관리해준다고 했을때, room-view-type과 함께 방 상태를 저장해도 불필요한 리렌더링에 있어 괜찮은지 궁금합니다.
- recoil에 room-type 파일이 있는데 안쓰이는것 같아서요... 혹시몰라서 아직 안지우긴 했습니다 !!