### PR TITLE
프로필 페이지 구현

### DIFF
--- a/client/src/components/body-modal.tsx
+++ b/client/src/components/body-modal.tsx
@@ -1,17 +1,20 @@
 import { useRecoilValue } from 'recoil';
 
-import { isOpenEventModalState, isOpenEventRegisterModalState } from '@src/recoil/atoms/is-open-modal';
+import { isOpenEventModalState, isOpenEventRegisterModalState, isOpenShareModalState } from '@src/recoil/atoms/is-open-modal';
 import EventModal from '@components/event/event-modal';
 import EventRegisterModal from '@components/event/event-register-modal';
+import ShareModal from '@components/profile/share-modal';
 
 function BodyModal() {
   const isOpenEventModal = useRecoilValue(isOpenEventModalState);
   const isOpenEventRegisterModal = useRecoilValue(isOpenEventRegisterModalState);
+  const isOpenShareModal = useRecoilValue(isOpenShareModalState);
 
   return (
     <>
       {isOpenEventModal && <EventModal />}
       {isOpenEventRegisterModal && <EventRegisterModal />}
+      {isOpenShareModal && <ShareModal />}
     </>
   );
 }

--- a/client/src/components/common/default-header.tsx
+++ b/client/src/components/common/default-header.tsx
@@ -84,7 +84,7 @@ function DefaultHeader() {
       <LogoTitle to="/" onClick={() => { resetNowItemsList(); setNowFetching(true); }}> NogariHouse </LogoTitle>
       <IconContainer>
         {rightSideIcons.map(makeIconToLink)}
-        <Link to="/profile"><ImageLayout src={user.profileUrl} alt="사용자" /></Link>
+        <Link to={`profile/${user.userId}`}><ImageLayout src={user.profileUrl} alt="사용자" /></Link>
       </IconContainer>
     </CustomDefaultHeader>
   );

--- a/client/src/components/event/event-header.tsx
+++ b/client/src/components/event/event-header.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { IconType } from 'react-icons';
 import { MdOutlineArrowBackIos } from 'react-icons/md';
 import { BiCalendarPlus } from 'react-icons/bi';
-import { useRecoilState } from 'recoil';
+import { useSetRecoilState } from 'recoil';
 
 import { CustomtHeader, HeaderTitleNunito } from '@common/header';
 import { makeIconToLink } from '@utils/index';
