### PR TITLE
🐡 [5-2] 채팅 목록 확인하기 구현

### DIFF
--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -138,3 +138,21 @@ export const getSearchResult = async (searchInfo: {keyword:string, option:string
     console.error(error);
   }
 };
+
+export const getChatRooms = async (userDocumentId: string) => {
+  try {
+    let response = await fetch(
+      `${process.env.REACT_APP_API_URL}/api/chat-rooms/${userDocumentId}`,
+      {
+        method: 'get',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+    response = await response.json();
+    return response;
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/client/src/components/chat/chat-header.tsx
+++ b/client/src/components/chat/chat-header.tsx
@@ -1,0 +1,63 @@
+import styled from 'styled-components';
+import {
+  FiMoreHorizontal, FiMessageSquare,
+} from 'react-icons/fi';
+
+import { makeIconToLink } from '@utils/index';
+
+const ChatHeaderStyle = styled.div`
+  background-color: #B6B6B6;
+
+  width: 100%;
+  height: 110px;
+
+  position: relative;
+
+  p {
+    position: absolute;
+    top: 35px;
+    left:50%;
+    transform: translateX(-50%);
+
+    font-family: 'Nunito';
+    font-style: Bold;
+    font-size: 32px;
+
+    margin: 0px;
+  }
+`;
+
+const ChatHeaderBtnDiv = styled.div`
+  position: absolute;
+  top: 35px;
+  right: 5%;
+
+  svg{
+    margin: 0px 10px 0px 10px;
+    &:hover {
+      filter: invert(88%) sepia(1%) saturate(4121%) hue-rotate(12deg) brightness(62%) contrast(79%);
+    }
+  }
+`;
+
+const chatHeaderBtn = [
+  {
+    Component: FiMessageSquare, link: '/chat-rooms/new', key: 'newChat', size: 32,
+  },
+  {
+    Component: FiMoreHorizontal, link: '//chat-rooms/new', key: 'selector', size: 32,
+  },
+];
+
+function ChatHeader() {
+  return (
+    <ChatHeaderStyle>
+      <p>BackChannel</p>
+      <ChatHeaderBtnDiv>
+        {chatHeaderBtn.map(makeIconToLink)}
+      </ChatHeaderBtnDiv>
+    </ChatHeaderStyle>
+  );
+}
+
+export default ChatHeader;

--- a/client/src/components/chat/chat-user-card.tsx
+++ b/client/src/components/chat/chat-user-card.tsx
@@ -1,0 +1,102 @@
+/* eslint-disable consistent-return */
+/* eslint-disable max-len */
+import styled from 'styled-components';
+
+interface Participants{
+  _id: string,
+  userName: string,
+  profileUrl: string
+}
+
+type chatUserCardProps = { participantsInfo: Array<Participants> };
+type ProfileProps = { profileUrl: string, length: number };
+
+const ChatUserCardLayout = styled.div`
+  background-color: #FFFFFF;
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+  border-radius: 30px;
+  margin-left: 0.8%;
+  width: 99%;
+  height: 120px;
+
+  display: flex;
+  flex-direction: row;
+`;
+
+const ChatUserCardProfileDiv = styled.div`
+  width: 100px;
+  height: 100px;
+  padding: 10px;
+
+  position: relative;
+`;
+
+const ChatUserCardFirstProfile = styled.div.attrs((props: ProfileProps) => ({ style: { background: `center / contain no-repeat url(${props.profileUrl})` } }))`
+  position: absolute;
+
+  width: ${(props: ProfileProps) => (props.length === 1 ? 85 : 65)}px;
+  height: ${(props: ProfileProps) => (props.length === 1 ? 85 : 65)}px;
+
+  border-radius: 25px;
+
+  background-size: ${(props: ProfileProps) => (props.length === 1 ? 120 : 100)}px;
+  z-index: 2;
+`;
+
+const ChatUserCardSecondProfile = styled.div.attrs((props: ProfileProps) => {
+  if (props.length === 1) return;
+  return { style: { background: `center / contain no-repeat url(${props.profileUrl})` } };
+})`
+  position: absolute;
+  top: 50px;
+  left: 40px;
+
+  width: 55px;
+  height: 55px;
+  background-size: 80px;
+  border-radius: 25px;
+
+  z-index: 1;
+`;
+
+const ChatUserCardInfo = styled.div`
+  p{
+    margin: 0px 0px 10px 0px;
+    transform: translate(10px, 25px);
+
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+`;
+
+const UserNameInfo = styled.p`
+  width: 200px;
+  font-family: "Nunito";
+  font-size: 24px;
+  font-weight: bold;
+`;
+
+const LastChatMsg = styled.p`
+  width: 300px;
+  font-family: "Nunito";
+  font-size: 20px;
+`;
+
+const ChatUserCard = ({ participantsInfo } : chatUserCardProps) => {
+  const userNames = participantsInfo.map((participant) => participant.userName).join(', ');
+  return (
+    <ChatUserCardLayout>
+      <ChatUserCardProfileDiv>
+        <ChatUserCardFirstProfile profileUrl={participantsInfo[0].profileUrl} length={participantsInfo.length} />
+        {participantsInfo.length > 1 && <ChatUserCardSecondProfile profileUrl={participantsInfo[1].profileUrl} length={participantsInfo.length} /> }
+      </ChatUserCardProfileDiv>
+      <ChatUserCardInfo>
+        <UserNameInfo>{userNames}</UserNameInfo>
+        <LastChatMsg>최근에 보내거나 받은 메세지</LastChatMsg>
+      </ChatUserCardInfo>
+    </ChatUserCardLayout>
+  );
+};
+
+export default ChatUserCard;

--- a/client/src/components/chat/chat-user-card.tsx
+++ b/client/src/components/chat/chat-user-card.tsx
@@ -16,6 +16,7 @@ const ChatUserCardLayout = styled.div`
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
   border-radius: 30px;
   margin-left: 0.8%;
+  margin-bottom: 10px;
   width: 99%;
   height: 120px;
 

--- a/client/src/components/chat/chat-user-card.tsx
+++ b/client/src/components/chat/chat-user-card.tsx
@@ -3,7 +3,7 @@
 import styled from 'styled-components';
 
 interface Participants{
-  _id: string,
+  userDocumentId: string,
   userName: string,
   profileUrl: string
 }

--- a/client/src/components/common/default-header.tsx
+++ b/client/src/components/common/default-header.tsx
@@ -29,7 +29,7 @@ const IconContainer = styled.div`
   a:not(:last-child) {
     margin-right: 30px;
   }
-  
+
   svg:hover {
     filter: invert(88%) sepia(1%) saturate(4121%) hue-rotate(12deg) brightness(62%) contrast(79%);
   }
@@ -69,7 +69,7 @@ function DefaultHeader() {
   const resetNowItemsList = useResetRecoilState(nowItemsListState);
   const leftSideIcons: IconAndLink[] = [
     { Component: HiSearch, link: '/search', key: 'search' },
-    { Component: HiOutlinePaperAirplane, link: '/chat', key: 'chat' },
+    { Component: HiOutlinePaperAirplane, link: '/chat-rooms', key: 'chat' },
   ];
   const rightSideIcons: IconAndLink[] = [
     { Component: HiOutlineMail, link: '/invite', key: 'invite' },

--- a/client/src/views/chat-rooms-view.tsx
+++ b/client/src/views/chat-rooms-view.tsx
@@ -1,7 +1,25 @@
 import React from 'react';
+import styled from 'styled-components';
+
+import ChatHeader from '@components/chat/chat-header';
+
+const ChatRoomsLayout = styled.div`
+  background-color: #FFFFFF;
+  border-radius: 30px;
+
+  width: 100%;
+  height: 100%;
+
+  overflow: hidden;
+  position: relative;
+`;
 
 function ChatRoomsViews() {
-  return (<></>);
+  return (
+    <ChatRoomsLayout>
+      <ChatHeader />
+    </ChatRoomsLayout>
+  );
 }
 
 export default ChatRoomsViews;

--- a/client/src/views/chat-rooms-view.tsx
+++ b/client/src/views/chat-rooms-view.tsx
@@ -22,13 +22,13 @@ const ChatRoomsLayout = styled.div`
 `;
 
 interface IChatUserType {
-  _id: string,
+  userDocumentId: string,
   userName: string,
   profileUrl: string,
 }
 
 interface IChatRoom {
-  _id: string,
+  chatDocumentId: string,
   participants: Array<IChatUserType>
 }
 
@@ -49,7 +49,7 @@ function ChatRoomsViews() {
   return (
     <ChatRoomsLayout>
       <ChatHeader />
-      {chatRooms.map((chatRoom: IChatRoom) => <ChatUserCard key={chatRoom._id} participantsInfo={chatRoom.participants} />)}
+      {chatRooms?.map((chatRoom: IChatRoom) => <ChatUserCard key={chatRoom.chatDocumentId} participantsInfo={chatRoom.participants} />)}
     </ChatRoomsLayout>
   );
 }

--- a/client/src/views/chat-rooms-view.tsx
+++ b/client/src/views/chat-rooms-view.tsx
@@ -1,8 +1,14 @@
-import React from 'react';
+/* eslint-disable no-underscore-dangle */
+/* eslint-disable max-len */
+import React, { useEffect, useState } from 'react';
+import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
+import userType from '@atoms/user';
 import ChatHeader from '@components/chat/chat-header';
 import ChatUserCard from '@components/chat/chat-user-card';
+import LoadingSpinner from '@common/loading-spinner';
+import { getChatRooms } from '@api/index';
 
 const ChatRoomsLayout = styled.div`
   background-color: #FFFFFF;
@@ -15,21 +21,30 @@ const ChatRoomsLayout = styled.div`
   position: relative;
 `;
 
-const dummyData = [
-  { _id: 'hello', userName: 'helo', profileUrl: 'https://kr.object.ncloudstorage.com/nogarihouse/profile/cat.jpeg' },
-  { _id: 'hello', userName: 'test!', profileUrl: 'https://kr.object.ncloudstorage.com/nogarihouse/profile/puppy2.jpeg' },
-  { _id: 'hello', userName: 'ChanHUi', profileUrl: 'https://kr.object.ncloudstorage.com/nogarihouse/profile/puppy2.jpeg' },
-];
-
-// const dummyData = [
-//   { _id: 'hello', userName: 'helo', profileUrl: 'https://kr.object.ncloudstorage.com/nogarihouse/profile/cat.jpeg' },
-// ];
+interface IChatRoomType {
+  _id: string,
+  userName: string,
+  profileUrl: string,
+}
 
 function ChatRoomsViews() {
+  const [loading, setLoading] = useState(true);
+  const [chatRooms, setChatRooms] = useState<Array<Array<IChatRoomType>>>([]);
+  const { userDocumentId } = useRecoilValue(userType);
+
+  useEffect(() => {
+    getChatRooms(userDocumentId)
+      .then((res: any) => {
+        setChatRooms(res);
+        setLoading(false);
+      });
+  }, []);
+
+  if (loading) return (<LoadingSpinner />);
   return (
     <ChatRoomsLayout>
       <ChatHeader />
-      <ChatUserCard participantsInfo={dummyData} />
+      {chatRooms.map((chatRoom:Array<IChatRoomType>) => <ChatUserCard key={chatRoom._id} participantsInfo={chatRoom} />)}
     </ChatRoomsLayout>
   );
 }

--- a/client/src/views/chat-rooms-view.tsx
+++ b/client/src/views/chat-rooms-view.tsx
@@ -8,6 +8,7 @@ import userType from '@atoms/user';
 import ChatHeader from '@components/chat/chat-header';
 import ChatUserCard from '@components/chat/chat-user-card';
 import LoadingSpinner from '@common/loading-spinner';
+import ScrollBarStyle from '@styles/scrollbar-style';
 import { getChatRooms } from '@api/index';
 
 const ChatRoomsLayout = styled.div`
@@ -19,6 +20,8 @@ const ChatRoomsLayout = styled.div`
 
   overflow: hidden;
   position: relative;
+
+  ${ScrollBarStyle};
 `;
 
 interface IChatUserType {

--- a/client/src/views/chat-rooms-view.tsx
+++ b/client/src/views/chat-rooms-view.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 import ChatHeader from '@components/chat/chat-header';
+import ChatUserCard from '@components/chat/chat-user-card';
 
 const ChatRoomsLayout = styled.div`
   background-color: #FFFFFF;
@@ -14,10 +15,21 @@ const ChatRoomsLayout = styled.div`
   position: relative;
 `;
 
+const dummyData = [
+  { _id: 'hello', userName: 'helo', profileUrl: 'https://kr.object.ncloudstorage.com/nogarihouse/profile/cat.jpeg' },
+  { _id: 'hello', userName: 'test!', profileUrl: 'https://kr.object.ncloudstorage.com/nogarihouse/profile/puppy2.jpeg' },
+  { _id: 'hello', userName: 'ChanHUi', profileUrl: 'https://kr.object.ncloudstorage.com/nogarihouse/profile/puppy2.jpeg' },
+];
+
+// const dummyData = [
+//   { _id: 'hello', userName: 'helo', profileUrl: 'https://kr.object.ncloudstorage.com/nogarihouse/profile/cat.jpeg' },
+// ];
+
 function ChatRoomsViews() {
   return (
     <ChatRoomsLayout>
       <ChatHeader />
+      <ChatUserCard participantsInfo={dummyData} />
     </ChatRoomsLayout>
   );
 }

--- a/client/src/views/chat-rooms-view.tsx
+++ b/client/src/views/chat-rooms-view.tsx
@@ -21,15 +21,20 @@ const ChatRoomsLayout = styled.div`
   position: relative;
 `;
 
-interface IChatRoomType {
+interface IChatUserType {
   _id: string,
   userName: string,
   profileUrl: string,
 }
 
+interface IChatRoom {
+  _id: string,
+  participants: Array<IChatUserType>
+}
+
 function ChatRoomsViews() {
   const [loading, setLoading] = useState(true);
-  const [chatRooms, setChatRooms] = useState<Array<Array<IChatRoomType>>>([]);
+  const [chatRooms, setChatRooms] = useState<Array<IChatRoom>>([]);
   const { userDocumentId } = useRecoilValue(userType);
 
   useEffect(() => {
@@ -44,7 +49,7 @@ function ChatRoomsViews() {
   return (
     <ChatRoomsLayout>
       <ChatHeader />
-      {chatRooms.map((chatRoom:Array<IChatRoomType>) => <ChatUserCard key={chatRoom._id} participantsInfo={chatRoom} />)}
+      {chatRooms.map((chatRoom: IChatRoom) => <ChatUserCard key={chatRoom._id} participantsInfo={chatRoom.participants} />)}
     </ChatRoomsLayout>
   );
 }

--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -3,6 +3,7 @@ import room from '@routes/room';
 import event from '@routes/event';
 import user from '@routes/user';
 import search from '@routes/search';
+import chats from '@routes/chats';
 
 // guaranteed to get dependencies
 export default () => {
@@ -11,5 +12,7 @@ export default () => {
   event(app);
   user(app);
   search(app);
+  chats(app);
+
   return app;
 };

--- a/server/src/api/routes/chats.ts
+++ b/server/src/api/routes/chats.ts
@@ -1,0 +1,22 @@
+import {
+  Router, Request, Response,
+} from 'express';
+import chatService from '@services/chat-service';
+
+const chatRouter = Router();
+
+export default (app: Router) => {
+  app.use('/chat-rooms', chatRouter);
+
+  chatRouter.get('/:userDocumentId', async (req: Request, res: Response) => {
+    try {
+      const { userDocumentId } = req.params;
+
+      const chatRoomInfo = await chatService.getChatRooms(userDocumentId);
+
+      res.status(200).json(chatRoomInfo);
+    } catch (error) {
+      console.error(error);
+    }
+  });
+};

--- a/server/src/services/chat-service.ts
+++ b/server/src/services/chat-service.ts
@@ -1,0 +1,35 @@
+/* eslint-disable no-underscore-dangle */
+/* eslint-disable consistent-return */
+/* eslint-disable max-len */
+/* eslint-disable array-callback-return */
+/* eslint-disable class-methods-use-this */
+// import Chats from '@models/chats';
+import Users from '@models/users';
+import Chats from '@models/chats';
+
+let instance: any = null;
+
+class ChatService {
+  constructor() {
+    if (instance) return instance;
+    instance = this;
+  }
+
+  async getChatRooms(userDocumentId : string) {
+    const chatRoomList = await Users.findOne({ _id: userDocumentId }, ['chatRooms']);
+
+    const chatRoomInfo = await Promise.all((chatRoomList!.chatRooms).map(async (chatDocumentId: string) => {
+      const userDocumentIds = await Chats.findOne({ _id: chatDocumentId }, ['participants']);
+      const UserInfo : any = [];
+      await Promise.all((userDocumentIds)!.participants.map(async (_id) => {
+        if (_id === userDocumentId) return;
+        const info = await Users.findOne({ _id }, ['userName', 'profileUrl']);
+        UserInfo.push({ userDocumentId: info!._id, userName: info!.userName, profileUrl: info!.profileUrl });
+      }));
+      return ({ chatDocumentId, participants: UserInfo });
+    }));
+    return chatRoomInfo;
+  }
+}
+
+export = new ChatService();


### PR DESCRIPTION
## 개요
- 채팅 목록 확인하기 구현
## 작업사항
- 채팅 페이지 UI 구현
- 채팅 방 컴포넌트 구현
- 채팅 방 목록 API 구현
## 변경로직
- chat router 추가
- chat service 추가
- component 폴더에 chat 폴더 추가
### 변경후

https://user-images.githubusercontent.com/51700274/141798574-46456f46-269b-457b-83f2-699e67e4c63f.mov

## 사용방법
- test@naver.com으로 로그인 하시면 제가 저장해두었던 채팅방이 하나 나오게 됩니다.
- 채팅방 정보에 대한 응답을 받을때 자기자신을 뺀 나머지에 대한 정보만 받습니다.
## 기타
- chat service에서 mongoose에 요청을 너무 많이 보내는것 같아요 ... 코드 자체도 굉장히 더럽습니다 ㅠㅠ 리팩토링 도와주세요 !!!
    - userDocumentId로 소속되어있는 채팅방 목록을 불러올때
    - 채팅방 목록에서 해당 채팅방에 들어있는 유저 id를 가져올때
    - 유저 id로부터 해당 유저의 정보를 가져올때
    - 이렇게 세가지 경우 모두 DB 요청을 보내게 됩니다...
    -  reduce 이용해서 구현하고 싶었는데 타입스크립트 에러가 너무 많이나서 실패하고 결국 되는데로 하다보니 코드가 너무 더러워졌어요ㅠㅠ 도와주세요 :(
- 아직은 DB에서 불러오는 기능만 구현되어있고, 다른 부분은 구현되어있지 않습니다 :)