### PR TITLE
✨ All 타입 검색기능 구현 완료

### DIFF
--- a/client/src/components/search/style.ts
+++ b/client/src/components/search/style.ts
@@ -56,3 +56,9 @@ export const TestBox = styled.div`
   margin-bottom: 10px;
   background-color: white;
 `;
+
+export const ItemDiv = styled.div`
+  div + div {
+  margin-bottom: 10px;
+  }
+`;

--- a/client/src/views/search-view.tsx
+++ b/client/src/views/search-view.tsx
@@ -30,6 +30,7 @@ function SearchView() {
   const inputKeywordRef = useRef<HTMLInputElement>(null);
   const nowFetchingRef = useRef<boolean>(false);
   const [loading, setLoading] = useState(true);
+  const [searchDataCount, setSearchDataCount] = useState(0);
   const user = useRecoilValue(userState);
   const [nowItemsList, setNowItemsList] = useRecoilState(nowItemsListState);
   const [nowFetching, setNowFetching] = useRecoilState(nowFetchingState);
@@ -42,7 +43,7 @@ function SearchView() {
 
   const fetchItems = async () => {
     try {
-      const newItemsList = await fetch(`${process.env.REACT_APP_API_URL}/api/search/${searchInfo.current.option}/${searchInfo.current.keyword || 'recent'}?count=${nowItemsList.length}`)
+      const newItemsList = await fetch(`${process.env.REACT_APP_API_URL}/api/search/${searchInfo.current.option}/${searchInfo.current.keyword || 'recent'}?count=${searchDataCount}`)
         .then((res) => res.json())
         .then((json) => json.items);
       setNowItemsList([...nowItemsList, ...newItemsList]);
@@ -56,6 +57,7 @@ function SearchView() {
     searchInfo.current.keyword = inputKeywordRef.current?.value as string;
     searchInfo.current.option = searchType.toLocaleLowerCase();
     resetItemList();
+    setSearchDataCount(0);
     setNowFetching(true);
   };
 
@@ -81,6 +83,7 @@ function SearchView() {
     if (!nowFetchingRef.current) {
       const diff = e.currentTarget.scrollHeight - e.currentTarget.scrollTop;
       if (diff < 700) {
+        setSearchDataCount(searchDataCount + 10);
         setNowFetching(true);
         nowFetchingRef.current = true;
         setTimeout(() => {

--- a/client/src/views/search-view.tsx
+++ b/client/src/views/search-view.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-underscore-dangle */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 import React, {
@@ -100,18 +101,37 @@ function SearchView() {
     else console.error('no room-id');
   };
 
+  const makeUserObjectIncludedIsFollow = (
+    userItem: {
+      _id: string,
+      userName:
+      string,
+      description: string,
+      profileUrl: string
+    },
+  ) => ({
+    _id: userItem._id,
+    userName: userItem.userName,
+    description: userItem.description,
+    profileUrl: userItem.profileUrl,
+    isFollow: !!followingList.includes(userItem._id),
+  });
+
   const makeItemToCardForm = (item:any) => {
     if (item.type === 'event') {
       return <ItemDiv onClick={setEventModal}>{makeEventToCard(item)}</ItemDiv>;
     }
 
     if (item.type === 'user') {
+      if (item._id === user.userDocumentId) return '';
+      const newUserItemForm = makeUserObjectIncludedIsFollow(item);
+
       return (
         <UserCard
           // eslint-disable-next-line no-underscore-dangle
-          key={item._id}
+          key={newUserItemForm._id}
           cardType="follow"
-          userData={item}
+          userData={newUserItemForm}
         />
       );
     }
@@ -143,22 +163,8 @@ function SearchView() {
     }
 
     if (searchType === 'People') {
-      const filteredItemList = nowItemsList.map((item) => {
-        const {
-          _id, userName, description, profileUrl,
-        } = item;
-
-        const newItem = {
-          _id,
-          userName,
-          description,
-          profileUrl,
-          isFollow: !!followingList.includes(_id),
-        };
-
-        return newItem;
-      // eslint-disable-next-line no-underscore-dangle
-      }).filter((item) => item._id !== user.userDocumentId);
+      const filteredItemList = nowItemsList
+        .map(makeUserObjectIncludedIsFollow).filter((item) => item._id !== user.userDocumentId);
 
       return <UserCardList userList={filteredItemList} cardType="follow" />;
     }

--- a/client/src/views/search-view.tsx
+++ b/client/src/views/search-view.tsx
@@ -153,7 +153,7 @@ function SearchView() {
     }
 
     if (searchType === 'All') {
-      return <div>{nowItemsList.map(makeItemToCardForm)}</div>;
+      return <>{nowItemsList.map(makeItemToCardForm)}</>;
     }
 
     if (searchType === 'Events') {

--- a/client/src/views/search-view.tsx
+++ b/client/src/views/search-view.tsx
@@ -150,7 +150,6 @@ function SearchView() {
     }
 
     if (searchType === 'All') {
-      console.log(nowItemsList);
       return <div>{nowItemsList.map(makeItemToCardForm)}</div>;
     }
 

--- a/client/src/views/search-view.tsx
+++ b/client/src/views/search-view.tsx
@@ -11,7 +11,7 @@ import { nowFetchingState, nowItemsListState } from '@atoms/main-section-scroll'
 import searchTypeState from '@atoms/search-type';
 import OptionBar from '@components/search/option-bar';
 import {
-  SearchViewLayout, SearchBarLayout, SearchInput, SearchScrollSection,
+  SearchViewLayout, SearchBarLayout, SearchInput, SearchScrollSection, ItemDiv,
 } from '@components/search/style';
 import LoadingSpinner from '@common/loading-spinner';
 import useSetEventModal from '@hooks/useSetEventModal';
@@ -100,37 +100,39 @@ function SearchView() {
     else console.error('no room-id');
   };
 
+  const makeItemToCardForm = (item:any) => {
+    if (item.type === 'event') {
+      return <ItemDiv onClick={setEventModal}>{makeEventToCard(item)}</ItemDiv>;
+    }
+
+    if (item.type === 'user') {
+      return (
+        <UserCard
+          // eslint-disable-next-line no-underscore-dangle
+          key={item._id}
+          cardType="follow"
+          userData={item}
+        />
+      );
+    }
+
+    if (item.type === 'room') {
+      return <ItemDiv onClick={roomCardClickHandler}>{makeRoomToCard(item)}</ItemDiv>;
+    }
+
+    return <div />;
+  };
+
   // eslint-disable-next-line consistent-return
   const showList = () => {
     if (searchInfo.current.option !== searchType.toLocaleLowerCase()) {
       return <LoadingSpinner />;
     }
 
-    // if (searchType === 'All') {
-    //   const newList = nowItemsList.map((result, item) => {
-    //     if (item.type === 'event') {
-    //       return result + makeEventToCard(item);
-    //     }
-
-    //     if (item.type === 'user') {
-    //       return (
-    //         <UserCard
-    //           // eslint-disable-next-line no-underscore-dangle
-    //           key={item._id}
-    //           cardType="follow"
-    //           userData={item}
-    //         />
-    //       );
-    //     }
-
-    //     if (item.type === 'room') {
-    //       return makeRoomToCard(item);
-    //     }
-
-    //     return <div />;
-    //   });
-    //   return newList;
-    // }
+    if (searchType === 'All') {
+      console.log(nowItemsList);
+      return <div>{nowItemsList.map(makeItemToCardForm)}</div>;
+    }
 
     if (searchType === 'Events') {
       return <EventCardList setEventModal={setEventModal} eventList={nowItemsList} />;

--- a/server/src/api/routes/search.ts
+++ b/server/src/api/routes/search.ts
@@ -54,16 +54,16 @@ export default (app: Router) => {
     if (typeof keyword !== 'string' || typeof count !== 'string') {
       res.json({ ok: false });
     } else {
-      const roomItems = (await roomsService.searchRooms(keyword, Number(count)))
-        ?.map(roomsService.makeItemToRoomInterface);
+      const roomItems = (
+        await roomsService
+          .searchRooms(keyword, Number(count)))!.map(roomsService.makeItemToRoomInterface);
       const userItems = (
-        await usersService.searchUsers(keyword, Number(count)))
-        ?.map(usersService.makeItemToUserInterface);
+        await usersService
+          .searchUsers(keyword, Number(count)))!.map(usersService.makeItemToUserInterface);
       const eventItems = (
         await eventsService
-          .searchEvent(keyword, Number(count)))
-        ?.map(eventsService.makeItemToEventInterface);
-      const items = Object.values({ ...roomItems, ...userItems, ...eventItems });
+          .searchEvent(keyword, Number(count)))!.map(eventsService.makeItemToEventInterface);
+      const items = [...userItems, ...roomItems, ...eventItems];
       res.json({ ok: true, items, keyword });
     }
   });

--- a/server/src/services/rooms-service.ts
+++ b/server/src/services/rooms-service.ts
@@ -71,7 +71,7 @@ class RoomService {
   makeItemToRoomInterface(item: {_id:string, title:string, isAnonymous:boolean, participantsInfo:Array<object>}) {
     return ({
       ...item,
-      type: 'event',
+      type: 'room',
     });
   }
 

--- a/server/src/services/users-service.ts
+++ b/server/src/services/users-service.ts
@@ -183,7 +183,7 @@ class UserService {
       const query = new RegExp(keyword, 'i');
       const res = await Users.find({
         $or: [{ userId: query }, { userName: query }, { description: query }],
-      }, ['userName', 'description,', 'profileUrl']).sort({ date: 1 }).skip(count).limit(10);
+      }, ['userName', 'description', 'profileUrl']).sort({ date: 1 }).skip(count).limit(10);
       return res;
     } catch (e) {
       console.error(e);


### PR DESCRIPTION
## 개요
all 타입 검색기능 구현 완료
## 작업사항
- 🐛 roomService의 makeItemToRoomInterface의 type 값 수정
  - 단순 오타 수정
- 💄 각 카드를 감싸는 ItemDiv 작성
  - 타입별 클릭 이벤트를 적용할 수 있도록 makeItemToCardForm함수를 구현
  - return 되는 각 itemCard를 onClick={clickHandler}를 포함한 ItemDiv로 덮어줌
- ✨ All로 검색시 각 아이템의 타입을 검사해서 Card를 씌워주는 기능 구현
- 🐛 userService의 description 오타 수정
  - 단순 오타 수정 
- ♻️ userItem에서 isFollow 값을 추가하는 코드를 함수로 분리
  - 중복 코드 리팩토링 
- 🐛 all 타입 검색시 데이터가 일부 보이지 않는 버그 수정
  - 스프레드 연산자 사용시 undefined일 경우를 고려해 적용 되지않는 오류 발생
  - searchType(...)?.map(...) 부분을 searchType(...)!.map(...)으로 수정
- 🔥 디버깅 콘솔로그 제거
- 🐛 All타입 검색 시 각 searchType에서 데이터를 조회하지 못하는 버그 해결
  - 버그 : count가 type별로 나누어져있지 않다보니 각 타입별 찾은 갯수를 초과해서 다음 요청에서 skip되는 구간이 생김
  - 해결 : searchDataCount를 상태관리, 스크롤 감지시 +10을 해주고 타입 변경시 0으로 초기화

## 변경로직
다른 곳에 영향을 줄만한 로직 변경은 없습니다.
search api요청시 count에 nowItemList.length 대신 searchDataCount 상태를 넣어줬습니다.

### 변경 후

https://user-images.githubusercontent.com/59464537/142252326-33444929-6c2b-4a4f-9fa7-6bc4f3787826.mov

## 기타
- all타입은 각 item의 타입을 검사해서 카드를 덮어 씌워줍니다. 나머지 타입들은 cardList형태를 사용하고 있는데, 나머지 타입들도 각 item 카드를 검사해서 덮어씌워주는게 좋은 지 고민입니다. 덮어 씌워준다면, 코드 길이가 10줄 정도 줄어드는 장점, 타입을 확실히 아는데도 검사를 다시 해줘야하는 단점이 있습니다.
