### PR TITLE
🐟  채팅방 만들기 기능 구현

### DIFF
--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -143,6 +143,22 @@ export const getSearchResult = async (searchInfo: {keyword:string, option:string
   }
 };
 
+export const findUsersById = async (findUserList: Array<string>) => {
+  try {
+    let response = await fetch(`${process.env.REACT_APP_API_URL}/api/user/info`, {
+      method: 'post',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ userList: findUserList }),
+    });
+    response = await response.json();
+    return response;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
 export const getChatRooms = async (userDocumentId: string) => {
   try {
     let response = await fetch(

--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -194,3 +194,19 @@ export const getFollowingsList = async (userDocumentId: string) => {
     console.error(error);
   }
 };
+
+export const postChatRoom = async (participants: Array<string>) => {
+  try {
+    let response = await fetch(`${process.env.REACT_APP_API_URL}/api/chat-rooms`, {
+      method: 'post',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ participants }),
+    });
+    response = await response.json();
+    return response;
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/client/src/components/chat/chat-header.tsx
+++ b/client/src/components/chat/chat-header.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable no-return-assign */
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import {
   FiMoreHorizontal, FiMessageSquare,
@@ -80,7 +82,7 @@ export function ChatRoomHeader() {
 export function NewChatRoomHeader() {
   return (
     <ChatHeaderStyle>
-      <BtnDiv dir="left">Cancel</BtnDiv>
+      <Link to="/chat-rooms"><BtnDiv dir="left">Cancel</BtnDiv></Link>
       <p>NEW MESSAGE</p>
       <BtnDiv dir="right">Done</BtnDiv>
     </ChatHeaderStyle>

--- a/client/src/components/chat/chat-header.tsx
+++ b/client/src/components/chat/chat-header.tsx
@@ -1,11 +1,13 @@
 /* eslint-disable no-return-assign */
-import { Link } from 'react-router-dom';
-import styled from 'styled-components';
+import { Link, useHistory } from 'react-router-dom';
+import styled, { css } from 'styled-components';
 import {
   FiMoreHorizontal, FiMessageSquare,
 } from 'react-icons/fi';
+import { useRecoilValue } from 'recoil';
 
 import { makeIconToLink } from '@utils/index';
+import selectedUserType from '@atoms/chat-selected-users';
 
 const ChatHeaderStyle = styled.div`
   background-color: #B6B6B6;
@@ -39,7 +41,7 @@ const ChatHeaderBtnDiv = styled.div`
   svg{
     margin: 0px 10px 0px 10px;
     &:hover {
-      filter: invert(88%) sepia(1%) saturate(4121%) hue-rotate(12deg) brightness(62%) contrast(79%);
+      filter: invert(88%) sepia(1%) saturate(121%) hue-rotate(12deg) brightness(62%) contrast(79%);
     }
   }
 `;
@@ -53,14 +55,7 @@ const chatRoomHeaderBtns = [
   },
 ];
 
-type btnDivProps = {dir: 'left' | 'right'};
-
-const BtnDiv = styled.button`
-  ${(props : btnDivProps) => {
-    if (props.dir === 'left') return 'left: 5%; color: #58964F;';
-    return 'right: 5%; color: #D7D7D7;';
-  }}
-
+const BtnStyle = css`
   position: absolute;
   transform: translateY(30px);
 
@@ -73,6 +68,32 @@ const BtnDiv = styled.button`
     filter: invert(88%) sepia(1%) saturate(4121%) hue-rotate(12deg) brightness(62%) contrast(79%);
   }
 `;
+
+const CanCelBtn = styled.button`
+  left: 5%;
+  color: #58964F;
+  ${BtnStyle};
+`;
+
+const DoneBtnStyle = styled.button`
+  right: 5%;
+  color: #58964F;
+  ${BtnStyle};
+`;
+
+const DoneBtn = () => {
+  const selectedUserList = useRecoilValue(selectedUserType);
+  const history = useHistory();
+
+  const makeChatRoom = () => {
+    if (selectedUserList.length === 0) return;
+    history.push({ pathname: '/chat-rooms/userDocumentId' });
+  };
+
+  return (
+    <DoneBtnStyle onClick={makeChatRoom}>Done</DoneBtnStyle>
+  );
+};
 
 export function ChatRoomHeader() {
   return (
@@ -88,9 +109,9 @@ export function ChatRoomHeader() {
 export function NewChatRoomHeader() {
   return (
     <ChatHeaderStyle>
-      <Link to="/chat-rooms"><BtnDiv dir="left">Cancel</BtnDiv></Link>
+      <Link to="/chat-rooms"><CanCelBtn>Cancel</CanCelBtn></Link>
       <p>NEW MESSAGE</p>
-      <BtnDiv dir="right">Done</BtnDiv>
+      <DoneBtn />
     </ChatHeaderStyle>
   );
 }

--- a/client/src/components/chat/chat-header.tsx
+++ b/client/src/components/chat/chat-header.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable max-len */
+/* eslint-disable no-underscore-dangle */
 /* eslint-disable no-return-assign */
 import { Link, useHistory } from 'react-router-dom';
 import styled, { css } from 'styled-components';
@@ -7,7 +9,9 @@ import {
 import { useRecoilValue } from 'recoil';
 
 import { makeIconToLink } from '@utils/index';
+import { postChatRoom } from '@api/index';
 import selectedUserType from '@atoms/chat-selected-users';
+import userType from '@atoms/user';
 
 const ChatHeaderStyle = styled.div`
   background-color: #B6B6B6;
@@ -83,11 +87,15 @@ const DoneBtnStyle = styled.button`
 
 const DoneBtn = () => {
   const selectedUserList = useRecoilValue(selectedUserType);
+  const user = useRecoilValue(userType);
   const history = useHistory();
 
   const makeChatRoom = () => {
     if (selectedUserList.length === 0) return;
-    history.push({ pathname: '/chat-rooms/userDocumentId' });
+    postChatRoom([...selectedUserList.map((selectedUser: any) => selectedUser.userDocumentId), user.userDocumentId])
+      .then((res: any) => {
+        history.push({ pathname: `/chat-rooms/${res.chatRoomId}` });
+      });
   };
 
   return (

--- a/client/src/components/chat/chat-header.tsx
+++ b/client/src/components/chat/chat-header.tsx
@@ -66,6 +66,10 @@ const BtnDiv = styled.button`
 
   background-color: transparent;
   border: none;
+
+  &:hover {
+    filter: invert(88%) sepia(1%) saturate(4121%) hue-rotate(12deg) brightness(62%) contrast(79%);
+  }
 `;
 
 export function ChatRoomHeader() {

--- a/client/src/components/chat/chat-header.tsx
+++ b/client/src/components/chat/chat-header.tsx
@@ -16,6 +16,8 @@ const ChatHeaderStyle = styled.div`
   position: relative;
 
   p {
+    width: 250px;
+
     position: absolute;
     top: 25px;
     left: 50%;

--- a/client/src/components/chat/chat-header.tsx
+++ b/client/src/components/chat/chat-header.tsx
@@ -3,9 +3,8 @@
 /* eslint-disable no-return-assign */
 import { Link, useHistory } from 'react-router-dom';
 import styled, { css } from 'styled-components';
-import {
-  FiMoreHorizontal, FiMessageSquare,
-} from 'react-icons/fi';
+import { FiMoreHorizontal } from 'react-icons/fi';
+import { BiMessageSquareAdd } from 'react-icons/bi';
 import { useRecoilValue } from 'recoil';
 
 import { makeIconToLink } from '@utils/index';
@@ -52,7 +51,7 @@ const ChatHeaderBtnDiv = styled.div`
 
 const chatRoomHeaderBtns = [
   {
-    Component: FiMessageSquare, link: '/chat-rooms/new', key: 'newChat', size: 32,
+    Component: BiMessageSquareAdd, link: '/chat-rooms/new', key: 'newChat', size: 32,
   },
   {
     Component: FiMoreHorizontal, link: '/chat-rooms/new', key: 'selector', size: 32,

--- a/client/src/components/chat/chat-header.tsx
+++ b/client/src/components/chat/chat-header.tsx
@@ -9,18 +9,18 @@ const ChatHeaderStyle = styled.div`
   background-color: #B6B6B6;
 
   width: 100%;
-  height: 110px;
+  height: 80px;
 
   position: relative;
 
   p {
     position: absolute;
-    top: 35px;
-    left:50%;
+    top: 25px;
+    left: 50%;
     transform: translateX(-50%);
 
     font-family: 'Nunito';
-    font-style: Bold;
+    font-weight: Bold;
     font-size: 32px;
 
     margin: 0px;
@@ -29,7 +29,7 @@ const ChatHeaderStyle = styled.div`
 
 const ChatHeaderBtnDiv = styled.div`
   position: absolute;
-  top: 35px;
+  top: 25px;
   right: 5%;
 
   svg{
@@ -40,24 +40,49 @@ const ChatHeaderBtnDiv = styled.div`
   }
 `;
 
-const chatHeaderBtn = [
+const chatRoomHeaderBtns = [
   {
     Component: FiMessageSquare, link: '/chat-rooms/new', key: 'newChat', size: 32,
   },
   {
-    Component: FiMoreHorizontal, link: '//chat-rooms/new', key: 'selector', size: 32,
+    Component: FiMoreHorizontal, link: '/chat-rooms/new', key: 'selector', size: 32,
   },
 ];
 
-function ChatHeader() {
+type btnDivProps = {dir: 'left' | 'right'};
+
+const BtnDiv = styled.button`
+  ${(props : btnDivProps) => {
+    if (props.dir === 'left') return 'left: 5%; color: #58964F;';
+    return 'right: 5%; color: #D7D7D7;';
+  }}
+
+  position: absolute;
+  transform: translateY(30px);
+
+  font-size: 20px;
+
+  background-color: transparent;
+  border: none;
+`;
+
+export function ChatRoomHeader() {
   return (
     <ChatHeaderStyle>
-      <p>BackChannel</p>
+      <p>BACK CHANNEL</p>
       <ChatHeaderBtnDiv>
-        {chatHeaderBtn.map(makeIconToLink)}
+        {chatRoomHeaderBtns.map(makeIconToLink)}
       </ChatHeaderBtnDiv>
     </ChatHeaderStyle>
   );
 }
 
-export default ChatHeader;
+export function NewChatRoomHeader() {
+  return (
+    <ChatHeaderStyle>
+      <BtnDiv dir="left">Cancel</BtnDiv>
+      <p>NEW MESSAGE</p>
+      <BtnDiv dir="right">Done</BtnDiv>
+    </ChatHeaderStyle>
+  );
+}

--- a/client/src/components/chat/chat-room-layout.tsx
+++ b/client/src/components/chat/chat-room-layout.tsx
@@ -1,0 +1,17 @@
+import ScrollBarStyle from '@styles/scrollbar-style';
+import styled from 'styled-components';
+
+const ChatRoomsLayout = styled.div`
+  background-color: #FFFFFF;
+  border-radius: 30px;
+
+  width: 100%;
+  height: 100%;
+
+  overflow: hidden;
+  position: relative;
+
+  ${ScrollBarStyle};
+`;
+
+export default ChatRoomsLayout;

--- a/client/src/components/chat/chat-user-card.tsx
+++ b/client/src/components/chat/chat-user-card.tsx
@@ -8,7 +8,11 @@ interface Participants{
   profileUrl: string
 }
 
-type chatUserCardProps = { participantsInfo: Array<Participants> };
+interface chatUserCardProps {
+  participantsInfo: Array<Participants>,
+  lastMsg: string,
+}
+
 type ProfileProps = { profileUrl: string, length: number };
 
 const ChatUserCardLayout = styled.div`
@@ -84,7 +88,7 @@ const LastChatMsg = styled.p`
   font-size: 20px;
 `;
 
-const ChatUserCard = ({ participantsInfo } : chatUserCardProps) => {
+const ChatUserCard = ({ participantsInfo, lastMsg } : chatUserCardProps) => {
   const userNames = participantsInfo.map((participant) => participant.userName).join(', ');
   return (
     <ChatUserCardLayout>
@@ -94,7 +98,7 @@ const ChatUserCard = ({ participantsInfo } : chatUserCardProps) => {
       </ChatUserCardProfileDiv>
       <ChatUserCardInfo>
         <UserNameInfo>{userNames}</UserNameInfo>
-        <LastChatMsg>최근에 보내거나 받은 메세지</LastChatMsg>
+        <LastChatMsg>{lastMsg}</LastChatMsg>
       </ChatUserCardInfo>
     </ChatUserCardLayout>
   );

--- a/client/src/components/common/room-card.tsx
+++ b/client/src/components/common/room-card.tsx
@@ -156,7 +156,7 @@ export default function RoomCard({
   const thumbnailUrl = participantsInfo
   .filter((val, idx) => idx < 2)
   .map((participant, idx) => ({ profileUrl: participant.profileUrl, Style: ProfileStyleArray[idx] }));
-  
+
 
   return (
     <RoomCardLayout>

--- a/client/src/components/common/user-card-list.tsx
+++ b/client/src/components/common/user-card-list.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-underscore-dangle */
 import React, { MouseEvent } from 'react';
 import styled from 'styled-components';
 
@@ -18,12 +19,14 @@ interface UserCardProps {
 
 const makeUserToCard = ({ cardType, userList }: UserCardProps) => (
   userList.map((user) => (
-    <UserCard
+    <div key={user._id} className="userCard" data-id={user._id} data-username={user.userName}>
+      <UserCard
       // eslint-disable-next-line no-underscore-dangle
-      key={user._id}
-      cardType={cardType}
-      userData={user}
-    />
+        key={user._id}
+        cardType={cardType}
+        userData={user}
+      />
+    </div>
   ))
 );
 

--- a/client/src/recoil/atoms/chat-selected-users.ts
+++ b/client/src/recoil/atoms/chat-selected-users.ts
@@ -1,0 +1,11 @@
+import { atom } from 'recoil';
+
+interface user {
+  userDocumentId: string,
+  userName: string,
+}
+
+export default atom<user[]>({
+  key: 'chatSelectedUsers', // 해당 atom의 고유 key
+  default: [],
+});

--- a/client/src/routes/main.tsx
+++ b/client/src/routes/main.tsx
@@ -23,7 +23,7 @@ function MainRouter() {
       <Route exact path="/activity" component={ActivityView} />
       <Route exact path="/chat-rooms" component={ChatRoomsView} />
       <Route exact path="/chat-rooms/new" component={ChatRoomsNewView} />
-      <Route exact path="/chat-rooms/:chat-id" component={ChatRoomDetailView} />
+      <Route exact path="/chat-rooms/:chat" component={ChatRoomDetailView} />
       <Route exact path="/event" component={EventView} />
       <Route exact path="/followers/:id" component={FollowersView} />
       <Route exact path="/following/:id" component={FollowingView} />

--- a/client/src/views/chat-room-detail-view.tsx
+++ b/client/src/views/chat-room-detail-view.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 function ChatRoomDetailView() {
-  return (<></>);
+  return (<><h1>here is chattingRoom!!</h1></>);
 }
 
 export default ChatRoomDetailView;

--- a/client/src/views/chat-rooms-new-view.tsx
+++ b/client/src/views/chat-rooms-new-view.tsx
@@ -1,7 +1,66 @@
-import React from 'react';
+/* eslint-disable max-len */
+import React, { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import { useRecoilValue } from 'recoil';
+
+import { NewChatRoomHeader } from '@components/chat/chat-header';
+import ChatRoomsLayout from '@components/chat/chat-room-layout';
+import UserCardList from '@components/common/user-card-list';
+import { findUsersById } from '@api/index';
+import userType from '@atoms/user';
+
+const SelectDiv = styled.div`
+  width: 90%;
+  height: 50px;
+
+  position: relative;
+
+  p {
+    position: absolute;
+    margin: 15px 20px 0px 30px;
+
+    font-size: 20px;
+    font-weight: bold;
+  }
+`;
+
+const SelectInputBar = styled.input`
+  position: absolute;
+  top: 11px;
+  left: 90px;
+
+  width: 400px;
+  height: 30px;
+
+  border: none;
+  font-size: 18px;
+  font-family: 'Nunito';
+
+  &:focus {
+    outline: none;
+  }
+`;
 
 function ChatRoomsNewView() {
-  return (<></>);
+  const { followers, followings } = useRecoilValue(userType);
+  const [userList, setUserList] = useState([]);
+
+  useEffect(() => {
+    const findUserList = followers.concat(followings).filter((item, index) => followers.indexOf(item) !== index);
+    findUsersById(findUserList)
+      .then((res: any) => setUserList(res.userList));
+  }, []);
+
+  return (
+    <ChatRoomsLayout>
+      <NewChatRoomHeader />
+      <SelectDiv>
+        <p>TO : </p>
+        <SelectInputBar />
+      </SelectDiv>
+      <UserCardList cardType="others" userList={userList} />
+    </ChatRoomsLayout>
+  );
 }
 
 export default ChatRoomsNewView;

--- a/client/src/views/chat-rooms-new-view.tsx
+++ b/client/src/views/chat-rooms-new-view.tsx
@@ -27,6 +27,21 @@ const SelectDiv = styled.div`
     font-size: 20px;
     font-weight: bold;
   }
+
+  &::-webkit-scrollbar {
+    width: 5px;
+    height: 8px;
+    background: #ffffff;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    border-radius: 8px;
+    background-color: #DCD9CD;
+
+    &:hover {
+      background-color: #CECABB;
+    }
+  }
 `;
 
 const SelectInputBar = styled.input`
@@ -34,7 +49,7 @@ const SelectInputBar = styled.input`
   top: 11px;
   left: 90px;
 
-  width: 400px;
+  width: 100px;
   height: 30px;
 
   border: none;

--- a/client/src/views/chat-rooms-new-view.tsx
+++ b/client/src/views/chat-rooms-new-view.tsx
@@ -17,9 +17,6 @@ const SelectDiv = styled.div`
 
   position: relative;
 
-  overflow-x: scroll;
-  overflow-y: hidden;
-
   p {
     position: absolute;
     margin: 15px 20px 0px 30px;
@@ -49,7 +46,7 @@ const SelectInputBar = styled.input`
   top: 11px;
   left: 90px;
 
-  width: 200px;
+  width: 300px;
   height: 30px;
 
   border: none;
@@ -62,18 +59,16 @@ const SelectInputBar = styled.input`
 `;
 
 const SelectedUserDiv = styled.div`
-  position: absolute;
-  height: 32px;
-  left: 90px;
-  top: 11px;
+  margin: 0% 15% 0% 15%;
+
 
   display: flex;
   flex-direction: row;
-
+  flex-wrap: wrap;
 `;
 
 const SelectUserComponent = styled.div`
-  margin-right: 10px;
+  margin 0px 10px 5px 0px;
   background-color: #F1F0E4;
   border-radius: 30px;
 
@@ -121,8 +116,6 @@ function ChatRoomsNewView() {
   }, [followingList]);
 
   useEffect(() => {
-    const SelectedUserDivWidth = (selectedUserDiv.current as any).offsetWidth;
-    (inputBar!.current as any).style.transform = `translatex(${SelectedUserDivWidth + 10}px)`;
     const selectedUserIds = selectedUsers.map((user: any) => user.userDocumentId);
     setUserList(allUserList.filter((user: any) => selectedUserIds.indexOf(user._id) === -1));
   }, [selectedUsers]);
@@ -132,15 +125,15 @@ function ChatRoomsNewView() {
       <NewChatRoomHeader />
       <SelectDiv>
         <p>TO : </p>
-        <SelectedUserDiv ref={selectedUserDiv}>
-          {selectedUsers.map((user: any) => (
-            <SelectUserComponent key={user.userDocumentId} data-id={user.userDocumentId} onClick={deleteUser}>
-              {user.userName}
-            </SelectUserComponent>
-          ))}
-        </SelectedUserDiv>
         <SelectInputBar ref={inputBar} onChange={searchUser} />
       </SelectDiv>
+      <SelectedUserDiv ref={selectedUserDiv}>
+        {selectedUsers.map((user: any) => (
+          <SelectUserComponent key={user.userDocumentId} data-id={user.userDocumentId} onClick={deleteUser}>
+            {user.userName}
+          </SelectUserComponent>
+        ))}
+      </SelectedUserDiv>
       <UserCardList cardType="others" userList={filteredUserList} clickEvent={addSelectedUser} />
     </ChatRoomsLayout>
   );

--- a/client/src/views/chat-rooms-new-view.tsx
+++ b/client/src/views/chat-rooms-new-view.tsx
@@ -41,14 +41,32 @@ const SelectInputBar = styled.input`
   }
 `;
 
+const SelectUserDiv = styled.div`
+  position: absolute;
+  height: 32px;
+  left: 90px;
+  top: 11px;
+
+`;
+
+const SelectUserComponent = styled.div`
+
+`;
+
 function ChatRoomsNewView() {
   const { followers, followings } = useRecoilValue(userType);
   const [userList, setUserList] = useState([]);
+  const [selectedUsers, setSelectedUsers] = useState<any>([]);
+
+  const addSelectedUser = (e: any) => {
+    const userCardDiv = e.target.closest('.userCard');
+    alert(userCardDiv.getAttribute('data-userName'));
+    setSelectedUsers([{ key: '123', userName: 'test' }]);
+  };
 
   useEffect(() => {
     const findUserList = followers.concat(followings).filter((item, index) => followers.indexOf(item) !== index);
-    findUsersById(findUserList)
-      .then((res: any) => setUserList(res.userList));
+    findUsersById(findUserList).then((res: any) => setUserList(res.userList));
   }, []);
 
   return (
@@ -56,9 +74,16 @@ function ChatRoomsNewView() {
       <NewChatRoomHeader />
       <SelectDiv>
         <p>TO : </p>
+        <SelectUserDiv>
+          {selectedUsers.map((user: any) => (
+            <SelectUserComponent key={user.key}>
+              {user.userName}
+            </SelectUserComponent>
+          ))}
+        </SelectUserDiv>
         <SelectInputBar />
       </SelectDiv>
-      <UserCardList cardType="others" userList={userList} />
+      <UserCardList cardType="others" userList={userList} clickEvent={addSelectedUser} />
     </ChatRoomsLayout>
   );
 }

--- a/client/src/views/chat-rooms-new-view.tsx
+++ b/client/src/views/chat-rooms-new-view.tsx
@@ -49,7 +49,7 @@ const SelectInputBar = styled.input`
   top: 11px;
   left: 90px;
 
-  width: 100px;
+  width: 200px;
   height: 30px;
 
   border: none;
@@ -114,8 +114,9 @@ function ChatRoomsNewView() {
 
   useEffect(() => {
     findUsersById(followingList).then((res: any) => {
+      const selectedUserIds = selectedUsers.map((user: any) => user.userDocumentId);
       setAllUserList(res.userList);
-      setUserList(res.userList);
+      setUserList(res.userList.filter((user: any) => selectedUserIds.indexOf(user._id) === -1));
     });
   }, [followingList]);
 

--- a/client/src/views/chat-rooms-new-view.tsx
+++ b/client/src/views/chat-rooms-new-view.tsx
@@ -81,15 +81,20 @@ function ChatRoomsNewView() {
     const userCardDiv = e.target.closest('.userCard');
     if (!userCardDiv) return;
     const userName = userCardDiv?.getAttribute('data-username');
+    (inputBar!.current as any).value = '';
     setSelectedUsers([...selectedUsers, { userDocumentId: userCardDiv?.getAttribute('data-id'), userName }]);
   };
 
   const deleteUser = (e: any) => {
     setSelectedUsers(selectedUsers.filter((user: any) => user.userDocumentId !== e.target.getAttribute('data-id')));
+    (inputBar!.current as any).value = '';
   };
 
   const searchUser = () => {
-    console.log((inputBar!.current as any).value);
+    const searchWord = (inputBar.current as any).value;
+    const selectedUserIds = selectedUsers.map((user: any) => user.userDocumentId);
+    setUserList(allUserList
+      .filter((user: any) => (user.userId.indexOf(searchWord) > -1 || user.userName.indexOf(searchWord) > -1) && selectedUserIds.indexOf(user._id) === -1));
   };
 
   useEffect(() => {

--- a/client/src/views/chat-rooms-new-view.tsx
+++ b/client/src/views/chat-rooms-new-view.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable max-len */
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
@@ -7,13 +8,20 @@ import { NewChatRoomHeader } from '@components/chat/chat-header';
 import ChatRoomsLayout from '@components/chat/chat-room-layout';
 import UserCardList from '@components/common/user-card-list';
 import { findUsersById } from '@api/index';
-import userType from '@atoms/user';
+import followType from '@atoms/following-list';
 
 const SelectDiv = styled.div`
   width: 90%;
   height: 50px;
 
   position: relative;
+
+  overflow-x: scroll;
+  overflow-y: hidden;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 
   p {
     position: absolute;
@@ -54,7 +62,7 @@ const SelectUserComponent = styled.div`
 `;
 
 function ChatRoomsNewView() {
-  const { followers, followings } = useRecoilValue(userType);
+  const followingList = useRecoilValue(followType);
   const [userList, setUserList] = useState([]);
   const [selectedUsers, setSelectedUsers] = useState<any>([]);
 
@@ -65,8 +73,7 @@ function ChatRoomsNewView() {
   };
 
   useEffect(() => {
-    const findUserList = followers.concat(followings).filter((item, index) => followers.indexOf(item) !== index);
-    findUsersById(findUserList).then((res: any) => setUserList(res.userList));
+
   }, []);
 
   return (

--- a/client/src/views/chat-rooms-view.tsx
+++ b/client/src/views/chat-rooms-view.tsx
@@ -2,27 +2,13 @@
 /* eslint-disable max-len */
 import React, { useEffect, useState } from 'react';
 import { useRecoilValue } from 'recoil';
-import styled from 'styled-components';
 
 import userType from '@atoms/user';
-import ChatHeader from '@components/chat/chat-header';
+import { ChatRoomHeader } from '@components/chat/chat-header';
 import ChatUserCard from '@components/chat/chat-user-card';
+import ChatRoomsLayout from '@components/chat/chat-room-layout';
 import LoadingSpinner from '@common/loading-spinner';
-import ScrollBarStyle from '@styles/scrollbar-style';
 import { getChatRooms } from '@api/index';
-
-const ChatRoomsLayout = styled.div`
-  background-color: #FFFFFF;
-  border-radius: 30px;
-
-  width: 100%;
-  height: 100%;
-
-  overflow: hidden;
-  position: relative;
-
-  ${ScrollBarStyle};
-`;
 
 interface IChatUserType {
   userDocumentId: string,
@@ -51,7 +37,7 @@ function ChatRoomsViews() {
   if (loading) return (<LoadingSpinner />);
   return (
     <ChatRoomsLayout>
-      <ChatHeader />
+      <ChatRoomHeader />
       {chatRooms?.map((chatRoom: IChatRoom) => <ChatUserCard key={chatRoom.chatDocumentId} participantsInfo={chatRoom.participants} />)}
     </ChatRoomsLayout>
   );

--- a/client/src/views/chat-rooms-view.tsx
+++ b/client/src/views/chat-rooms-view.tsx
@@ -18,7 +18,8 @@ interface IChatUserType {
 
 interface IChatRoom {
   chatDocumentId: string,
-  participants: Array<IChatUserType>
+  participants: Array<IChatUserType>,
+  lastMsg: string,
 }
 
 function ChatRoomsViews() {
@@ -38,7 +39,7 @@ function ChatRoomsViews() {
   return (
     <ChatRoomsLayout>
       <ChatRoomHeader />
-      {chatRooms?.map((chatRoom: IChatRoom) => <ChatUserCard key={chatRoom.chatDocumentId} participantsInfo={chatRoom.participants} />)}
+      {chatRooms?.map((chatRoom: IChatRoom) => <ChatUserCard key={chatRoom.chatDocumentId} participantsInfo={chatRoom.participants} lastMsg={chatRoom.lastMsg} />)}
     </ChatRoomsLayout>
   );
 }

--- a/client/src/views/room-view.tsx
+++ b/client/src/views/room-view.tsx
@@ -23,9 +23,6 @@ interface RoomCardProps {
 }
 
 const RoomDiv = styled.div`
-  div + div {
-  margin-bottom: 10px;
-}
 `;
 
 export const makeRoomToCard = (room: RoomCardProps) => (

--- a/client/src/views/room-view.tsx
+++ b/client/src/views/room-view.tsx
@@ -23,6 +23,9 @@ interface RoomCardProps {
 }
 
 const RoomDiv = styled.div`
+  div + div {
+    margin-bottom: 10px;
+  }
 `;
 
 export const makeRoomToCard = (room: RoomCardProps) => (

--- a/server/src/api/routes/chats.ts
+++ b/server/src/api/routes/chats.ts
@@ -8,6 +8,17 @@ const chatRouter = Router();
 export default (app: Router) => {
   app.use('/chat-rooms', chatRouter);
 
+  chatRouter.post('/', async (req: Request, res: Response) => {
+    try {
+      const { participants } = req.body;
+      const chatRoomId = await chatService.makeChatRoom(participants);
+
+      res.status(200).json({ chatRoomId });
+    } catch (error) {
+      console.log(error);
+    }
+  });
+
   chatRouter.get('/:userDocumentId', async (req: Request, res: Response) => {
     try {
       const { userDocumentId } = req.params;

--- a/server/src/api/routes/user.ts
+++ b/server/src/api/routes/user.ts
@@ -86,4 +86,15 @@ export default (app: Router) => {
       res.json({ ok: false, msg: 'signup error' });
     }
   });
+
+  userRouter.post('/info', async (req: Request, res: Response) => {
+    const userDocumentIdList = req.body;
+    try {
+      const userList = (await usersService.findUsersById(userDocumentIdList.userList))
+        ?.map(usersService.makeItemToUserInterface);
+      res.json({ ok: true, userList });
+    } catch (e) {
+      res.json({ ok: false });
+    }
+  });
 };

--- a/server/src/models/chats.ts
+++ b/server/src/models/chats.ts
@@ -7,7 +7,9 @@ interface IChattingLog {
 
 interface IChatTypesModel extends Document {
   participants: Array<string>,
-  chattingLog: Array<IChattingLog>
+  chattingLog: Array<IChattingLog>,
+  lastMsg: string,
+  recentActive: Date,
 }
 
 const chatSchema = new Schema({
@@ -17,7 +19,15 @@ const chatSchema = new Schema({
   },
   chattingLog: {
     type: [Object],
-    required: true,
+    default: [],
+  },
+  lastMsg: {
+    type: String,
+    default: '',
+  },
+  recentActive: {
+    type: Date,
+    default: new Date(),
   },
 });
 

--- a/server/src/services/chat-service.ts
+++ b/server/src/services/chat-service.ts
@@ -19,17 +19,23 @@ class ChatService {
   async getChatRooms(userDocumentId : string) {
     const chatRoomList = await Users.findOne({ _id: userDocumentId }, ['chatRooms']);
 
-    const chatRoomInfo = await Promise.all((chatRoomList!.chatRooms).map(async (chatDocumentId: string) => {
-      const userDocumentIds = await Chats.findOne({ _id: chatDocumentId }, ['participants']);
+    const chatRoomInfoArray = await Promise.all((chatRoomList!.chatRooms).map(async (chatDocumentId: string) => {
+      const chatRoomInfo = await Chats.findOne({ _id: chatDocumentId }, ['participants', 'lastMsg', 'recentActive']);
       const UserInfo : any = [];
-      await Promise.all((userDocumentIds)!.participants.map(async (_id) => {
+      await Promise.all((chatRoomInfo)!.participants.map(async (_id) => {
         if (_id === userDocumentId) return;
         const info = await Users.findOne({ _id }, ['userName', 'profileUrl']);
         UserInfo.push({ userDocumentId: info!._id, userName: info!.userName, profileUrl: info!.profileUrl });
       }));
-      return ({ chatDocumentId, participants: UserInfo });
+      return ({
+        chatDocumentId, participants: UserInfo, lastMsg: chatRoomInfo?.lastMsg, recentActive: chatRoomInfo?.recentActive,
+      });
     }));
-    return chatRoomInfo;
+    return chatRoomInfoArray.sort((a: any, b: any) => {
+      if (a.recentActive < b.recentActive) return 1;
+      if (a.recentActive > b.recentActive) return -1;
+      return 0;
+    });
   }
 
   async makeChatRoom(participants: Array<string>) {

--- a/server/src/services/chat-service.ts
+++ b/server/src/services/chat-service.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-return-await */
 /* eslint-disable no-underscore-dangle */
 /* eslint-disable consistent-return */
 /* eslint-disable max-len */
@@ -29,6 +30,18 @@ class ChatService {
       return ({ chatDocumentId, participants: UserInfo });
     }));
     return chatRoomInfo;
+  }
+
+  async makeChatRoom(participants: Array<string>) {
+    const chatRoom = await Chats.findOne({ participants }, ['participants']);
+    if (chatRoom) return chatRoom._id;
+
+    const newChatRoom = new Chats({ participants });
+    await newChatRoom.save();
+
+    participants.forEach(async (userDocumentId) => await Users.findOneAndUpdate({ _id: userDocumentId }, { $push: { chatRooms: newChatRoom._id } }));
+
+    return newChatRoom._id;
   }
 }
 

--- a/server/src/services/users-service.ts
+++ b/server/src/services/users-service.ts
@@ -198,6 +198,16 @@ class UserService {
       console.error(e);
     }
   }
+
+  async findUsersById(documentIdList: Array<string>) {
+    try {
+      const participantsInfo = Users.find({ _id: { $in: documentIdList } }, ['userName', 'profileUrl', 'description']);
+      console.log(participantsInfo);
+      return participantsInfo;
+    } catch (e) {
+      console.log(e);
+    }
+  }
 }
 
 export default new UserService();

--- a/server/src/services/users-service.ts
+++ b/server/src/services/users-service.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 /* eslint-disable no-console */
 /* eslint-disable no-underscore-dangle */
 /* eslint-disable class-methods-use-this */
@@ -164,16 +165,17 @@ class UserService {
   }
 
   makeItemToUserInterface(
-    item: { _id: string, userName: string, description: string, profileUrl: string },
+    item: { _id: string, userName: string, description: string, profileUrl: string, userId: string },
   ) {
     const {
-      _id, userName, description, profileUrl,
+      _id, userName, description, profileUrl, userId,
     } = item;
     return ({
       _id,
       userName,
       description,
       profileUrl,
+      userId,
       type: 'user',
     });
   }
@@ -201,7 +203,7 @@ class UserService {
 
   async findUsersById(documentIdList: Array<string>) {
     try {
-      const participantsInfo = Users.find({ _id: { $in: documentIdList } }, ['userName', 'profileUrl', 'description']);
+      const participantsInfo = Users.find({ _id: { $in: documentIdList } }, ['userId', 'userName', 'profileUrl', 'description']);
       return participantsInfo;
     } catch (e) {
       console.log(e);

--- a/server/src/services/users-service.ts
+++ b/server/src/services/users-service.ts
@@ -202,7 +202,6 @@ class UserService {
   async findUsersById(documentIdList: Array<string>) {
     try {
       const participantsInfo = Users.find({ _id: { $in: documentIdList } }, ['userName', 'profileUrl', 'description']);
-      console.log(participantsInfo);
       return participantsInfo;
     } catch (e) {
       console.log(e);


### PR DESCRIPTION
## 개요
- 채팅방 만들기 기능 구현
## 작업사항
- 채팅방 만들기 페이지 레이아웃 구현
- 채팅방 만들기 페이지 유저 검색 기능 구현
- 채팅방 만들기 유저 클릭시 이벤트 구현
- 채팅방 만들기 뒤로가기(cancel) 버튼 이벤트 구현
- 채팅방 만들기 API 구현
- 채팅방 팔로워 유저 정보 검색 API 구현
- 채팅방 목록 최근 대화 표시 기능 구현

## 변경로직
- chat model에 최근 메세지와 최근 활동 시간을 나타낼수 있도록 field를 추가해주었습니다.
- 스크롤바가 아니라 검색 부분과 유저 선택 div를 분리하여 해당부분에 스크롤바를 없애주었습니다.

### 변경후

- 채팅방 만들기 유저 검색 부분

https://user-images.githubusercontent.com/51700274/142228497-0303c586-0952-4bd9-bd8b-4d21c577fecc.mov


- 유저 검색 이후 채팅방 만들기

https://user-images.githubusercontent.com/51700274/142228293-6f8caf83-6134-4a30-8120-252e3f6dba15.mov


## 사용방법
- 영상 참고해주세요 !

## 기타
- 현재 채팅방에 추가될수 있는 유저는 전역상태에 저장되어있는 following 리스트 입니다.
- follower 목록은 선택창에 없는데 추가해줘야 할까요...?