### PR TITLE
♻️ search view에서 RoomCardLis 사용을 위한 코드 리팩토링

### DIFF
--- a/client/src/views/room-view.tsx
+++ b/client/src/views/room-view.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable no-underscore-dangle */
-import React, { useEffect, useState } from 'react';
+import React, { MouseEvent, useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { useSetRecoilState } from 'recoil';
 
@@ -23,8 +23,27 @@ interface RoomCardProps {
 }
 
 const RoomDiv = styled.div`
-  margin-bottom: 20px;
+  div + div {
+  margin-bottom: 10px;
+}
 `;
+
+const makeRoomToCard = (room: RoomCardProps) => (
+  <div className="RoomCard" data-id={room._id}>
+    <RoomCard
+      key={room._id}
+      _id={room._id}
+      title={room.title}
+      isAnonymous={room.isAnonymous}
+      participantsInfo={room.participantsInfo}
+    />
+  </div>
+);
+
+export function RoomCardList({ roomList, roomCardClickHandler }:
+  { roomList: RoomCardProps[], roomCardClickHandler: (e: MouseEvent) => void }) {
+  return <RoomDiv onClick={roomCardClickHandler}>{roomList?.map(makeRoomToCard)}</RoomDiv>;
+}
 
 function RoomView() {
   const [nowItemList, nowItemType] = useFetchItems<RoomCardProps>('/room', 'room');
@@ -32,27 +51,13 @@ function RoomView() {
   const setRoomView = useSetRecoilState(roomViewType);
   const setRoomDocumentId = useSetRecoilState(roomDocumentIdState);
 
-  function roomCardClickEvent(roomDocumentId: string) {
+  const roomCardClickHandler = (e: MouseEvent) => {
+    const RoomCardDiv = (e.target as HTMLDivElement).closest('.RoomCard');
+    const roomDocumentId = RoomCardDiv?.getAttribute('data-id');
     setRoomView('inRoomView');
-    setRoomDocumentId(roomDocumentId);
-    // roomView
-  }
-
-  const makeRoomToCard = (room: RoomCardProps) => (
-    <RoomDiv key={room._id} onClick={() => roomCardClickEvent(room._id)}>
-      <RoomCard
-        key={room._id}
-        _id={room._id}
-        title={room.title}
-        isAnonymous={room.isAnonymous}
-        participantsInfo={room.participantsInfo}
-      />
-    </RoomDiv>
-  );
-
-  function RoomCardList({ roomList }: { roomList: RoomCardProps[] }) {
-    return <>{roomList?.map(makeRoomToCard)}</>;
-  }
+    if (roomDocumentId) setRoomDocumentId(roomDocumentId);
+    else console.error('no room-id');
+  };
 
   useEffect(() => {
     if (nowItemList && nowItemType === 'room') {
@@ -64,7 +69,7 @@ function RoomView() {
     return <LoadingSpinner />;
   }
 
-  return <RoomCardList roomList={nowItemList} />;
+  return <RoomCardList roomCardClickHandler={roomCardClickHandler} roomList={nowItemList} />;
 }
 
 export default RoomView;


### PR DESCRIPTION
room-view에서 RoomCardList를 export 하기 위해서 리팩토링했습니다.

RoomCard click 시 onClick 핸들러를 각각 카드에 달아주는 방식에서 CardList 를 감싸는 RoomDiv에서 위임해주는 방식으로 변경했습니다