### PR TITLE
in-room-modal 관련 컴포넌트 리팩토링

### DIFF
--- a/client/src/components/room/in-room-modal.tsx
+++ b/client/src/components/room/in-room-modal.tsx
@@ -42,13 +42,11 @@ function InRoomModal() {
   const myBox = useRef<HTMLVideoElement>(null);
 
   const handleIce = useCallback((data: any) => {
-    console.log('sent candidate');
     dispatch({ type: 'SENT_CANDIDATE', payload: { data: data.candidate, socket } });
   }, [socket]);
 
   // 다른 유저 접속시 연결하기 dispatch로 비디오 태그 추가
   const handleAddStream = (data: any) => {
-    console.log('ADDSTream');
     dispatch({ type: 'ADD_STREAM', payload: { data } });
   };
 
@@ -69,12 +67,11 @@ function InRoomModal() {
       ],
     });
     myPeerConnection.current?.addEventListener('icecandidate', handleIce);
-    myPeerConnection.current?.addEventListener('addstream', handleAddStream);
+    myPeerConnection.current?.addEventListener('track', handleAddStream);
+
     myStream.current?.getTracks()
       .forEach((track: any) => {
-        console.log(track);
         myPeerConnection.current?.addTrack(track, myStream.current);
-        console.log(myPeerConnection.current);
       });
   };
 
@@ -141,7 +138,7 @@ function InRoomModal() {
 
       const offer = await myPeerConnection.current?.createOffer();
       myPeerConnection.current?.setLocalDescription(offer);
-      console.log('sent the offer');
+
       socket.emit('room:offer', offer);
     });
 
@@ -154,21 +151,17 @@ function InRoomModal() {
     });
 
     socket?.on('room:offer', async (offer: RTCSessionDescriptionInit) => {
-      console.log('received the offer');
       myPeerConnection.current?.setRemoteDescription(offer);
       const answer = await myPeerConnection.current?.createAnswer();
       myPeerConnection.current?.setLocalDescription(answer);
       socket.emit('room:answer', answer);
-      console.log('sent the answer');
     });
 
     socket?.on('room:answer', async (answer: RTCSessionDescriptionInit) => {
-      console.log('received the answer');
       myPeerConnection.current?.setRemoteDescription(answer);
     });
 
     socket?.on('room:ice', async (ice: RTCIceCandidateInit) => {
-      console.log('received candidate');
       myPeerConnection.current?.addIceCandidate(ice);
     });
   }, [socket]);

--- a/client/src/components/room/in-room-modal.tsx
+++ b/client/src/components/room/in-room-modal.tsx
@@ -171,7 +171,6 @@ function InRoomModal() {
       console.log('received candidate');
       myPeerConnection.current?.addIceCandidate(ice);
     });
