### PR TITLE
Room 내부 마이크 토글 이벤트 구현

### DIFF
--- a/client/src/components/room/in-room-modal.tsx
+++ b/client/src/components/room/in-room-modal.tsx
@@ -41,6 +41,11 @@ function InRoomModal() {
   const myStream = useRef<any>();
   const myBox = useRef<HTMLVideoElement>(null);
 
+  const micToggle = (isMicOn : boolean) => {
+    socket?.emit('room:mic', { roomDocumentId, userDocumentId: user.userDocumentId, isMicOn });
+    setMic(isMicOn);
+  };
+
   const handleIce = useCallback((data: any) => {
     console.log('sent candidate');
     dispatch({ type: 'SENT_CANDIDATE', payload: { data: data.candidate, socket } });
@@ -145,6 +150,14 @@ function InRoomModal() {
       socket.emit('room:offer', offer);
     });
 
+    socket?.on('room:mic', async (payload: any) => {
+      const { userData } = payload;
+      dispatch({
+        type: 'UPDATE_USER',
+        payload: { userData },
+      });
+    });
+
     socket?.on('room:leave', async (payload: any) => {
       const { userDocumentId } = payload;
       dispatch({
@@ -171,7 +184,6 @@ function InRoomModal() {
       console.log('received candidate');
       myPeerConnection.current?.addIceCandidate(ice);
     });
-
   }, [socket]);
 
   const leaveEvent = () => {
@@ -185,14 +197,14 @@ function InRoomModal() {
         <OptionBtn><FiMoreHorizontal /></OptionBtn>
       </InRoomHeader>
       <InRoomUserList>
-        {state.participants.map(({ userDocumentId, stream }: any) => <InRoomOtherUserBox key={userDocumentId} stream={stream} userDocumentId={userDocumentId} isMicOn={false} />)}
+        {state.participants.map(({ userDocumentId, stream, mic }: any) => <InRoomOtherUserBox key={userDocumentId} stream={stream} userDocumentId={userDocumentId} isMicOn={mic} />)}
         <InRoomUserBox ref={myBox} key={user.userDocumentId} userDocumentId={user.userDocumentId} isMicOn={isMic} />
       </InRoomUserList>
       <InRoomFooter>
         <DefaultButton buttonType="active" size="small" onClick={leaveEvent}> Leave a Quietly </DefaultButton>
         <FooterBtnDiv><FiScissors /></FooterBtnDiv>
         <FooterBtnDiv><FiPlus /></FooterBtnDiv>
-        <FooterBtnDiv>{isMic ? <FiMic onClick={() => setMic(false)} /> : <FiMicOff onClick={() => setMic(true)} />}</FooterBtnDiv>
+        <FooterBtnDiv>{isMic ? <FiMic onClick={() => micToggle(false)} /> : <FiMicOff onClick={() => micToggle(true)} />}</FooterBtnDiv>
       </InRoomFooter>
     </>
   );

--- a/client/src/components/room/in-room-reducer.tsx
+++ b/client/src/components/room/in-room-reducer.tsx
@@ -3,6 +3,7 @@ import { deepCopy } from '@src/utils';
 
 export type Action = { type: 'JOIN_USER', payload: any } | { type: 'SET_USERS', payload: any }
 | { type: 'LEAVE_USER', payload: any } | { type: 'ADD_STREAM', payload: any } | { type: 'SENT_CANDIDATE', payload: any }
+| { type: 'UPDATE_USER', payload: any};
 
 export type TState = {
     participants: Array<any>
@@ -14,7 +15,6 @@ export const initialState = {
 
 export const reducer = (state: TState, action: Action): TState => {
   switch (action.type) {
-
     case 'JOIN_USER': {
       const { userData } = action.payload;
       const newParticipants = deepCopy(state.participants);
@@ -26,6 +26,17 @@ export const reducer = (state: TState, action: Action): TState => {
     case 'SET_USERS': {
       const { participants } = action.payload;
       const newParticipants = deepCopy(participants);
+
+      return { ...state, participants: newParticipants };
+    }
+
+    case 'UPDATE_USER': {
+      const { userData } = action.payload;
+      const newParticipants = state.participants.reduce((acc, cur) => {
+        if (userData.userDocumentId === cur.userDocumentId) acc.push({ userDocumentId: userData.userDocumentId, mic: userData.isMicOn });
+        else acc.push(cur);
+        return acc;
+      }, []);
 
       return { ...state, participants: newParticipants };
     }

--- a/server/src/services/rooms-service.ts
+++ b/server/src/services/rooms-service.ts
@@ -37,6 +37,10 @@ class RoomService {
     return result;
   }
 
+  async setMic(roomDocumentId: string, userDocumentId: string, isMicOn: boolean) {
+    await Rooms.updateOne({ _id: roomDocumentId, 'participants.userDocumentId': userDocumentId }, { $set: { 'participants.$.mic': isMicOn } });
+  }
+
   // eslint-disable-next-line consistent-return
   async get10Rooms(count: number) {
     try {

--- a/server/src/sockets/room.ts
+++ b/server/src/sockets/room.ts
@@ -51,9 +51,19 @@ export default function registerRoomHandler(socket : Socket) {
     socket.to(roomDocumentId).emit('room:ice', ice);
   };
 
+  const handleMic = async (payload: any) => {
+    const {
+      roomDocumentId, userDocumentId, isMicOn,
+    } = payload;
+
+    const userData = { userDocumentId, isMicOn };
+    socket.to(roomDocumentId).emit('room:mic', { userData });
+  };
+
   socket.on('room:join', handleRoomJoin);
   socket.on('room:offer', handleRoomOffer);
   socket.on('room:answer', handleRoomAnswer);
   socket.on('room:ice', handleRoomIce);
   socket.on('disconnect', handleRoomLeave);
+  socket.on('room:mic', handleMic);
 }

--- a/server/src/sockets/room.ts
+++ b/server/src/sockets/room.ts
@@ -56,6 +56,8 @@ export default function registerRoomHandler(socket : Socket) {
       roomDocumentId, userDocumentId, isMicOn,
     } = payload;
 
+    await RoomService.setMic(roomDocumentId, userDocumentId, isMicOn);
+
     const userData = { userDocumentId, isMicOn };
     socket.to(roomDocumentId).emit('room:mic', { userData });
   };


### PR DESCRIPTION
## 개요
- Room 내부 마이크 토글 이벤트 구현
## 작업사항
- 마이크 버튼 클릭시 소켓을 이용해 다른 유저들에게 정보 전달 및 업데이트
- 해당 정보 mongoDB에도 업데이트
## 변경로직
- inRoomUserList에 mic 정보가 들어가는데 해당 값을 false값이 아닌 participants의 mic값으로 변경해주었습니다.
- 마이크 버튼 클릭시 내부 상태 변경과 socket emit 두가지 기능을 해줘야해서 새로 함수를 만들고 해당 함수가 실행될수 있도록 구현하였습니다.
### 변경후

https://user-images.githubusercontent.com/51700274/141686837-b70898b5-f460-4182-b9d7-993c978f9a06.mov

## 사용방법
- 위 영상에서 나온것 처럼 방에 들어가서 마이크 버튼을 클릭하고 다른 유저에서 해당 유저의 마이크가 바뀌는지 확인하면 됩니다.
## 기타
- in-room-modal 의 reducer 부분에 로직을 추가해주는 과정에 있어서 participants 배열이 어떤식으로 구성되어있는지 헷갈리더라구요.. 현재는 any 타입으로 되어있는데 해당부분을 interface로 바꿔주면 좋을것 같습니다.
- mic 값이 바뀌면 InRoomOtherUserBox 에 들어가는 mic 값이 바뀌게 되는데 해당 컴포넌트에 stream 값도 바뀌게 되어서 webRTC 부분에 영향이 가지 않을까 걱정입니다...
    - 저는 맥미니로 개발을 해서 캠이 없어서 잘 작동하는지 확인을 못합니다 ㅠㅠ
- 마이크 정보를 저장해주는 로직을 await를 사용해서 구현하였는데 다른 정보 업데이트와 달리 해당 정보는 클라이언트에 보여주는 정보와는 직접적인 연관이 없습니다. (마이크 버튼이 달라지는 부분은 socket으로 이미 정보를 받아서 상태를 바꿔주기 때문)
    - 저장된 정보는 유저가 새로 들어올때 사용됩니다.
- 그래서 해당 부분은 await를 사용하지 않아도 되지 않을까... 하는 생각인데 어떻게 생각하시나요 ?? 다른 오류같은게 발생할수 있을까요...?