### PR TITLE
검색 기능 추가 구현(Rooms)

### DIFF
--- a/client/src/components/room/in-room-modal.tsx
+++ b/client/src/components/room/in-room-modal.tsx
@@ -171,7 +171,6 @@ function InRoomModal() {
       console.log('received candidate');
       myPeerConnection.current?.addIceCandidate(ice);
     });
-
   }, [socket]);
 
   const leaveEvent = () => {

--- a/client/src/components/room/in-room-reducer.tsx
+++ b/client/src/components/room/in-room-reducer.tsx
@@ -14,7 +14,6 @@ export const initialState = {
 
 export const reducer = (state: TState, action: Action): TState => {
   switch (action.type) {
-
     case 'JOIN_USER': {
       const { userData } = action.payload;
       const newParticipants = deepCopy(state.participants);

--- a/client/src/views/search-view.tsx
+++ b/client/src/views/search-view.tsx
@@ -44,19 +44,6 @@ function SearchView() {
     }
   };
 
-  useEffect(() => {
-    resetItemList();
-    setNowFetching(true);
-
-    return () => resetItemList();
-  }, []);
-
-  useEffect(() => {
-    if (nowFetching) {
-      fetchItems().then(() => setNowFetching(false));
-    }
-  }, [nowFetching]);
-
   const searchRequestHandler = () => {
     searchInfo.current.keyword = inputKeywordRef.current?.value as string;
     searchInfo.current.option = searchType.toLocaleLowerCase();
@@ -65,12 +52,22 @@ function SearchView() {
   };
 
   useEffect(() => {
+    searchRequestHandler();
+  }, [searchType]);
+
+  useEffect(() => {
+    if (nowFetching) {
+      fetchItems().then(() => setNowFetching(false));
+    }
+  }, [nowFetching]);
+
+  useEffect(() => {
     if (nowItemsList && (nowItemTypeRef.current === 'recent' || nowItemTypeRef.current === inputKeywordRef.current?.value)) {
       setLoading(false);
     } else {
       setLoading(true);
     }
-  });
+  }, []);
 
   const scrollBarChecker = useCallback((e: UIEvent<HTMLDivElement>) => {
     if (!nowFetchingRef.current) {
@@ -98,6 +95,10 @@ function SearchView() {
 
   // eslint-disable-next-line consistent-return
   const itemList = () => {
+    if (searchInfo.current.option !== searchType.toLocaleLowerCase()) {
+      return <LoadingSpinner />;
+    }
+
     if (searchType === 'Events') {
       return <EventCardList setEventModal={setEventModal} eventList={nowItemsList} />;
     }

--- a/client/src/views/search-view.tsx
+++ b/client/src/views/search-view.tsx
@@ -1,8 +1,8 @@
 import React, {
-  useRef, useCallback, UIEvent, useEffect, useState,
+  useRef, useCallback, UIEvent, useEffect, useState, MouseEvent,
 } from 'react';
 import {
-  useRecoilState, useRecoilValue, useResetRecoilState,
+  useRecoilState, useRecoilValue, useResetRecoilState, useSetRecoilState,
 } from 'recoil';
 
 import { nowFetchingState, nowItemsListState } from '@atoms/main-section-scroll';
@@ -14,6 +14,9 @@ import {
 import LoadingSpinner from '@common/loading-spinner';
 import useSetEventModal from '@hooks/useSetEventModal';
 import { EventCardList } from '@views/event-view';
+import { RoomCardList } from '@views/room-view';
+import roomViewType from '@atoms/room-view-type';
+import roomDocumentIdState from '@atoms/room-document-id';
 
 function SearchView() {
   const searchType = useRecoilValue(searchTypeState);
@@ -82,6 +85,28 @@ function SearchView() {
     }
   }, []);
 
+  const setRoomView = useSetRecoilState(roomViewType);
+  const setRoomDocumentId = useSetRecoilState(roomDocumentIdState);
+
+  const roomCardClickHandler = (e: MouseEvent) => {
+    const RoomCardDiv = (e.target as HTMLDivElement).closest('.RoomCard');
+    const roomDocumentId = RoomCardDiv?.getAttribute('data-id');
+    setRoomView('inRoomView');
+    if (roomDocumentId) setRoomDocumentId(roomDocumentId);
+    else console.error('no room-id');
+  };
+
+  // eslint-disable-next-line consistent-return
+  const itemList = () => {
+    if (searchType === 'Events') {
+      return <EventCardList setEventModal={setEventModal} eventList={nowItemsList} />;
+    }
+
+    if (searchType === 'Rooms') {
+      return <RoomCardList roomCardClickHandler={roomCardClickHandler} roomList={nowItemsList} />;
+    }
+  };
+
   return (
     <SearchViewLayout>
       <SearchBarLayout>
@@ -92,7 +117,7 @@ function SearchView() {
       <SearchScrollSection onScroll={scrollBarChecker}>
         {loading
           ? <LoadingSpinner />
-          : <EventCardList setEventModal={setEventModal} eventList={nowItemsList} />}
+          : itemList()}
       </SearchScrollSection>
     </SearchViewLayout>
   );

--- a/server/src/api/routes/search.ts
+++ b/server/src/api/routes/search.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response } from 'express';
 
 import eventsService from '@src/services/events-service';
+import roomsService from '@src/services/rooms-service';
 
 const searchRouter = Router();
 
@@ -11,10 +12,35 @@ export default (app: Router) => {
     const { keyword } = req.params;
     const { count } = req.query;
     if (typeof keyword !== 'string' || typeof count !== 'string') {
-        res.json({ ok: false });
+      res.json({ ok: false });
     } else {
-        const items = (await eventsService.searchEvent(keyword, Number(count)))?.map(eventsService.makeItemToEventInterface);
-        res.json({ ok: true, items, keyword })
+      const items = (
+        await eventsService
+          .searchEvent(keyword, Number(count)))
+        ?.map(eventsService.makeItemToEventInterface);
+      res.json({ ok: true, items, keyword });
+    }
+  });
+
+  // searchRouter.get('/people/:keyword', async (req: Request, res: Response) => {
+  //   const { keyword } = req.params;
+  //   const { count } = req.query;
+  //   if (typeof keyword !== 'string' || typeof count !== 'string') {
+  //       res.json({ ok: false });
+  //   } else {
+  //       const items = (await eventsService.searchEvent(keyword, Number(count)))?.map(eventsService.makeItemToEventInterface);
+  //       res.json({ ok: true, items, keyword })
+  //   }
+  // });
+
+  searchRouter.get('/rooms/:keyword', async (req: Request, res: Response) => {
+    const { keyword } = req.params;
+    const { count } = req.query;
+    if (typeof keyword !== 'string' || typeof count !== 'string') {
+      res.json({ ok: false });
+    } else {
+      const items = (await roomsService.searchRooms(keyword, Number(count)));
+      res.json({ ok: true, items, keyword });
     }
   });
 };

--- a/server/src/services/events-service.ts
+++ b/server/src/services/events-service.ts
@@ -47,8 +47,8 @@ export default {
   },
 
   searchEvent: async (keyword: string, count: number) => {
-    const query = new RegExp(keyword,'i');
-    const res = await Events.find({ $or : [{ title: query }, { description: query }] }).sort({ date: 1 }).skip(count).limit(10);
+    const query = new RegExp(keyword, 'i');
+    const res = await Events.find({ $or: [{ title: query }, { description: query }] }).sort({ date: 1 }).skip(count).limit(10);
     return res;
-  }
+  },
 };

--- a/server/src/services/rooms-service.ts
+++ b/server/src/services/rooms-service.ts
@@ -59,10 +59,11 @@ class RoomService {
     }
   }
 
+  // eslint-disable-next-line consistent-return
   async searchRooms(keyword: string, count: number) {
     try {
       const query = new RegExp(keyword, 'i');
-      const res = await Rooms.find({ $or: [{ title: query }, { description: query }] }).sort({ date: 1 }).skip(count).limit(10);
+      const res = await Rooms.find({ title: query }).sort({ date: 1 }).skip(count).limit(10);
 
       const roomsInfo = await Promise.all((res).map(async ({
         _id, title, isAnonymous, participants,

--- a/server/src/services/rooms-service.ts
+++ b/server/src/services/rooms-service.ts
@@ -58,6 +58,28 @@ class RoomService {
       console.error(e);
     }
   }
+
+  async searchRooms(keyword: string, count: number) {
+    try {
+      const query = new RegExp(keyword, 'i');
+      const res = await Rooms.find({ $or: [{ title: query }, { description: query }] }).sort({ date: 1 }).skip(count).limit(10);
+
+      const roomsInfo = await Promise.all((res).map(async ({
+        _id, title, isAnonymous, participants,
+      }) => {
+        const userList = participants.map(({ userDocumentId }) => ({ _id: userDocumentId }));
+        const participantsInfo = await Users.find({ _id: { $in: userList } }, ['userName', 'profileUrl']);
+        const roomInfo = {
+          _id, title, isAnonymous, participantsInfo,
+        };
+        return roomInfo;
+      }));
+
+      return roomsInfo;
+    } catch (e) {
+      console.error(e);
+    }
+  }
 }
 
 export = new RoomService();

--- a/server/src/services/users-service.ts
+++ b/server/src/services/users-service.ts
@@ -67,7 +67,7 @@ class UserService {
 
   async signup(info: ISignupUserInfo) {
     try {
-      const result = await Users.insertMany([info]);
+      await Users.insertMany([info]);
     } catch (error) {
       console.error(error);
     }


### PR DESCRIPTION
## 개요
검색창에서 Room 타입 카테고리를 선택 후 검색하면 키워드가 제목에 포함된 방들이 보여지도록 구현했습니다.

## 작업사항
- room 검색 API 작성
- room service에서 키워드가 포함된 방 검색
- search view에서 검색된 방 RoomCard를 보여주도록 구현

## 변경로직
- 기존 EventsList를 보여주는 로직을 참고해서 구현해봤습니다.
- loading이 아니라면 event리스트를 보여주던 코드를 itemList함수 형태로 분리했습니다.

### 변경후

https://user-images.githubusercontent.com/59464537/141655407-0a33842e-76dc-4d80-843f-76c5c2d1ae0b.mov


### 에러 기록
- 타입을 선택하고(Rooms, Events) 검색을 한 이후에 타입을 바꾸면 에러가 발생하는 상황입니다.


https://user-images.githubusercontent.com/59464537/141655371-5ad20b17-02bc-422f-bfb2-4e8e4bf76d37.mov



 