-
   }, [socket]);
 
   const leaveEvent = () => {

--- a/client/src/components/room/in-room-reducer.tsx
+++ b/client/src/components/room/in-room-reducer.tsx
@@ -14,7 +14,6 @@ export const initialState = {
 
 export const reducer = (state: TState, action: Action): TState => {
   switch (action.type) {
-
     case 'JOIN_USER': {
       const { userData } = action.payload;
       const newParticipants = deepCopy(state.participants);

--- a/client/src/components/room/in-room-reducer.tsx
+++ b/client/src/components/room/in-room-reducer.tsx
@@ -41,7 +41,8 @@ export const reducer = (state: TState, action: Action): TState => {
       const { data } = action.payload;
       const { participants } = state;
       const newParticipant = participants.pop();
-      newParticipant.stream = data.stream;
+      // eslint-disable-next-line prefer-destructuring
+      newParticipant.stream = data.streams[0];
       participants.push(newParticipant);
 
       return { ...state, participants };

--- a/client/src/components/room/in-room-reducer.tsx
+++ b/client/src/components/room/in-room-reducer.tsx
@@ -4,8 +4,14 @@ import { deepCopy } from '@src/utils';
 export type Action = { type: 'JOIN_USER', payload: any } | { type: 'SET_USERS', payload: any }
 | { type: 'LEAVE_USER', payload: any } | { type: 'ADD_STREAM', payload: any } | { type: 'SENT_CANDIDATE', payload: any }
 
+export type TParticipant = {
+  userDocumentId: string,
+  mic: boolean,
+  stream?: MediaStream,
+}
+
 export type TState = {
-    participants: Array<any>
+    participants: Array<TParticipant>
 }
 
 export const initialState = {
@@ -40,9 +46,9 @@ export const reducer = (state: TState, action: Action): TState => {
     case 'ADD_STREAM': {
       const { data } = action.payload;
       const { participants } = state;
-      const newParticipant = participants.pop();
+      const newParticipant = participants.pop() as TParticipant;
       // eslint-disable-next-line prefer-destructuring
-      newParticipant.stream = data.streams[0];
+      newParticipant!.stream = data.streams[0];
       participants.push(newParticipant);
 
       return { ...state, participants };

--- a/client/src/components/room/in-room-user-box.tsx
+++ b/client/src/components/room/in-room-user-box.tsx
@@ -2,12 +2,12 @@
 import React, {
   Ref, RefObject, useEffect, useRef, useState,
 } from 'react';
-import styled from 'styled-components';
 import {
   FiMic, FiMicOff,
 } from 'react-icons/fi';
 
 import { getUserInfo } from '@api/index';
+import { InRoomUserBoxStyle, InRoomUserMicDiv, UserBox } from './style';
 
 export interface IParticipant {
     userDocumentId: string,
@@ -15,42 +15,7 @@ export interface IParticipant {
     stream?: any,
 }
 
-const InRoomUserBoxStyle = styled.div`
-  position: relative;
-  width: 80px;
-  height: 90px;
-
-  p {
-    margin: 5px;
-  }
-`;
-
-const InRoomUserMicDiv = styled.div`
-  position: absolute;
-  right: 10px;
-  bottom: 20px;
-
-  width: 30px;
-  height: 30px;
-
-  background-color: #58964F;
-  border-radius: 30px;
-
-  svg {
-    transform: translate(6px, 6px);
-  }
-`;
-
-const UserBox = styled.video`
-  width: 60px;
-  min-width: 48px;
-  height: 60px;
-  border-radius: 30%;
-  overflow: hidden;
-  background-color: #6F8A87;
-`;
-
-export function InRoomOtherUserBox({ userDocumentId, isMicOn, stream }: IParticipant) {
+export function InRoomUserBox({ userDocumentId, isMicOn, stream }: IParticipant) {
   const [userInfo, setUserInfo] = useState<any>();
   const ref = useRef<HTMLVideoElement>(null);
 
@@ -60,8 +25,8 @@ export function InRoomOtherUserBox({ userDocumentId, isMicOn, stream }: IPartici
   }, []);
 
   useEffect(() => {
+    if (!ref.current) return;
     ref.current!.srcObject = stream;
-    console.log(ref.current?.srcObject);
   }, [stream]);
 
   return (
@@ -74,24 +39,3 @@ export function InRoomOtherUserBox({ userDocumentId, isMicOn, stream }: IPartici
     </InRoomUserBoxStyle>
   );
 }
-
-export const InRoomUserBox = React.forwardRef<HTMLVideoElement, IParticipant>(
-  (props, ref) => {
-    const [userInfo, setUserInfo] = useState<any>();
-
-    useEffect(() => {
-      getUserInfo(props.userDocumentId)
-        .then((res) => setUserInfo(res));
-    }, []);
-
-    return (
-      <InRoomUserBoxStyle>
-        <UserBox ref={ref} poster={userInfo?.profileUrl} autoPlay muted playsInline />
-        <InRoomUserMicDiv>
-          { props.isMicOn ? <FiMic /> : <FiMicOff /> }
-        </InRoomUserMicDiv>
-        <p>{ userInfo?.userName }</p>
-      </InRoomUserBoxStyle>
-    );
-  },
-);

--- a/client/src/components/room/style.ts
+++ b/client/src/components/room/style.ts
@@ -75,3 +75,38 @@ export const FooterBtnDiv = styled.div`
     transform: translate(8px, 8px);
   };
 `;
+
+export const InRoomUserBoxStyle = styled.div`
+  position: relative;
+  width: 80px;
+  height: 90px;
+
+  p {
+    margin: 5px;
+  }
+`;
+
+export const InRoomUserMicDiv = styled.div`
+  position: absolute;
+  right: 10px;
+  bottom: 20px;
+
+  width: 30px;
+  height: 30px;
+
+  background-color: #58964F;
+  border-radius: 30px;
+
+  svg {
+    transform: translate(6px, 6px);
+  }
+`;
+
+export const UserBox = styled.video`
+  width: 60px;
+  min-width: 48px;
+  height: 60px;
+  border-radius: 30%;
+  overflow: hidden;
+  background-color: #6F8A87;
+`;

--- a/client/src/hooks/useSocket.tsx
+++ b/client/src/hooks/useSocket.tsx
@@ -1,0 +1,22 @@
+import { useEffect, useRef } from 'react';
+import { io, Socket } from 'socket.io-client';
+
+const useSocket = (): Socket | undefined => {
+  const socket = useRef<Socket>();
+
+  useEffect(() => {
+    const url = process.env.REACT_APP_API_URL as string;
+    socket.current = io(url);
+
+    return () => {
+      if (socket.current) {
+        socket.current.disconnect();
+        socket.current = undefined;
+      }
+    };
+  }, []);
+
+  return socket.current;
+};
+
+export default useSocket;

--- a/client/src/views/room-view.tsx
+++ b/client/src/views/room-view.tsx
@@ -29,7 +29,7 @@ const RoomDiv = styled.div`
 `;
 
 const makeRoomToCard = (room: RoomCardProps) => (
-  <div className="RoomCard" data-id={room._id}>
+  <div className="RoomCard" key={room._id} data-id={room._id}>
     <RoomCard
       key={room._id}
       _id={room._id}

--- a/server/src/api/routes/search.ts
+++ b/server/src/api/routes/search.ts
@@ -11,10 +11,11 @@ export default (app: Router) => {
     const { keyword } = req.params;
     const { count } = req.query;
     if (typeof keyword !== 'string' || typeof count !== 'string') {
-        res.json({ ok: false });
+      res.json({ ok: false });
     } else {
-        const items = (await eventsService.searchEvent(keyword, Number(count)))?.map(eventsService.makeItemToEventInterface);
-        res.json({ ok: true, items, keyword })
+      const items = (await eventsService.searchEvent(keyword,
+        Number(count)))?.map(eventsService.makeItemToEventInterface);
+      res.json({ ok: true, items, keyword });
     }
   });
 };


### PR DESCRIPTION
## 개요

in-room-modal 관련 컴포넌트 리팩토링

## 작업사항

- webRTCConnection 관련 메서드 수정
- useSocket 훅 생성
- socket useRef로 관리
- in-room-user 컴포넌트 단일화

## 변경로직
- mdn에서 권장하는 메서드들로 일부 webRTCConnection 관련 메서드 수정했습니다. (addStream => track)
- socket 연결은 채팅에서도 활용할 수 있다고 판단하여 별도의 useSocket으로 훅을 만들었습니다.
- socket State를 사용했을 때 다른 메서드들에서 의존성이 커져서 useRef로 변경했습니다.

### 변경후

동작 내용은 똑같습니다.

## 사용방법

```js

const socket = useSocket();

```

useSocket 같은 경우 처럼 선언 하신 후 

```js
useEffect(() => {
    if (!socket) return;  //내부적으로 emit을 할 경우 사용

    socket.emit('room:join', {
      roomDocumentId, userDocumentId: user.userDocumentId,
    });

    socket.on('room:join', async (payload: any) => {
     ....
      socket!.emit('room:offer', offer);
    });

  }, [socket]);

```

이벤트를 등록 후 사용하면 됩니다.

## 기타
- 지난번 크롱님 피드백 시간에 파일 당 코드 길이가 균일하면 좋다고 하셔서 in-room-modal 코드 길이를 줄여보려고 했는데 소켓 이벤트 등록이나 webrtc 연결 코드 둘 다 의존성이 강해서 분리하기가 어렵습니다... 분리 할 수 잇는 좋은 방법이 있는지 궁금합니다!