### PR TITLE
회원가입 유효성 검사 구현

### DIFF
--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -113,8 +113,8 @@ export const postCheckMail = async (email: { email: string }) => {
       body: JSON.stringify(email),
     });
 
-    const json: { verificationNumber: string } = await response.json();
-    return json;
+    const json = await response.json();
+    return json as { isUnique: boolean, verificationNumber: string };
   } catch (error) {
     console.error(error);
   }

--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -103,9 +103,9 @@ export const postSignUpUserInfo = async (postSignupUserInfoConfig: Object) => {
   }
 };
 
-export const postCheckMail = async (email: Object) => {
+export const postCheckMail = async (email: { email: string }) => {
   try {
-    let response = await fetch(`${process.env.REACT_APP_API_URL}/api/user/signup/mail`, {
+    const response = await fetch(`${process.env.REACT_APP_API_URL}/api/user/signup/mail`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -113,8 +113,8 @@ export const postCheckMail = async (email: Object) => {
       body: JSON.stringify(email),
     });
 
-    response = await response.json();
-    return response;
+    const json: { verificationNumber: string } = await response.json();
+    return json;
   } catch (error) {
     console.error(error);
   }

--- a/client/src/components/common/custom-inputbar.tsx
+++ b/client/src/components/common/custom-inputbar.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 export const CustomInputBar = styled.input`
   border: none;
   background-color: #ffffff;
-  width: 60%;
+  width: 100%;
   min-width: max-content;
   height: 60px;
   &:focus {

--- a/client/src/components/common/custom-inputbar.tsx
+++ b/client/src/components/common/custom-inputbar.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 export const CustomInputBar = styled.input`
   border: none;
   background-color: #ffffff;
-  width: 100%;
+  width: 60%;
   min-width: max-content;
   height: 60px;
   &:focus {

--- a/client/src/components/sign/sign-body.tsx
+++ b/client/src/components/sign/sign-body.tsx
@@ -1,11 +1,14 @@
+import scrollbarStyle from '@src/assets/styles/scrollbar-style';
 import styled from 'styled-components';
 
 const SignBody = styled.div`
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
   width: 100%;
+  height: calc(100vh - 100px);
+  ${scrollbarStyle};
 `;
 
 export default SignBody;

--- a/client/src/components/sign/sign-title.tsx
+++ b/client/src/components/sign/sign-title.tsx
@@ -10,6 +10,7 @@ const TitleDiv = styled.div`
   width: calc(740px*100vw/1440px);
   font-size: 4rem;
   min-width: 650px;
+  text-align: center;
 `;
 
 function SignTitle({

--- a/client/src/views/signup-info-view.tsx
+++ b/client/src/views/signup-info-view.tsx
@@ -31,18 +31,17 @@ const Padding = styled.div`
 
 function SignupInfoView() {
   const inputPasswordRef = useRef<HTMLInputElement>(null);
+  const inputPasswordCheckRef = useRef<HTMLInputElement>(null);
   const inputFullNameRef = useRef<HTMLInputElement>(null);
   const inputIdRef = useRef<HTMLInputElement>(null);
   const [isDisabled, setIsDisabled] = useState(true);
-  // const [isInputBarView, setIsInputBarView] = useState(true);
   const history = useHistory();
   const location = useLocation();
 
   const selectedItems = new Set();
-  const userInput = useRef<{ id: string, password: string, name: string}>({ id: '', password: '', name: '' });
 
   const inputOnChange = useCallback(() => {
-    if (inputPasswordRef.current?.value && inputFullNameRef.current?.value && inputIdRef.current?.value) {
+    if (inputPasswordRef.current?.value && inputPasswordCheckRef.current?.value && inputFullNameRef.current?.value && inputIdRef.current?.value) {
       setIsDisabled(false);
     } else {
       setIsDisabled(true);
@@ -54,25 +53,24 @@ function SignupInfoView() {
     if (typeof interestName === 'string') selectedItems.add(interestName);
   };
 
-  // const onClickInputViewNextButton = () => {
-  //   userInput.current.id = inputIdRef.current?.value as string;
-  //   userInput.current.password = inputPasswordRef.current?.value as string;
-  //   userInput.current.name = inputFullNameRef.current?.value as string;
-  //   setIsInputBarView(false);
-  // };
+  const checkPassword = () => inputPasswordRef.current?.value === inputPasswordCheckRef.current?.value;
 
-  const onClickInterestViewNextButton = () => {
-    const userInfo = {
-      loginType: 'normal',
-      userId: userInput.current.id,
-      password: userInput.current.password,
-      userName: userInput.current.name,
-      userEmail: (location.state as {email: string}).email,
-      interesting: Array.from(selectedItems),
-    };
+  const onClickNextButton = () => {
+    if (checkPassword()) {
+      const userInfo = {
+        loginType: 'normal',
+        userId: inputIdRef.current?.value as string,
+        password: inputPasswordRef.current?.value as string,
+        userName: inputFullNameRef.current?.value as string,
+        userEmail: (location.state as {email: string}).email,
+        interesting: Array.from(selectedItems),
+      };
 
-    postSignUpUserInfo(userInfo)
-      .then(() => { history.replace('/'); });
+      postSignUpUserInfo(userInfo)
+        .then(() => { history.replace('/'); });
+    } else {
+      alert('비밀번호를 확인해주세요');
+    }
   };
 
   return (
@@ -81,7 +79,8 @@ function SignupInfoView() {
       <SignBody>
         <CustomInputBox>
           <SignTitle title="what’s your password?" />
-          <CustomInputBar key="password" ref={inputPasswordRef} onChange={inputOnChange} type="text" placeholder="Password" />
+          <CustomInputBar key="password" ref={inputPasswordRef} onChange={inputOnChange} type="password" placeholder="Password" />
+          <CustomInputBar key="password" ref={inputPasswordCheckRef} onChange={inputOnChange} type="password" placeholder="Password Check" />
           <SignTitle title="what’s your full name?" />
           <CustomInputBar key="fullName" ref={inputFullNameRef} onChange={inputOnChange} type="text" placeholder="Full name" />
           <SignTitle title="what’s your id?" />
@@ -104,7 +103,7 @@ function SignupInfoView() {
             <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
             <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
           </InterestItemWarapper>
-          <DefaultButton buttonType="secondary" size="medium" onClick={onClickInterestViewNextButton} isDisabled={isDisabled}>NEXT</DefaultButton>
+          <DefaultButton buttonType="secondary" size="medium" onClick={onClickNextButton} isDisabled={isDisabled}>NEXT</DefaultButton>
           <Padding />
         </CustomInputBox>
       </SignBody>

--- a/client/src/views/signup-info-view.tsx
+++ b/client/src/views/signup-info-view.tsx
@@ -25,12 +25,16 @@ const InterestItemWarapper = styled.div`
   margin-right: -5%;
 `;
 
+const Padding = styled.div`
+  padding: 20px;
+`;
+
 function SignupInfoView() {
   const inputPasswordRef = useRef<HTMLInputElement>(null);
   const inputFullNameRef = useRef<HTMLInputElement>(null);
   const inputIdRef = useRef<HTMLInputElement>(null);
   const [isDisabled, setIsDisabled] = useState(true);
-  const [isInputBarView, setIsInputBarView] = useState(true);
+  // const [isInputBarView, setIsInputBarView] = useState(true);
   const history = useHistory();
   const location = useLocation();
 
@@ -50,12 +54,12 @@ function SignupInfoView() {
     if (typeof interestName === 'string') selectedItems.add(interestName);
   };
 
-  const onClickInputViewNextButton = () => {
-    userInput.current.id = inputIdRef.current?.value as string;
-    userInput.current.password = inputPasswordRef.current?.value as string;
-    userInput.current.name = inputFullNameRef.current?.value as string;
-    setIsInputBarView(false);
-  };
+  // const onClickInputViewNextButton = () => {
+  //   userInput.current.id = inputIdRef.current?.value as string;
+  //   userInput.current.password = inputPasswordRef.current?.value as string;
+  //   userInput.current.name = inputFullNameRef.current?.value as string;
+  //   setIsInputBarView(false);
+  // };
 
   const onClickInterestViewNextButton = () => {
     const userInfo = {
@@ -75,47 +79,34 @@ function SignupInfoView() {
     <>
       <SignHeader />
       <SignBody>
-        {isInputBarView ? (
-          <>
-            <CustomInputBox>
-              <SignTitle title="what’s your password?" />
-              <CustomInputBar key="password" ref={inputPasswordRef} onChange={inputOnChange} type="text" placeholder="Password" />
-              <SignTitle title="what’s your full name?" />
-              <CustomInputBar key="fullName" ref={inputFullNameRef} onChange={inputOnChange} type="text" placeholder="Full name" />
-              <SignTitle title="what’s your id?" />
-              <CustomInputBar key="id" ref={inputIdRef} onChange={inputOnChange} type="text" placeholder="Nick name" />
-            </CustomInputBox>
-            <DefaultButton buttonType="secondary" size="medium" onClick={onClickInputViewNextButton} isDisabled={isDisabled}>
-              NEXT
-            </DefaultButton>
-          </>
-        ) : (
-          <>
-            <CustomInputBox>
-              <SignTitle title="what’s your interests?" />
-              <InterestItemWarapper>
-                <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
-                <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
-                <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
-                <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
-                <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
-                <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
-                <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
-                <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
-                <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
-                <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
-                <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
-                <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
-                <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
-                <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
-                <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
-              </InterestItemWarapper>
-            </CustomInputBox>
-            <DefaultButton buttonType="secondary" size="medium" onClick={onClickInterestViewNextButton} isDisabled={isDisabled}>
-              NEXT
-            </DefaultButton>
-          </>
-        )}
+        <CustomInputBox>
+          <SignTitle title="what’s your password?" />
+          <CustomInputBar key="password" ref={inputPasswordRef} onChange={inputOnChange} type="text" placeholder="Password" />
+          <SignTitle title="what’s your full name?" />
+          <CustomInputBar key="fullName" ref={inputFullNameRef} onChange={inputOnChange} type="text" placeholder="Full name" />
+          <SignTitle title="what’s your id?" />
+          <CustomInputBar key="id" ref={inputIdRef} onChange={inputOnChange} type="text" placeholder="Nick name" />
+          <SignTitle title="what’s your interests?" />
+          <InterestItemWarapper>
+            <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
+            <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
+            <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
+            <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
+            <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
+            <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
+            <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
+            <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
+            <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
+            <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
+            <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
+            <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
+            <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
+            <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
+            <InterestItem onClick={onClickInterestItem} text="🐟노가리" />
+          </InterestItemWarapper>
+          <DefaultButton buttonType="secondary" size="medium" onClick={onClickInterestViewNextButton} isDisabled={isDisabled}>NEXT</DefaultButton>
+          <Padding />
+        </CustomInputBox>
       </SignBody>
     </>
   );

--- a/client/src/views/signup-info-view.tsx
+++ b/client/src/views/signup-info-view.tsx
@@ -25,6 +25,10 @@ const InterestItemWarapper = styled.div`
   margin-right: -5%;
 `;
 
+const CustomInfoInputBar = styled(CustomInputBar)`
+  width: 70%;
+`;
+
 const Padding = styled.div`
   padding: 20px;
 `;
@@ -79,12 +83,12 @@ function SignupInfoView() {
       <SignBody>
         <CustomInputBox>
           <SignTitle title="what’s your password?" />
-          <CustomInputBar key="password" ref={inputPasswordRef} onChange={inputOnChange} type="password" placeholder="Password" />
-          <CustomInputBar key="password" ref={inputPasswordCheckRef} onChange={inputOnChange} type="password" placeholder="Password Check" />
+          <CustomInfoInputBar key="password" ref={inputPasswordRef} onChange={inputOnChange} type="password" placeholder="Password" />
+          <CustomInfoInputBar key="password" ref={inputPasswordCheckRef} onChange={inputOnChange} type="password" placeholder="Password Check" />
           <SignTitle title="what’s your full name?" />
-          <CustomInputBar key="fullName" ref={inputFullNameRef} onChange={inputOnChange} type="text" placeholder="Full name" />
+          <CustomInfoInputBar key="fullName" ref={inputFullNameRef} onChange={inputOnChange} type="text" placeholder="Full name" />
           <SignTitle title="what’s your id?" />
-          <CustomInputBar key="id" ref={inputIdRef} onChange={inputOnChange} type="text" placeholder="Nick name" />
+          <CustomInfoInputBar key="id" ref={inputIdRef} onChange={inputOnChange} type="text" placeholder="Nick name" />
           <SignTitle title="what’s your interests?" />
           <InterestItemWarapper>
             <InterestItem onClick={onClickInterestItem} text="🐟노가리" />

--- a/client/src/views/signup-view.tsx
+++ b/client/src/views/signup-view.tsx
@@ -20,15 +20,15 @@ const CustomBackgroundWrapper = styled(BackgroundWrapper)`
 function SignUpView() {
   const inputEmailRef = useRef<HTMLInputElement>(null);
   const inputVerificationRef = useRef<HTMLInputElement>(null);
-  const verificationNumber = useRef<number>();
+  const verificationNumber = useRef<string>();
   const [isEmailInputView, setIsEmailInputView] = useState(true);
   const [isDisabled, setIsDisabled] = useState(true);
   const [loading, setLoading] = useState(false);
   const emailState = useRef<string>();
   const history = useHistory();
 
-  const setVerificationNumber = useCallback((number: number) => {
-    verificationNumber.current = number;
+  const setVerificationNumber = useCallback((inputVerificationNumber: string) => {
+    verificationNumber.current = inputVerificationNumber;
   }, []);
 
   const inputOnChange = useCallback(() => {
@@ -46,16 +46,8 @@ function SignUpView() {
     if (testEmailValidation(inputEmailValue)) {
       setLoading(true);
 
-      const postSignupMailConfig = {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ email: inputEmailValue }),
-      };
-
       postCheckMail({ email: inputEmailValue })
-        .then((json: any) => json.verificationNumber)
+        .then((json) => json!.verificationNumber)
         .then(setVerificationNumber)
         .then(() => {
           emailState.current = inputEmailValue;

--- a/client/src/views/signup-view.tsx
+++ b/client/src/views/signup-view.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable max-len */
 import React, { useCallback, useRef, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
@@ -20,7 +20,7 @@ const CustomBackgroundWrapper = styled(BackgroundWrapper)`
 function SignUpView() {
   const inputEmailRef = useRef<HTMLInputElement>(null);
   const inputVerificationRef = useRef<HTMLInputElement>(null);
-  const verificationNumber = useRef<string>();
+  const verificationNumberRef = useRef<string>();
   const [isEmailInputView, setIsEmailInputView] = useState(true);
   const [isDisabled, setIsDisabled] = useState(true);
   const [loading, setLoading] = useState(false);
@@ -28,7 +28,7 @@ function SignUpView() {
   const history = useHistory();
 
   const setVerificationNumber = useCallback((inputVerificationNumber: string) => {
-    verificationNumber.current = inputVerificationNumber;
+    verificationNumberRef.current = inputVerificationNumber;
   }, []);
 
   const inputOnChange = useCallback(() => {
@@ -40,21 +40,26 @@ function SignUpView() {
     }
   }, []);
 
+  const fetchPostMail = async (inputEmailValue: string) => {
+    const { isUnique, verificationNumber } = await postCheckMail({ email: inputEmailValue }) as { isUnique: boolean, verificationNumber: string };
+    if (isUnique) {
+      setVerificationNumber(verificationNumber);
+      emailState.current = inputEmailValue;
+      setLoading(false);
+      setIsDisabled(true);
+      setIsEmailInputView(false);
+    } else {
+      setLoading(false);
+      alert('이미 존재하는 이메일입니다');
+    }
+  };
+
   const onClickEmailNextButton = () => {
     const inputEmailValue = inputEmailRef.current?.value as string;
 
     if (testEmailValidation(inputEmailValue)) {
       setLoading(true);
-
-      postCheckMail({ email: inputEmailValue })
-        .then((json) => json!.verificationNumber)
-        .then(setVerificationNumber)
-        .then(() => {
-          emailState.current = inputEmailValue;
-          setLoading(false);
-          setIsDisabled(true);
-          setIsEmailInputView(false);
-        });
+      fetchPostMail(inputEmailValue);
     } else {
       alert('올바른 이메일을 입력해주세요');
     }
@@ -63,7 +68,7 @@ function SignUpView() {
   const onClickVerificationNextButton = () => {
     const inputVerificationValue = inputVerificationRef.current?.value as string;
 
-    if (inputVerificationValue === (verificationNumber.current?.toString())) {
+    if (inputVerificationValue === (verificationNumberRef.current?.toString())) {
       history.replace('/signup/info', { email: emailState.current });
     } else {
       alert('인증번호를 확인하세요.');

--- a/server/src/api/routes/user.ts
+++ b/server/src/api/routes/user.ts
@@ -53,7 +53,7 @@ export default (app: Router) => {
   userRouter.post('/signup/mail', async (req: Request, res: Response) => {
     const { email } = req.body;
 
-    const isUnique: boolean = usersService.isUniqueEmail(email);
+    const isUnique: boolean = await usersService.isUniqueEmail(email);
 
     if (isUnique) {
       const verificationNumber = await usersService.sendVerificationMail(email);

--- a/server/src/api/routes/user.ts
+++ b/server/src/api/routes/user.ts
@@ -53,9 +53,15 @@ export default (app: Router) => {
   userRouter.post('/signup/mail', async (req: Request, res: Response) => {
     const { email } = req.body;
 
-    const verificationNumber = await usersService.sendVerificationMail(email);
+    const isUnique: boolean = usersService.isUniqueEmail(email);
 
-    res.json({ verificationNumber });
+    if (isUnique) {
+      const verificationNumber = await usersService.sendVerificationMail(email);
+      res.json({ isUnique, verificationNumber });
+    } else {
+      res.json({ isUnique, verificationNumber: '-1' });
+    }
+
   });
 
   userRouter.post('/signup/userInfo', async (req: Request, res: Response) => {

--- a/server/src/services/users-service.ts
+++ b/server/src/services/users-service.ts
@@ -125,6 +125,11 @@ class UserService {
     };
   }
 
+  async isUniqueEmail(email: string) {
+    const user = await Users.findOne({ userEmail: email });
+    return !user;
+  }
+
   async sendVerificationMail(email: string) {
     const transporter = nodemailer.createTransport({
       service: 'gmail',


### PR DESCRIPTION
## 개요
회원가입 유효성 검사 구현
## 작업사항

- 회원가입 시 비밀번호 이중으로 입력
- 이메일 입력 시 존재하는 이메일이면 회원가입 불가

## 변경로직
- 인증번호만 보내주던 /user/signup/mail API가 유효한 이메일인지 확인하는 isUnique 값을 boolean으로 같이 보내줍니다!
- signup-info-view 페이지를 스크롤을 통해서 모든 정보를 하나의 페이지에서 받을 수 있도록 했습니다.

### 변경후

![image](https://user-images.githubusercontent.com/74816327/142014933-3693003f-f5fe-45d3-a405-d71c059393e3.png)
![image](https://user-images.githubusercontent.com/74816327/142015496-587bbe81-7301-4a13-bc92-597bb6d44942.png)

## 기타

브라우저 alert가 아닌 커스텀 alert를 만들어야겠다는 생각이 드네요 