### PR TITLE
음성채팅 음소거 On&Off 반영 기능 추가

### DIFF
--- a/client/src/components/common/default-button.tsx
+++ b/client/src/components/common/default-button.tsx
@@ -46,6 +46,9 @@ const CustomDefaultButton = styled.button`
   font-family: ${(props) => (props.font ? props.font : 'Bangers')};;
   font-size: ${(props: DefaultButtonProps) => sizes[props.size].fontSize}px;
   opacity: ${(props) => (props.disabled ? 0.5 : 1)};
+  &:hover {
+    cursor: pointer;
+  }
 `;
 
 function DefaultButton({

--- a/client/src/components/common/small-checkbox.tsx
+++ b/client/src/components/common/small-checkbox.tsx
@@ -12,13 +12,33 @@ interface SmallCheckboxProps extends CheckBoxProps{
 }
 
 const CheckBox = styled.input`
+  & {
+    display: none;
+  }
 
   & + label {
-      font-size: 14px;
-      line-height: 21px;
-      display: block;
+      position: absolute; 
+      top: 0px; 
+      right: 55px; 
+      width: 15px;
+      height: 15px;
+      float: left;
+      border-radius: 6px;
+      border: 2px solid #bcbcbc;
       cursor: pointer;
-      margin-left: 4px;
+    }
+
+    & + label span {
+      position: absolute; 
+      top: -2px; 
+      left: 20px; 
+      display: block; 
+      font-weight: bold;
+      user-select: none;
+    }
+
+    &:checked + label {
+      background-color: #4A6970;
     }
 `;
 

--- a/client/src/components/room/anonymous-checkbox.tsx
+++ b/client/src/components/room/anonymous-checkbox.tsx
@@ -4,10 +4,19 @@ import styled from 'styled-components';
 import SmallCheckbox, { CheckBoxProps } from '@common/small-checkbox';
 
 const AnonymousCheckBoxLayout = styled.div`
+  position: relative; 
   display: flex;
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
+`;
+
+const Text = styled.span`
+  width: 150px;
+  font-size: 14px;
+  line-height: 21px;
+  display: block;
+  margin-left: 4px;
 `;
 
 function AnonymousCheckBox({ checked, onChange }: CheckBoxProps) {
@@ -15,7 +24,9 @@ function AnonymousCheckBox({ checked, onChange }: CheckBoxProps) {
     <AnonymousCheckBoxLayout>
       <SmallCheckbox id="c1" checked={checked} onChange={onChange} />
       {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
-      <label htmlFor={'c1' as string}>Allow anonymous ?</label>
+      <label htmlFor={'c1' as string}>
+        <Text>Allow anonymous ?</Text>
+      </label>
     </AnonymousCheckBoxLayout>
   );
 }

--- a/client/src/components/room/in-room-modal.tsx
+++ b/client/src/components/room/in-room-modal.tsx
@@ -25,11 +25,15 @@ function InRoomModal() {
   const setRoomView = useSetRecoilState(roomViewType);
   const [roomInfo, setRoomInfo] = useState<IRooms>();
   const [isMic, setMic] = useState(true);
-  const [participants, myVideo, roomDocumentId, user, socket] = useRtc();
+  const [participants, myVideoRef, roomDocumentId, user, socket, myStreamRef] = useRtc();
 
   const micToggle = (isMicOn : boolean) => {
     socket?.emit('room:mic', { roomDocumentId, userDocumentId: user.userDocumentId, isMicOn });
     setMic(isMicOn);
+    myStreamRef.current!
+      .getAudioTracks()
+      // eslint-disable-next-line
+      .forEach((track: MediaStreamTrack) => (track.enabled = !track.enabled));
   };
 
   // roomId 기반으로 room 정보 불러오기
@@ -50,7 +54,7 @@ function InRoomModal() {
         {/* eslint-disable-next-line max-len */}
         {participants.map(({ userDocumentId, stream, mic }: any) => <InRoomOtherUserBox key={userDocumentId} stream={stream} userDocumentId={userDocumentId} isMicOn={mic} isMine={false} />)}
         {/* eslint-disable-next-line max-len */}
-        <InRoomUserBox ref={myVideo as RefObject<HTMLVideoElement>} key={user.userDocumentId} userDocumentId={user.userDocumentId} isMicOn={isMic} isMine />
+        <InRoomUserBox ref={myVideoRef as RefObject<HTMLVideoElement>} key={user.userDocumentId} userDocumentId={user.userDocumentId} isMicOn={isMic} isMine />
       </InRoomUserList>
       <InRoomFooter>
         <DefaultButton buttonType="active" size="small" onClick={() => setRoomView('createRoomView')}> Leave a Quietly </DefaultButton>

--- a/client/src/components/room/in-room-modal.tsx
+++ b/client/src/components/room/in-room-modal.tsx
@@ -81,7 +81,7 @@ function InRoomModal() {
       </InRoomHeader>
       <InRoomUserList>
         {/* eslint-disable-next-line max-len */}
-        <InRoomUserBox ref={myVideoRef as RefObject<HTMLVideoElement>} key={user.userDocumentId} userDocumentId={user.userDocumentId} isMicOn={isMic} isMine />
+        <InRoomUserBox ref={myVideoRef as RefObject<HTMLVideoElement>} key={user.userDocumentId} stream={myStreamRef.current as MediaStream} userDocumentId={user.userDocumentId} isMicOn={isMic} isMine />
         {/* eslint-disable-next-line max-len */}
         {participants.map(({ userDocumentId, stream, mic }: any) => <InRoomOtherUserBox key={userDocumentId} stream={stream} userDocumentId={userDocumentId} isMicOn={mic} isMine={false} />)}
 

--- a/client/src/components/room/in-room-modal.tsx
+++ b/client/src/components/room/in-room-modal.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-/* eslint-disable max-len */
 import React, { useEffect, useState, RefObject } from 'react';
 import { useSetRecoilState } from 'recoil';
 import {
@@ -49,14 +47,20 @@ function InRoomModal() {
         <OptionBtn><FiMoreHorizontal /></OptionBtn>
       </InRoomHeader>
       <InRoomUserList>
+        {/* eslint-disable-next-line max-len */}
         {participants.map(({ userDocumentId, stream, mic }: any) => <InRoomOtherUserBox key={userDocumentId} stream={stream} userDocumentId={userDocumentId} isMicOn={mic} isMine={false} />)}
+        {/* eslint-disable-next-line max-len */}
         <InRoomUserBox ref={myVideo as RefObject<HTMLVideoElement>} key={user.userDocumentId} userDocumentId={user.userDocumentId} isMicOn={isMic} isMine />
       </InRoomUserList>
       <InRoomFooter>
         <DefaultButton buttonType="active" size="small" onClick={() => setRoomView('createRoomView')}> Leave a Quietly </DefaultButton>
         <FooterBtnDiv><FiScissors /></FooterBtnDiv>
         <FooterBtnDiv><FiPlus /></FooterBtnDiv>
-        <FooterBtnDiv>{isMic ? <FiMic onClick={() => micToggle(false)} /> : <FiMicOff onClick={() => micToggle(true)} />}</FooterBtnDiv>
+        <FooterBtnDiv>
+          {isMic
+            ? <FiMic onClick={() => micToggle(false)} />
+            : <FiMicOff onClick={() => micToggle(true)} />}
+        </FooterBtnDiv>
       </InRoomFooter>
     </>
   );

--- a/client/src/components/room/right-sidebar.tsx
+++ b/client/src/components/room/right-sidebar.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable object-shorthand */
 import React from 'react';
 import styled from 'styled-components';
 import { useRecoilValue } from 'recoil';
@@ -27,20 +26,20 @@ const RoomModalLayout = styled.div`
 function RightSideBar() {
   const roomView = useRecoilValue(roomViewType);
 
-  if (roomView === 'createRoomView') { // 방 생성 모달
+  if (roomView === 'createRoomView') {
     return (
       <RoomModalLayout>
         <RoomModal />
       </RoomModalLayout>
     );
-  } if (roomView === 'closedSelectorView') { // closed인 경우 특정 인원을 지정하는 화면을 만들어야함
+  }
+  if (roomView === 'closedSelectorView') {
     return (
       <RoomModalLayout>
         <h1> closed!!! </h1>
       </RoomModalLayout>
     );
   }
-  // 방에 들어가 있는 경우
   if (roomView === 'inRoomView') {
     return (
       <RoomModalLayout>

--- a/client/src/components/room/room-modal.tsx
+++ b/client/src/components/room/room-modal.tsx
@@ -1,11 +1,12 @@
 /* eslint-disable object-shorthand */
 import React, { useState, useRef } from 'react';
 import styled from 'styled-components';
-import { useRecoilState, useSetRecoilState } from 'recoil';
+import { useRecoilState, useSetRecoilState, useRecoilValue } from 'recoil';
 
 import roomTypeState from '@atoms/room-type';
 import roomDocumentIdState from '@atoms/room-document-id';
-import roomViewType from '@src/recoil/atoms/room-view-type';
+import userTypeState from '@atoms/user';
+import roomViewType from '@atoms/room-view-type';
 import { postRoomInfo } from '@api/index';
 import DefaultButton from '@common/default-button';
 import RoomTypeCheckBox from '@components/room/room-type-check-box';
@@ -18,10 +19,14 @@ const CustomTitleForm = styled.div`
 `;
 
 const TitleInputbar = styled.input`
-  border: 1px solid #58964F;
-  border-radius: 8px;
-  padding: 0;
-
+  background: none;
+  color: #58964F;
+  font-size: 18px;
+  padding: 10px 10px 10px 5px;
+  display: block;
+  border: none;
+  border-radius: 0;
+  border-bottom: 1px solid #58964F;
   &:focus {
     outline: none;
   }
@@ -34,6 +39,7 @@ const TitleInputbarLabel = styled.label`
 
 // 룸 생성 모달
 function RoomModal() {
+  const user = useRecoilValue(userTypeState);
   const setRoomView = useSetRecoilState(roomViewType);
   const [roomType] = useRecoilState(roomTypeState);
   const setRoomDocumentId = useSetRecoilState(roomDocumentIdState);
@@ -42,12 +48,11 @@ function RoomModal() {
   const inputRef = useRef<HTMLInputElement>(null);
 
   const submitButtonHandler = () => {
-    // userId 현재 아이디 가져와야함
     const roomInfo = {
       type: roomType,
       title: inputRef.current?.value as string,
-      userId: 'dlatqdlatq',
-      userName: 'sungbin',
+      userId: user.userId,
+      userName: user.userName,
       isAnonymous: isAnonymous,
     };
     postRoomInfo(roomInfo)

--- a/client/src/components/room/room-modal.tsx
+++ b/client/src/components/room/room-modal.tsx
@@ -7,10 +7,10 @@ import roomTypeState from '@atoms/room-type';
 import roomDocumentIdState from '@atoms/room-document-id';
 import userTypeState from '@atoms/user';
 import roomViewType from '@atoms/room-view-type';
-import { postRoomInfo } from '@api/index';
 import DefaultButton from '@common/default-button';
 import RoomTypeCheckBox from '@components/room/room-type-check-box';
 import AnonymousCheckBox from '@components/room/anonymous-checkbox';
+import { postRoomInfo } from '@api/index';
 
 const CustomTitleForm = styled.div`
   display: flex;

--- a/client/src/hooks/useRtc.tsx
+++ b/client/src/hooks/useRtc.tsx
@@ -91,7 +91,7 @@ export const useSetPeerConnection = <T extends IRTC>(setParticipants: Dispatch<R
   return setPeerConnection;
 };
 
-export const useRtc = <T extends IRTC>(): [Array<T>, RefObject<HTMLVideoElement | null>, string, IUser, Socket | undefined] => {
+export const useRtc = <T extends IRTC>(): [Array<T>, RefObject<HTMLVideoElement | null>, string, IUser, Socket | undefined, MutableRefObject<MediaStream | null>] => {
   const peerConnectionsRef = useRef<{ [socketId: string]: RTCPeerConnection }>({});
   const [participants, setParticipants] = useState<Array<T>>([]);
   const roomDocumentId = useRecoilValue(roomDocumentIdState);
@@ -169,5 +169,5 @@ export const useRtc = <T extends IRTC>(): [Array<T>, RefObject<HTMLVideoElement 
     };
   }, [socket, setPeerConnection]);
 
-  return [participants, myVideoRef, roomDocumentId, user, socket];
+  return [participants, myVideoRef, roomDocumentId, user, socket, myStreamRef];
 };

--- a/client/src/hooks/useRtc.tsx
+++ b/client/src/hooks/useRtc.tsx
@@ -28,7 +28,7 @@ export const useLocalStream = (): [MutableRefObject<MediaStream | null>, RefObje
 
   const getLocalStream = useCallback(async () => {
     try {
-      myStreamRef.current = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+      myStreamRef.current = await navigator.mediaDevices.getUserMedia({ audio: true, video: false });
       if (myVideoRef.current) myVideoRef.current.srcObject = myStreamRef.current;
       myStreamRef.current!
         .getAudioTracks()

--- a/client/src/utils/test.js
+++ b/client/src/utils/test.js
@@ -1,0 +1,49 @@
+/* eslint-disable */
+
+export default function SoundMeter(context) {
+  this.context = context;
+  this.instant = 0.0;
+  this.slow = 0.0;
+  this.clip = 0.0;
+  this.script = context.createScriptProcessor(2048, 1, 1);
+  const that = this;
+  this.script.onaudioprocess = function (event) {
+    const input = event.inputBuffer.getChannelData(0);
+    let i;
+    let sum = 0.0;
+    let clipcount = 0;
+    for (i = 0; i < input.length; ++i) {
+      sum += input[i] * input[i];
+      if (Math.abs(input[i]) > 0.99) {
+        clipcount += 1;
+      }
+    }
+    that.instant = Math.sqrt(sum / input.length);
+    that.slow = 0.95 * that.slow + 0.05 * that.instant;
+    that.clip = clipcount / input.length;
+  };
+}
+
+SoundMeter.prototype.connectToSource = function (stream, callback) {
+  console.log('SoundMeter connecting');
+  try {
+    this.mic = this.context.createMediaStreamSource(stream);
+    this.mic.connect(this.script);
+    // necessary to make sample run, but should not be.
+    this.script.connect(this.context.destination);
+    if (typeof callback !== 'undefined') {
+      callback(null);
+    }
+  } catch (e) {
+    console.error(e);
+    if (typeof callback !== 'undefined') {
+      callback(e);
+    }
+  }
+};
+
+SoundMeter.prototype.stop = function () {
+  console.log('SoundMeter stopping');
+  this.mic.disconnect();
+  this.script.disconnect();
+};

--- a/server/src/sockets/room.ts
+++ b/server/src/sockets/room.ts
@@ -1,7 +1,6 @@
 import { Server, Socket } from 'socket.io';
 
 import RoomService from '@services/rooms-service';
-import usersService from '@services/users-service';
 
 interface IUsers {
   [id: string]: any,
@@ -51,13 +50,10 @@ export default function registerRoomHandler(socket : Socket, server : Server) {
   };
 
   const handleMic = async (payload: any) => {
-    const {
-      roomDocumentId, userDocumentId, isMicOn,
-    } = payload;
-
+    const { roomDocumentId, userDocumentId, isMicOn } = payload;
     await RoomService.setMic(roomDocumentId, userDocumentId, isMicOn);
 
-    const userData = { userDocumentId, isMicOn };
+    const userData = { userDocumentId, isMicOn, socketId: socket.id };
     socket.to(roomDocumentId).emit('room:mic', { userData });
   };
 


### PR DESCRIPTION
## 개요

오후에 보여드린 음성채팅 on/off 기능 및 room 관련 코드 리팩토링 관련 PR입니다.
이후 구현 기능인 음성 여부에 따라 표시 기능과 음성 변조는 현재 web audio api를 공부하고 있어 오늘내로 보여드리긴 어려울 거 같아서 PR 보냅니다!

## 작업사항

* Room 관련 코드 리팩토링
* 마이크 음소거 기능 추가

## 변경로직
- 리팩토링은 기본 UI를 사용안하기 위해 커스텀 스타일을 만들어서 수정을 했고 불필요한 lint 코드와 테스트 코드를 삭제했습니다.
- 음소거 기능 같은 경우에는 처음 기본값을 off로 해놨습니다. 그래서 UI는 in-room-modal에 상태를 활용하여 보여주고 내부적으로는 useRtc 훅에서 myStreamRef를 연결할 때 마이크 기능을 껐습니다. 이후 음소거 여부를 소켓으로 전파하는 것은 in-room-modal.tsx에서 구현을 했습니다.
### 변경후


https://user-images.githubusercontent.com/55152516/142225421-587db09a-f552-4223-8adf-49956e02a5d5.mov



## 기타
- 아마 web audio api를 공부만 잘한다면 나머지 기능도 빠르게 구현할 수 있겠다는 느낌이 드네요 ㅎㅎ...