@@ -28,10 +28,10 @@ const EventAddButton = styled.div`
 
 function EventHeader() {
   const Icon: IconAndLink = { Component: MdOutlineArrowBackIos, link: '/', key: 'main' };
-  const [isOpenModal, setIsOpenModal] = useRecoilState(isOpenEventRegisterModalState);
+  const setIsOpenModal = useSetRecoilState(isOpenEventRegisterModalState);
 
   const changeModalState = () => {
-    setIsOpenModal(!isOpenModal);
+    setIsOpenModal(true);
   };
 
   return (

--- a/client/src/components/profile/profile-header.tsx
+++ b/client/src/components/profile/profile-header.tsx
@@ -1,15 +1,15 @@
-/* eslint-disable */
 import React from 'react';
 import styled from 'styled-components';
 import { IconType } from 'react-icons';
 import { MdOutlineArrowBackIos, MdSettings } from 'react-icons/md';
 import { HiShare } from 'react-icons/hi';
-import { useRecoilState, useSetRecoilState } from 'recoil';
+import { useLocation } from 'react-router-dom';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import { isOpenShareModalState } from '@atoms/is-open-modal';
+import userState from '@atoms/user';
 import { CustomtHeader, HeaderTitleNunito } from '@common/header';
 import { makeIconToLink } from '@utils/index';
-import { isOpenEventRegisterModalState } from '@atoms/is-open-modal';
 
 interface IconAndLink {
   Component:IconType,
@@ -32,10 +32,15 @@ const IconContainer = styled.div`
   }
 `;
 
+const idRegex = /\/profile\/(.*)/;
+
 function ProfileHeader() {
   const BackIcon: IconAndLink = { Component: MdOutlineArrowBackIos, link: '/', key: 'main' };
   const SettingIcon: IconAndLink = { Component: MdSettings, link: '/settings', key: 'setting' };
+  const user = useRecoilValue(userState);
   const setIsOpenModal = useSetRecoilState(isOpenShareModalState);
+  const location = useLocation();
+  const paths = location.pathname.match(idRegex);
 
   const changeModalState = () => {
     setIsOpenModal(true);
@@ -46,12 +51,15 @@ function ProfileHeader() {
       <CustomtHeader>
         {makeIconToLink(BackIcon)}
         <HeaderTitleNunito>
-          MyPage
+          Profile
         </HeaderTitleNunito>
+        {(paths && (paths[1] === user.userId))
+        && (
         <IconContainer>
           <HiShare onClick={changeModalState} size={48} />
           {makeIconToLink(SettingIcon)}
         </IconContainer>
+        )}
       </CustomtHeader>
     </>
   );

--- a/client/src/components/profile/profile-header.tsx
+++ b/client/src/components/profile/profile-header.tsx
@@ -4,8 +4,9 @@ import styled from 'styled-components';
 import { IconType } from 'react-icons';
 import { MdOutlineArrowBackIos, MdSettings } from 'react-icons/md';
 import { HiShare } from 'react-icons/hi';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 
+import { isOpenShareModalState } from '@atoms/is-open-modal';
 import { CustomtHeader, HeaderTitleNunito } from '@common/header';
 import { makeIconToLink } from '@utils/index';
 import { isOpenEventRegisterModalState } from '@atoms/is-open-modal';
@@ -34,10 +35,10 @@ const IconContainer = styled.div`
 function ProfileHeader() {
   const BackIcon: IconAndLink = { Component: MdOutlineArrowBackIos, link: '/', key: 'main' };
   const SettingIcon: IconAndLink = { Component: MdSettings, link: '/settings', key: 'setting' };
-  const [isOpenModal, setIsOpenModal] = useRecoilState(isOpenEventRegisterModalState);
+  const setIsOpenModal = useSetRecoilState(isOpenShareModalState);
 
   const changeModalState = () => {
-    setIsOpenModal(!isOpenModal);
+    setIsOpenModal(true);
   };
 
   return (
@@ -48,8 +49,8 @@ function ProfileHeader() {
           MyPage
         </HeaderTitleNunito>
         <IconContainer>
-          <HiShare size={48} />
-          <MdSettings size={48} />
+          <HiShare onClick={changeModalState} size={48} />
+          {makeIconToLink(SettingIcon)}
         </IconContainer>
       </CustomtHeader>
     </>

--- a/client/src/components/profile/profile-header.tsx
+++ b/client/src/components/profile/profile-header.tsx
@@ -1,0 +1,59 @@
+/* eslint-disable */
+import React from 'react';
+import styled from 'styled-components';
+import { IconType } from 'react-icons';
+import { MdOutlineArrowBackIos, MdSettings } from 'react-icons/md';
+import { HiShare } from 'react-icons/hi';
+import { useRecoilState } from 'recoil';
+
+import { CustomtHeader, HeaderTitleNunito } from '@common/header';
+import { makeIconToLink } from '@utils/index';
+import { isOpenEventRegisterModalState } from '@atoms/is-open-modal';
+
+interface IconAndLink {
+  Component:IconType,
+  key: string | number,
+  link: string,
+  size?: number,
+  color?: string,
+}
+
+const IconContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+
+  svg:not(:last-child) {
+    margin-right: 30px;
+  }
+
+  svg:hover {
+    filter: invert(88%) sepia(1%) saturate(4121%) hue-rotate(12deg) brightness(62%) contrast(79%);
+  }
+`;
+
+function ProfileHeader() {
+  const BackIcon: IconAndLink = { Component: MdOutlineArrowBackIos, link: '/', key: 'main' };
+  const SettingIcon: IconAndLink = { Component: MdSettings, link: '/settings', key: 'setting' };
+  const [isOpenModal, setIsOpenModal] = useRecoilState(isOpenEventRegisterModalState);
+
+  const changeModalState = () => {
+    setIsOpenModal(!isOpenModal);
+  };
+
+  return (
+    <>
+      <CustomtHeader>
+        {makeIconToLink(BackIcon)}
+        <HeaderTitleNunito>
+          MyPage
+        </HeaderTitleNunito>
+        <IconContainer>
+          <HiShare size={48} />
+          <MdSettings size={48} />
+        </IconContainer>
+      </CustomtHeader>
+    </>
+  );
+}
+
+export default ProfileHeader;

--- a/client/src/components/profile/profile-header.tsx
+++ b/client/src/components/profile/profile-header.tsx
@@ -53,13 +53,10 @@ function ProfileHeader() {
         <HeaderTitleNunito>
           Profile
         </HeaderTitleNunito>
-        {(paths && (paths[1] === user.userId))
-        && (
         <IconContainer>
           <HiShare onClick={changeModalState} size={48} />
-          {makeIconToLink(SettingIcon)}
+          {(paths && (paths[1] === user.userId)) && makeIconToLink(SettingIcon)}
         </IconContainer>
-        )}
       </CustomtHeader>
     </>
   );

--- a/client/src/components/profile/share-modal.tsx
+++ b/client/src/components/profile/share-modal.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { useSetRecoilState } from 'recoil';
+
+import { isOpenShareModalState } from '@atoms/is-open-modal';
+import { ModalBox, BackgroundWrapper } from '@common/modal';
+
+function ShareModal() {
+  const setIsOpenShareModal = useSetRecoilState(isOpenShareModalState);
+
+  return (
+    <>
+      <BackgroundWrapper />
+      <ModalBox>
+        <div>SHARE</div>
+        <button type="button" aria-label="test" onClick={() => setIsOpenShareModal(false)}>cancle</button>
+      </ModalBox>
+    </>
+  );
+}
+
+export default ShareModal;

--- a/client/src/recoil/atoms/is-open-modal.ts
+++ b/client/src/recoil/atoms/is-open-modal.ts
@@ -9,3 +9,8 @@ export const isOpenEventModalState = atom<boolean>({
   key: 'isOpenEventModalState',
   default: false,
 });
+
+export const isOpenShareModalState = atom<boolean>({
+  key: 'isOpenShareModalState',
+  default: false,
+});

--- a/client/src/routes/header.tsx
+++ b/client/src/routes/header.tsx
@@ -7,6 +7,7 @@ import EventHeader from '@components/event/event-header';
 import InviteHeader from '@components/invite-header';
 import RecentSearchHeader from '@components/search/recent-search-header';
 import SearchHeader from '@components/search/search-header';
+import ProfileHeader from '@components/profile/profile-header';
 
 function HeaderRouter() {
   return (
@@ -17,6 +18,7 @@ function HeaderRouter() {
       <Route exact path="/activity" component={ActivityHeader} />
       <Route exact path="/event" component={EventHeader} />
       <Route exact path="/invite" component={InviteHeader} />
+      <Route exact path="/profile" component={ProfileHeader} />
       <Route path="/" component={DefaultHeader} />
     </Switch>
   );

--- a/client/src/routes/header.tsx
+++ b/client/src/routes/header.tsx
@@ -18,7 +18,7 @@ function HeaderRouter() {
       <Route exact path="/activity" component={ActivityHeader} />
       <Route exact path="/event" component={EventHeader} />
       <Route exact path="/invite" component={InviteHeader} />
-      <Route exact path="/profile" component={ProfileHeader} />
+      <Route exact path="/profile/:id" component={ProfileHeader} />
       <Route path="/" component={DefaultHeader} />
     </Switch>
   );

--- a/client/src/views/profile-view.tsx
+++ b/client/src/views/profile-view.tsx
@@ -135,7 +135,7 @@ function ProfileView() {
     <ProfileViewLayout>
       <ImageAndFollowButtonDiv>
         <LargeProfileImageBox src={userDetailInfo.current.profileUrl} />
-        {user.userId !== paths[1]
+        {user.userId !== profileId
         &&
         <DefaultButton
         buttonType="primary"

--- a/client/src/views/profile-view.tsx
+++ b/client/src/views/profile-view.tsx
@@ -147,7 +147,7 @@ function ProfileView() {
       </DefaultButton>}
       </ImageAndFollowButtonDiv>
       <UserNameDiv>{userDetailInfo.current.userName}</UserNameDiv>
-      <UserIdDiv>{`@${userDetailInfo.current.userName}`}</UserIdDiv>
+      <UserIdDiv>{`@${userDetailInfo.current.userId}`}</UserIdDiv>
       <FollowBox>
         <FollowBoxDiv>
           <FollowNumberDiv>{userDetailInfo.current.followers.length}</FollowNumberDiv>

--- a/client/src/views/profile-view.tsx
+++ b/client/src/views/profile-view.tsx
@@ -1,11 +1,34 @@
 /* eslint-disable */
 import React, { useEffect, useRef, useState } from 'react';
 import { useLocation } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
+import followingListState from '@atoms/following-list';
+import userState from '@atoms/user';
 import LoadingSpinner from '@common/loading-spinner';
+import scrollbarStyle from '@styles/scrollbar-style';
+import DefaultButton from '@common/default-button';
 
 const idRegex = /\/profile\/(.*)/;
+
+const ProfileViewLayout = styled.div`
+  position:relative;
+  display: flex;
+  flex-direction: column;
+
+  width: 80%;
+  height: 100%;
+  margin: auto;
+
+  ${scrollbarStyle};
+`;
+
+const ImageAndFollowButtonDiv = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`
 
 const LargeProfileImageBox = styled.img`
   width: 100px;
@@ -13,22 +36,74 @@ const LargeProfileImageBox = styled.img`
   border-radius: 30%;
 `;
 
+const UserNameDiv = styled.div`
+  font-size: 28px;
+  font-weight: bold;
+  margin-top: 10px;
+`;
+
+const UserIdDiv = styled.div`
+  font-size: 24px;
+  margin-top: 10px;
+`;
+
+const FollowBox = styled.div`
+  position:relative;
+  display: flex;
+  justify-content: space-between;
+  align-items:center;
+
+  width: 80%;
+  margin-top: 10px;
+`;
+
+const FollowBoxDiv = styled.div`
+  display: flex;
+`;
+
+const FollowNumberDiv = styled.div`
+  font-size: 28px;
+  font-weight: 600;
+  margin-right: 20px;
+`;
+
+const FollowTextDiv = styled.div`
+  font-size: 24px;
+`
+
+const DescriptionDiv = styled.div`
+  font-size: 20px;
+  margin-top: 30px;
+`
+
+const JoinDateDiv = styled.div`
+  font-size: 20px;
+  margin-top: 50px;
+`
+
 interface IUserDetail {
+  _id: string,
   userName: string,
   userId: string,
   userEmail: string,
   description: string,
   followings: string[],
   followers: string[],
-  joinDate: Date,
+  joinDate: string,
   profileUrl: string
 }
 
+const makeDateToJoinDate = (dateString: string) => {
+  const date = new Date(dateString);
+  return `${date.getMonth()+1}월 ${date.getDate()}, ${date.getFullYear()}`
+}
+
 function ProfileView() {
+  const user = useRecoilValue(userState);
+  const followingList = useRecoilValue(followingListState)
   const location = useLocation();
   const paths = location.pathname.match(idRegex);
   const [loading, setLoading] = useState(true);
-  const [emptyUser, setEmptyUser] = useState(false);
   const userDetailInfo = useRef<IUserDetail>();
 
   if (!paths) {
@@ -39,29 +114,53 @@ function ProfileView() {
 
   useEffect(() => {
     const getUserDetail = async () => {
-      const result = await fetch(`${process.env.REACT_APP_API_URL}/api/user/:${profileId}`).then((res) => res.json());
+      const result = await fetch(`${process.env.REACT_APP_API_URL}/api/user/${profileId}`).then((res) => res.json());
       if (result.ok) {
-        userDetailInfo.current = result;
-      } else {
-        setEmptyUser(true);
+        userDetailInfo.current = result.userDetailInfo;
       }
       setLoading(false);
-    } 
+    };
+
+    getUserDetail();
   })
 
   if (loading) {
     return <LoadingSpinner />;
   }
-
-  if (emptyUser) {
+  if (!userDetailInfo.current) {
     return <div>존재하지 않는 사용자입니다.</div>;
   }
 
   return (
-    <>
-      <LargeProfileImageBox />
-      <div>{profileId}</div>
-    </>
+    <ProfileViewLayout>
+      <ImageAndFollowButtonDiv>
+        <LargeProfileImageBox src={userDetailInfo.current.profileUrl} />
+        {user.userId !== paths[1]
+        &&
+        <DefaultButton
+        buttonType="primary"
+        size="small"
+        font="Nunito"
+        isDisabled={followingList.includes(userDetailInfo.current._id)}
+      >
+        {followingList.includes(userDetailInfo.current._id) ? 'following' : 'follow'}
+      </DefaultButton>}
+      </ImageAndFollowButtonDiv>
+      <UserNameDiv>{userDetailInfo.current.userName}</UserNameDiv>
+      <UserIdDiv>{`@${userDetailInfo.current.userName}`}</UserIdDiv>
+      <FollowBox>
+        <FollowBoxDiv>
+          <FollowNumberDiv>{userDetailInfo.current.followers.length}</FollowNumberDiv>
+          <FollowTextDiv>followers</FollowTextDiv>
+        </FollowBoxDiv>
+        <FollowBoxDiv>
+          <FollowNumberDiv>{userDetailInfo.current.followings.length}</FollowNumberDiv>
+          <FollowTextDiv>following</FollowTextDiv>
+        </FollowBoxDiv>
+      </FollowBox>
+      <DescriptionDiv>{userDetailInfo.current.description}</DescriptionDiv>
+      <JoinDateDiv>{`Joined ${makeDateToJoinDate(userDetailInfo.current.joinDate)}`}</JoinDateDiv>
+    </ProfileViewLayout>
   );
 }
 

--- a/client/src/views/profile-view.tsx
+++ b/client/src/views/profile-view.tsx
@@ -1,7 +1,68 @@
-import React from 'react';
+/* eslint-disable */
+import React, { useEffect, useRef, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import styled from 'styled-components';
+
+import LoadingSpinner from '@common/loading-spinner';
+
+const idRegex = /\/profile\/(.*)/;
+
+const LargeProfileImageBox = styled.img`
+  width: 100px;
+  height: 100px;
+  border-radius: 30%;
+`;
+
+interface IUserDetail {
+  userName: string,
+  userId: string,
+  userEmail: string,
+  description: string,
+  followings: string[],
+  followers: string[],
+  joinDate: Date,
+  profileUrl: string
+}
 
 function ProfileView() {
-  return (<></>);
+  const location = useLocation();
+  const paths = location.pathname.match(idRegex);
+  const [loading, setLoading] = useState(true);
+  const [emptyUser, setEmptyUser] = useState(false);
+  const userDetailInfo = useRef<IUserDetail>();
+
+  if (!paths) {
+    return <div>존재하지 않는 사용자입니다.</div>;
+  }
+
+  const profileId = paths[1];
+
+  useEffect(() => {
+    const getUserDetail = async () => {
+      const result = await fetch(`${process.env.REACT_APP_API_URL}/api/user/:${profileId}`).then((res) => res.json());
+      if (result.ok) {
+        userDetailInfo.current = result;
+      } else {
+        setEmptyUser(true);
+      }
+      setLoading(false);
+    } 
+  })
+
+  if (loading) {
+    return <LoadingSpinner />;
+  }
+
+  if (emptyUser) {
+    return <div>존재하지 않는 사용자입니다.</div>;
+  }
+
+  return (
+    <>
+      <LargeProfileImageBox />
+      <div>{profileId}</div>
+    </>
+  );
 }
 
 export default ProfileView;

--- a/server/src/api/routes/user.ts
+++ b/server/src/api/routes/user.ts
@@ -12,7 +12,7 @@ export default (app: Router) => {
 
   userRouter.get('/', authJWT, async (req: Request, res: Response) => {
     const { accessToken, userDocumentId } = req.body;
-    const user = await usersService.findUser(userDocumentId);
+    const user = await usersService.findUserByDocumentId(userDocumentId);
     if (user) {
       const {
         _id, profileUrl, userName, userId,
@@ -24,6 +24,17 @@ export default (app: Router) => {
       res.json({ ok: false });
     }
   });
+
+  userRouter.get('/:userId', async (req: Request, res: Response) => {
+    const { userId } = req.params;
+    const userInfo = await usersService.findUserByUserId(userId);
+    if (userInfo) {
+      const userDetailInfo = usersService.makeUserDetailInterface(userInfo);
+      res.json({ ok: true, userDetailInfo });
+    } else {
+      res.json({ ok: false });
+    }
+  })
 
   userRouter.get('/followings/:userDocumentId', async (req: Request, res: Response) => {
     try {
@@ -39,7 +50,7 @@ export default (app: Router) => {
     try {
       const { userDocumentId } = req.params;
 
-      const userInfo = await usersService.findUser(userDocumentId);
+      const userInfo = await usersService.findUserByDocumentId(userDocumentId);
       res.status(200).json(userInfo);
     } catch (error) {
       console.error(error);

--- a/server/src/models/users.ts
+++ b/server/src/models/users.ts
@@ -102,6 +102,10 @@ const usersSchema = new Schema({
     type: String,
     default: 'https://kr.object.ncloudstorage.com/nogarihouse/profile/default-user-image.png',
   },
+  joinDate: {
+    type: Date,
+    default: new Date(),
+  }
 });
 
 usersSchema.pre('insertMany', async (next: any, docs: any) => {

--- a/server/src/services/users-service.ts
+++ b/server/src/services/users-service.ts
@@ -5,17 +5,28 @@
 import nodemailer from 'nodemailer';
 import jwt from 'jsonwebtoken';
 
-import Users from '@models/users';
+import Users, { IUserTypesModel } from '@models/users';
 import RefreshTokens from '@models/refresh-token';
 import jwtUtils from '@utils/jwt-util';
 
 interface ISignupUserInfo {
-  loginType: string;
-  userId: string;
-  password: string;
-  userName: string;
-  userEmail: string;
-  interesting: string[];
+  loginType: string,
+  userId: string,
+  password: string,
+  userName: string,
+  userEmail: string,
+  interesting: string[]
+}
+
+interface IUserDetail {
+  userName: string,
+  userId: string,
+  userEmail: string,
+  description: string,
+  followings: string[],
+  followers: string[],
+  joinDate: Date,
+  profileUrl: string
 }
 
 let instance: any = null;
@@ -61,8 +72,13 @@ class UserService {
     return { ok: false, msg: 'wrong password' };
   }
 
-  async findUser(userDocumentId: string) {
+  async findUserByDocumentId(userDocumentId: string) {
     const result = await Users.findOne({ _id: userDocumentId });
+    return result;
+  }
+
+  async findUserByUserId(userId: string) {
+    const result = await Users.findOne({ userId });
     return result;
   }
 
@@ -171,6 +187,22 @@ class UserService {
       profileUrl,
       type: 'user',
     });
+  }
+
+  makeUserDetailInterface(user: IUserTypesModel & {
+    _id: any;
+  }) {
+    const {userName, userId, userEmail, description, followings, followers, joinDate, profileUrl} = user;
+    return {
+      userName,
+      userId,
+      userEmail,
+      description,
+      followings,
+      followers,
+      joinDate,
+      profileUrl,
+    }
   }
 
   async searchUsers(keyword: string, count: number) {

--- a/server/src/services/users-service.ts
+++ b/server/src/services/users-service.ts
@@ -66,11 +66,6 @@ class UserService {
     return result;
   }
 
-  async findUsers(userDocumentId: string) {
-    const result = await Users.findOne({ _id: userDocumentId });
-    return result;
-  }
-
   async signup(info: ISignupUserInfo) {
     try {
       await Users.insertMany([info]);

--- a/server/src/services/users-service.ts
+++ b/server/src/services/users-service.ts
@@ -192,8 +192,9 @@ class UserService {
   makeUserDetailInterface(user: IUserTypesModel & {
     _id: any;
   }) {
-    const {userName, userId, userEmail, description, followings, followers, joinDate, profileUrl} = user;
+    const {_id, userName, userId, userEmail, description, followings, followers, joinDate, profileUrl} = user;
     return {
+      _id,
       userName,
       userId,
       userEmail,


### PR DESCRIPTION
## 개요
프로필 페이지 구현

## 작업사항
- 프로필 페이지 스타일
- 접속한 프로필 주소를 확인해서 없는 유저인지 확인하는 예외처리
- 해당 프로필 유저를 팔로잉중인지 아닌지 확인하여 버튼 표시
- 자신의 페이지 / 다른 유저의 페이지에 따라서 헤더 설정 다르게 구현

## 변경로직
- 프로필 페이지에 접속하면 url path가 `/profile/:id` 이기 때문에 userId를 가지고 DB를 조회하게 됩니다.
따라서 기존에 `_id`를 가지고 유저를 조회하는 서비스 로직의 네이밍을 변경하고 userId를 이용해서 조회하는 서비스 로직을 구현했습니다.
- 본인의 페이지에서는 프로필 세팅 버튼이 존재하지만 다른 유저의 페이지에서는 보이면 안되므로 확인하는 과정을 거쳤습니다.
- 기존 피그마 디자인에서는 헤더 텍스트가 My Page였지만 다른 유저의 프로필을 보는 과정을 고려해서 Profile로 바꿨습니다.
- 앞으로 유저가 회원가입 할 때 joinDate라는 field가 default로 가입 시각을 생성하도록 했습니다.
- 
## 변경후

iHoHyeon 계정으로 본인 , test1 의 프로필을 조회하는 화면

![image](https://user-images.githubusercontent.com/74816327/142238369-5c1e0a3e-fa8f-4e35-b0fc-91a0c167a9f3.png)

![image](https://user-images.githubusercontent.com/74816327/142238532-aa0d3076-5d8d-4fae-a53e-34dc112df6ed.png)


## 기타
아직 기능들은 미완성이라 코드를 한 곳에 전부 집어넣었습니다!
