### PR TITLE
유저 접속 & 퇴장 기능 추가 및 음성 채팅 기능 추가(에러 발생)

### DIFF
--- a/client/src/components/room/in-room-modal.tsx
+++ b/client/src/components/room/in-room-modal.tsx
@@ -121,10 +121,10 @@ function InRoomModal() {
     });
 
     socket?.on('room:join', async (payload: any) => {
-      const { userDocumentId, userData } = payload;
+      const { userData } = payload;
       dispatch({
         type: 'UPDATE_USER',
-        payload: { userDocumentId, userData },
+        payload: { userData },
       });
 
       const offer = await myPeerConnection.current?.createOffer();
@@ -146,6 +146,14 @@ function InRoomModal() {
     socket?.on('room:ice', async (ice: RTCIceCandidateInit) => {
       myPeerConnection.current?.addIceCandidate(ice);
     });
+
+    socket?.on('room:leave', async (payload: any) => {
+      const { userDocumentId } = payload;
+      dispatch({
+        type: 'DELETE_USER',
+        payload: { userDocumentId },
+      });
+    });
   }, [socket]);
 
   const leaveEvent = () => {
@@ -159,13 +167,8 @@ function InRoomModal() {
         <OptionBtn><FiMoreHorizontal /></OptionBtn>
       </InRoomHeader>
       <InRoomUserList>
-        {state.participants.map((participant) => (
-          <InRoomUserBox userDocumentId={participant.userDocumentId} isMicOn={participant.isMicOn} />
-        ))}
-        {/* {roomInfo?.participants?.map((participant) => (
-          <InRoomUserBox userDocumentId={participant.userDocumentId} isMicOn={participant.isMicOn} />
-        ))} */}
-        <InRoomUserBox ref={myBox} userDocumentId={user.userDocumentId} isMicOn={isMic} />
+        {state.participants.map(({ userDocumentId }: any) => <InRoomUserBox key={userDocumentId} userDocumentId={userDocumentId} isMicOn={false} />)}
+        <InRoomUserBox ref={myBox} key={user.userDocumentId} userDocumentId={user.userDocumentId} isMicOn={isMic} />
       </InRoomUserList>
       <InRoomFooter>
         <DefaultButton buttonType="active" size="small" onClick={leaveEvent}> Leave a Quietly </DefaultButton>

--- a/client/src/components/room/in-room-modal.tsx
+++ b/client/src/components/room/in-room-modal.tsx
@@ -14,7 +14,7 @@ import userTypeState from '@atoms/user';
 import roomDocumentIdState from '@atoms/room-document-id';
 import roomViewType from '@src/recoil/atoms/room-view-type';
 import DefaultButton from '@common/default-button';
-import InRoomUserBox, { IParticipant } from '@components/room/in-room-user-box';
+import { IParticipant, InRoomUserBox, InRoomOtherUserBox } from '@components/room/in-room-user-box';
 import { getRoomInfo } from '@api/index';
 import { reducer, initialState } from '@components/room/in-room-reducer';
 import {
@@ -55,7 +55,7 @@ function InRoomModal() {
 
   // 다른 유저 접속시 연결하기 dispatch로 비디오 태그 추가
   const handleAddStream = (data: any) => {
-    console.log(data);
+    dispatch({ type: 'ADD_STREAM', payload: { data } });
   };
 
   const makeConnection = () => {
@@ -167,7 +167,7 @@ function InRoomModal() {
         <OptionBtn><FiMoreHorizontal /></OptionBtn>
       </InRoomHeader>
       <InRoomUserList>
-        {state.participants.map(({ userDocumentId }: any) => <InRoomUserBox key={userDocumentId} userDocumentId={userDocumentId} isMicOn={false} />)}
+        {state.participants.map(({ userDocumentId, stream }: any) => <InRoomOtherUserBox key={userDocumentId} stream={stream} userDocumentId={userDocumentId} isMicOn={false} />)}
         <InRoomUserBox ref={myBox} key={user.userDocumentId} userDocumentId={user.userDocumentId} isMicOn={isMic} />
       </InRoomUserList>
       <InRoomFooter>

--- a/client/src/components/room/in-room-reducer.tsx
+++ b/client/src/components/room/in-room-reducer.tsx
@@ -1,7 +1,7 @@
 import { deepCopy } from '@src/utils';
 
 export type Action = { type: 'UPDATE_USER', payload: any } | { type: 'SET_USERS', payload: any }
-| { type: 'DELETE_USER', payload: any } | { type: 'ADD_STREAM', payload: any }
+| { type: 'DELETE_USER', payload: any } | { type: 'ADD_STREAM', payload: any } | { type: 'SENT_CANDIDATE', payload: any }
 
 export type TState = {
     participants: Array<any>
@@ -44,6 +44,13 @@ export const reducer = (state: TState, action: Action): TState => {
       participants.push(newParticipant);
 
       return { ...state, participants };
+    }
+
+    case 'SENT_CANDIDATE': {
+      const { data, socket } = action.payload;
+      socket?.emit('room:ice', { ice: data });
+
+      return { ...state };
     }
 
     default:

--- a/client/src/components/room/in-room-reducer.tsx
+++ b/client/src/components/room/in-room-reducer.tsx
@@ -1,9 +1,9 @@
 import { deepCopy } from '@src/utils';
 
-export type Action = { type: 'UPDATE_USER', payload: any } | { type: 'SET_USERS', payload: any }
+export type Action = { type: 'UPDATE_USER', payload: any } | { type: 'SET_USERS', payload: any } | { type: 'DELETE_USER', payload: any }
 
 export type TState = {
-    participants: Array<any>,
+    participants: Array<any>
 }
 
 export const initialState = {
@@ -13,9 +13,9 @@ export const initialState = {
 export const reducer = (state: TState, action: Action): TState => {
   switch (action.type) {
     case 'UPDATE_USER': {
-      const { userDocumentId, userData } = action.payload;
+      const { userData } = action.payload;
       const newParticipants = deepCopy(state.participants);
-      newParticipants[userDocumentId] = userData;
+      newParticipants.push(userData);
 
       return { ...state, participants: newParticipants };
     }
@@ -23,6 +23,14 @@ export const reducer = (state: TState, action: Action): TState => {
     case 'SET_USERS': {
       const { participants } = action.payload;
       const newParticipants = deepCopy(participants);
+
+      return { ...state, participants: newParticipants };
+    }
+
+    case 'DELETE_USER': {
+      const { userDocumentId } = action.payload;
+      const newParticipants = state.participants
+        .filter((participant) => (participant.userDocumentId !== userDocumentId));
 
       return { ...state, participants: newParticipants };
     }

--- a/client/src/components/room/in-room-reducer.tsx
+++ b/client/src/components/room/in-room-reducer.tsx
@@ -1,6 +1,7 @@
 import { deepCopy } from '@src/utils';
 
-export type Action = { type: 'UPDATE_USER', payload: any } | { type: 'SET_USERS', payload: any } | { type: 'DELETE_USER', payload: any }
+export type Action = { type: 'UPDATE_USER', payload: any } | { type: 'SET_USERS', payload: any }
+| { type: 'DELETE_USER', payload: any } | { type: 'ADD_STREAM', payload: any }
 
 export type TState = {
     participants: Array<any>
@@ -33,6 +34,16 @@ export const reducer = (state: TState, action: Action): TState => {
         .filter((participant) => (participant.userDocumentId !== userDocumentId));
 
       return { ...state, participants: newParticipants };
+    }
+
+    case 'ADD_STREAM': {
+      const { data } = action.payload;
+      const { participants } = state;
+      const newParticipant = participants.pop();
+      newParticipant.stream = data.stream;
+      participants.push(newParticipant);
+
+      return { ...state, participants };
     }
 
     default:

--- a/client/src/components/room/in-room-user-box.tsx
+++ b/client/src/components/room/in-room-user-box.tsx
@@ -56,10 +56,13 @@ export function InRoomOtherUserBox({ userDocumentId, isMicOn, stream }: IPartici
 
   useEffect(() => {
     getUserInfo(userDocumentId)
-      .then((res) => setUserInfo(res))
-      // eslint-disable-next-line no-return-assign
-      .then(() => ref.current!.srcObject = stream);
+      .then((res) => setUserInfo(res));
   }, []);
+
+  useEffect(() => {
+    ref.current!.srcObject = stream;
+    console.log(ref.current?.srcObject);
+  }, [stream]);
 
   return (
     <InRoomUserBoxStyle>

--- a/client/src/components/room/in-room-user-box.tsx
+++ b/client/src/components/room/in-room-user-box.tsx
@@ -66,7 +66,7 @@ export function InRoomOtherUserBox({ userDocumentId, isMicOn, stream }: IPartici
 
   return (
     <InRoomUserBoxStyle>
-      <UserBox ref={ref} poster={userInfo?.profileUrl} autoPlay />
+      <UserBox ref={ref} poster={userInfo?.profileUrl} autoPlay playsInline />
       <InRoomUserMicDiv>
         { isMicOn ? <FiMic /> : <FiMicOff /> }
       </InRoomUserMicDiv>
@@ -86,7 +86,7 @@ export const InRoomUserBox = React.forwardRef<HTMLVideoElement, IParticipant>(
 
     return (
       <InRoomUserBoxStyle>
-        <UserBox ref={ref} poster={userInfo?.profileUrl} autoPlay muted />
+        <UserBox ref={ref} poster={userInfo?.profileUrl} autoPlay muted playsInline />
         <InRoomUserMicDiv>
           { props.isMicOn ? <FiMic /> : <FiMicOff /> }
         </InRoomUserMicDiv>

--- a/client/src/components/room/in-room-user-box.tsx
+++ b/client/src/components/room/in-room-user-box.tsx
@@ -83,7 +83,7 @@ export const InRoomUserBox = React.forwardRef<HTMLVideoElement, IParticipant>(
 
     return (
       <InRoomUserBoxStyle>
-        <UserBox ref={ref} poster={userInfo?.profileUrl} autoPlay />
+        <UserBox ref={ref} poster={userInfo?.profileUrl} autoPlay muted />
         <InRoomUserMicDiv>
           { props.isMicOn ? <FiMic /> : <FiMicOff /> }
         </InRoomUserMicDiv>

--- a/client/src/components/room/in-room-user-box.tsx
+++ b/client/src/components/room/in-room-user-box.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import React, {
-  Ref, RefObject, useEffect, useState,
+  Ref, RefObject, useEffect, useRef, useState,
 } from 'react';
 import styled from 'styled-components';
 import {
@@ -12,6 +12,7 @@ import { getUserInfo } from '@api/index';
 export interface IParticipant {
     userDocumentId: string,
     isMicOn: boolean,
+    stream?: any,
 }
 
 const InRoomUserBoxStyle = styled.div`
@@ -49,7 +50,29 @@ const UserBox = styled.video`
   background-color: #6F8A87;
 `;
 
-const InRoomUserBox = React.forwardRef<HTMLVideoElement, IParticipant>(
+export function InRoomOtherUserBox({ userDocumentId, isMicOn, stream }: IParticipant) {
+  const [userInfo, setUserInfo] = useState<any>();
+  const ref = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    getUserInfo(userDocumentId)
+      .then((res) => setUserInfo(res))
+      // eslint-disable-next-line no-return-assign
+      .then(() => ref.current!.srcObject = stream);
+  }, []);
+
+  return (
+    <InRoomUserBoxStyle>
+      <UserBox ref={ref} poster={userInfo?.profileUrl} autoPlay />
+      <InRoomUserMicDiv>
+        { isMicOn ? <FiMic /> : <FiMicOff /> }
+      </InRoomUserMicDiv>
+      <p>{ userInfo?.userName }</p>
+    </InRoomUserBoxStyle>
+  );
+}
+
+export const InRoomUserBox = React.forwardRef<HTMLVideoElement, IParticipant>(
   (props, ref) => {
     const [userInfo, setUserInfo] = useState<any>();
 
@@ -69,5 +92,3 @@ const InRoomUserBox = React.forwardRef<HTMLVideoElement, IParticipant>(
     );
   },
 );
-
-export default InRoomUserBox;

--- a/server/src/sockets/room.ts
+++ b/server/src/sockets/room.ts
@@ -19,7 +19,9 @@ export default function registerRoomHandler(socket : Socket) {
     users[socket.id] = { roomDocumentId, userDocumentId };
     await RoomService.addParticipant(roomDocumentId, userDocumentId);
     const userData = await usersService.findUser(userDocumentId);
-    socket.to(roomDocumentId).emit('room:join', { userDocumentId, userData });
+    // eslint-disable-next-line no-underscore-dangle
+    const obj = { userDocumentId: userData!._id, mic: false };
+    socket.to(roomDocumentId).emit('room:join', { userData: obj });
   };
 
   const handleRoomLeave = async () => {

--- a/server/src/sockets/room.ts
+++ b/server/src/sockets/room.ts
@@ -27,7 +27,7 @@ export default function registerRoomHandler(socket : Socket) {
   const handleRoomLeave = async () => {
     const { roomDocumentId, userDocumentId } = users[socket.id];
     delete users[socket.id];
-
+    console.log('disconnet!!!!!!');
     await RoomService.deleteParticipant(roomDocumentId, userDocumentId);
     socket.to(roomDocumentId).emit('room:leave', { userDocumentId });
   };
@@ -48,7 +48,6 @@ export default function registerRoomHandler(socket : Socket) {
   // eslint-disable-next-line no-undef
   const handleRoomIce = (ice: RTCIceCandidateInit) => {
     const { roomDocumentId } = users[socket.id];
-
     socket.to(roomDocumentId).emit('room:ice', ice);
   };
 


### PR DESCRIPTION
## 개요

실시간 유저 접속 & 퇴장 기능 추가와 음성 채팅 기능을 추가했습니다! (찬희님과 작업이 겹치네요 ㅋㅋㅋㅋ)
아직 음성채팅은 로컬 환경에서 확인하느라 정상적으로 동작이 제대로 되는지 확인은 못했습니다 ㅎㅎ..  => 확인해보니 연결이 아직 안되네요ㅠ

## 작업사항

실시간 유저 접속 & 퇴장 기능 추가 : 해당 기능은 제가 지난 작업 도중에 reducer로 participants의 어떤 정보를 넣어줄지 헷갈려해서 제대로 동작이 안되었던 거 같습니다 그래서 reducer 수정과 socket 부분을 고쳐주웠습니다

음성채팅은 조금 위험한 방법이긴 한데 최종적으로 상대방의 stream을 등록하는 과정인 handleAddStream메서드에서 가장 뒤에 있는 participants에게 stream 속성을 추가해줬습니다. 그 이유는 새롭게 접속하면 신규 접속자는 participants배열 뒤에 추가 될 거라고 판단해서 맨뒤에 있는 participant를 뽑아서 넣어줬습니다 (그런데 만약 해당 과정 중에 신규 접속자의 userDocumentId를 알 수 있다면 해결 할 수 있을 거 같습니다!) 그 후 stream을 InRoomOtherUserBox컴포넌트에게 props로 전달하여 video 태그와 연결을 시켜줬습니다

## 변경로직

해당 사진을 참고하시면 webrtc의 동작 방식을 알 수 있습니다!

![image](https://user-images.githubusercontent.com/55152516/141330338-df3f7127-74e5-45f2-932f-c244c7dadd78.png)

다른 유저가 접속하면 handleIce와 handleAddStream가 동작되고 handleAddStream가 내 화면에서 다른 유저의 video 태그를 연결해주는 역할을 합니다. 이 때 handleAddStream에서 받은 stream을 내 화면에서 다른 유저의 video 태그(InRoomOtherUserBox)에 연결을 해줘야하기 때문에 props로 stream을 넘겨줬습니다

### 변경후

음성 채팅은 영상으로 확인 할 수 없고 실시간 유저 접속 & 퇴장 기능은 찬희님 영상을 참고,,,

## 기타

InRoomOtherUserBox와 InRoomUserBox가 분리되어 있습니다! 그 이유는 내 video에서 stream을 어떻게 전달해야하는지 몰라서 다르게 구별했는데요 만약에 내 video에 stream을 전달할 방법을 찾는다면 하나의 컴포넌트로 통일해도 좋을 듯 합니다 (근데 굳이 내 비디오 tag에 연결을 해야할까요..?)
