### PR TITLE
프로필 화면에서 팔로우 버튼 활성화, 기타 관련 기능 구현

### DIFF
--- a/client/src/components/common/event-card.tsx
+++ b/client/src/components/common/event-card.tsx
@@ -9,12 +9,20 @@ const EventCardLayout = styled.div`
   align-items: flex-start;
   position: relative;
 
-  padding: 24px;
   height: max-content;
   max-height: 200px;
+  padding: 24px;
+  border-radius: 30px;
+
+  margin-left: 0.8%;
 
   div:not(:last-child) {
     margin-bottom: 10px;
+  }
+
+  &:hover {
+  background-color: #eeebe4e4;
+  box-shadow: 0px 2px 4px rgb(0 0 0 / 25%);
   }
 `;
 

--- a/client/src/components/common/user-card-list.tsx
+++ b/client/src/components/common/user-card-list.tsx
@@ -7,6 +7,7 @@ import UserCard from '@common/user-card';
 interface IUserForCard{
   _id: string,
   userName: string,
+  userId: string,
   description: string,
   profileUrl: string,
   isFollow?: boolean,

--- a/client/src/components/common/user-card.tsx
+++ b/client/src/components/common/user-card.tsx
@@ -80,7 +80,7 @@ const UserDescription = styled.div`
 
 export default function UserCard(props: UserCardProps) {
   const [loading, setLoading] = useState(false);
-  const isFollowRef = useRef<boolean>(props.userData.isFollow as boolean);
+  const isFollowingRef = useRef<boolean>(props.userData.isFollow as boolean);
   const setFollowingList = useSetRecoilState(followingListState);
 
   const fetchFollow = useCallback((isFollow: boolean, targetUserDocumentId: string) => {
@@ -96,7 +96,7 @@ export default function UserCard(props: UserCardProps) {
     }).then((res) => res.json())
       .then((json) => {
         if (json.ok) {
-          isFollowRef.current = !isFollowRef.current;
+          isFollowingRef.current = !isFollowingRef.current;
           isFollow ? setFollowingList((followList) => followList.filter((id) => id !== targetUserDocumentId)) : setFollowingList((followList) => [...followList, targetUserDocumentId]);
         }
         setLoading(false);
@@ -125,13 +125,13 @@ export default function UserCard(props: UserCardProps) {
       {props.cardType === 'follow'
         && (
           <DefaultButton
-            buttonType={isFollowRef.current ? 'following' : 'follow'}
+            buttonType={isFollowingRef.current ? 'following' : 'follow'}
             size="small"
             font="Nunito"
             isDisabled={false}
-            onClick={() => fetchFollow(isFollowRef.current, props.userData._id)}
+            onClick={() => fetchFollow(isFollowingRef.current, props.userData._id)}
           >
-            {isFollowRef.current ? 'following' : 'follow'}
+            {isFollowingRef.current ? 'following' : 'follow'}
           </DefaultButton>
         )}
     </UserCardLayout>

--- a/client/src/components/common/user-card.tsx
+++ b/client/src/components/common/user-card.tsx
@@ -3,13 +3,12 @@
 /* eslint-disable no-underscore-dangle */
 /* eslint-disable max-len */
 /* eslint-disable no-unused-expressions */
-import React, { useCallback, useRef, useState } from 'react';
-import { useSetRecoilState } from 'recoil';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 
-import followingListState from '@atoms/following-list';
 import UserImage from '@common/user-image';
 import DefaultButton from '@common/default-button';
+import useIsFollowingRef from '@hooks/useIsFollowingRef';
 import LoadingSpinner from './loading-spinner';
 
 interface UserCardProps {
@@ -80,28 +79,7 @@ const UserDescription = styled.div`
 
 export default function UserCard(props: UserCardProps) {
   const [loading, setLoading] = useState(false);
-  const isFollowingRef = useRef<boolean>(props.userData.isFollow as boolean);
-  const setFollowingList = useSetRecoilState(followingListState);
-
-  const fetchFollow = useCallback((isFollow: boolean, targetUserDocumentId: string) => {
-    setLoading(true);
-    const type = isFollow ? 'unfollow' : 'follow';
-    fetch(`${process.env.REACT_APP_API_URL}/api/user/follow`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      credentials: 'include',
-      body: JSON.stringify({ type, targetUserDocumentId }),
-    }).then((res) => res.json())
-      .then((json) => {
-        if (json.ok) {
-          isFollowingRef.current = !isFollowingRef.current;
-          isFollow ? setFollowingList((followList) => followList.filter((id) => id !== targetUserDocumentId)) : setFollowingList((followList) => [...followList, targetUserDocumentId]);
-        }
-        setLoading(false);
-      });
-  }, []);
+  const [isFollowingRef, fetchFollow] = useIsFollowingRef(setLoading, props.userData.isFollow);
 
   return (
     <UserCardLayout sizeType={props.cardType}>
@@ -129,7 +107,7 @@ export default function UserCard(props: UserCardProps) {
             size="small"
             font="Nunito"
             isDisabled={false}
-            onClick={() => fetchFollow(isFollowingRef.current, props.userData._id)}
+            onClick={() => fetchFollow(isFollowingRef.current as boolean, props.userData._id)}
           >
             {isFollowingRef.current ? 'following' : 'follow'}
           </DefaultButton>

--- a/client/src/components/common/user-card.tsx
+++ b/client/src/components/common/user-card.tsx
@@ -4,6 +4,7 @@
 /* eslint-disable max-len */
 /* eslint-disable no-unused-expressions */
 import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
 import UserImage from '@common/user-image';
@@ -16,6 +17,7 @@ interface UserCardProps {
   userData: {
     _id: string,
     userName: string,
+    userId: string,
     description: string,
     profileUrl: string,
     isFollow?: boolean,
@@ -32,7 +34,7 @@ const sizes = {
   others: { cardLayoutSize: 60, userNameSize: 16, descriptionSize: 12 },
 };
 
-const UserCardLayout = styled.div`
+const UserCardLayout = styled(Link)`
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -40,8 +42,11 @@ const UserCardLayout = styled.div`
   margin-left: 0.8%;
   width: 99%;
   height: ${(props: sizeProps) => sizes[props.sizeType].cardLayoutSize}px;
+  color: black;
+  text-decoration: none;
 
   &:hover {
+  cursor: default;
   background-color: #eeebe4e4;
   box-shadow: 0px 2px 4px rgb(0 0 0 / 25%);
   }
@@ -87,8 +92,10 @@ export default function UserCard(props: UserCardProps) {
   const [loading, setLoading] = useState(false);
   const [isFollowingRef, fetchFollow] = useIsFollowingRef(setLoading, props.userData.isFollow);
 
+  console.log(props.userData);
+
   return (
-    <UserCardLayout sizeType={props.cardType}>
+    <UserCardLayout to={`/profile/${props.userData.userId}`} sizeType={props.cardType}>
       <UserInfoLayout>
         <UserImageLayout>
           <UserImage src={props.userData.profileUrl} size={props.cardType === 'others' ? 'others' : 'default'} />

--- a/client/src/components/common/user-card.tsx
+++ b/client/src/components/common/user-card.tsx
@@ -3,7 +3,7 @@
 /* eslint-disable no-underscore-dangle */
 /* eslint-disable max-len */
 /* eslint-disable no-unused-expressions */
-import React, { useState } from 'react';
+import React, { MouseEvent, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -121,7 +121,7 @@ export default function UserCard(props: UserCardProps) {
             size="small"
             font="Nunito"
             isDisabled={false}
-            onClick={() => fetchFollow(isFollowingRef.current as boolean, props.userData._id)}
+            onClick={(e: MouseEvent) => { e.stopPropagation(); fetchFollow(isFollowingRef.current as boolean, props.userData._id); }}
           >
             {isFollowingRef.current ? 'following' : 'follow'}
           </DefaultButton>

--- a/client/src/components/common/user-card.tsx
+++ b/client/src/components/common/user-card.tsx
@@ -4,7 +4,7 @@
 /* eslint-disable max-len */
 /* eslint-disable no-unused-expressions */
 import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 
 import UserImage from '@common/user-image';
@@ -21,7 +21,7 @@ interface UserCardProps {
     description: string,
     profileUrl: string,
     isFollow?: boolean,
-  }
+  },
 }
 
 interface sizeProps {
@@ -34,7 +34,7 @@ const sizes = {
   others: { cardLayoutSize: 60, userNameSize: 16, descriptionSize: 12 },
 };
 
-const UserCardLayout = styled(Link)`
+const UserCardLayout = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -91,11 +91,12 @@ const UserDescription = styled.div`
 export default function UserCard(props: UserCardProps) {
   const [loading, setLoading] = useState(false);
   const [isFollowingRef, fetchFollow] = useIsFollowingRef(setLoading, props.userData.isFollow);
+  const history = useHistory();
 
   console.log(props.userData);
 
   return (
-    <UserCardLayout to={`/profile/${props.userData.userId}`} sizeType={props.cardType}>
+    <UserCardLayout onClick={() => props.cardType !== 'others' && history.push(`/profile/${props.userData.userId}`)} sizeType={props.cardType}>
       <UserInfoLayout>
         <UserImageLayout>
           <UserImage src={props.userData.profileUrl} size={props.cardType === 'others' ? 'others' : 'default'} />

--- a/client/src/components/common/user-card.tsx
+++ b/client/src/components/common/user-card.tsx
@@ -37,8 +37,14 @@ const UserCardLayout = styled.div`
   align-items: center;
   justify-content: space-between;
   border-radius: 30px;
-  width: 100%;
+  margin-left: 0.8%;
+  width: 99%;
   height: ${(props: sizeProps) => sizes[props.sizeType].cardLayoutSize}px;
+
+  &:hover {
+  background-color: #eeebe4e4;
+  box-shadow: 0px 2px 4px rgb(0 0 0 / 25%);
+  }
 `;
 
 const UserInfoLayout = styled.div`

--- a/client/src/components/profile/followers-header.tsx
+++ b/client/src/components/profile/followers-header.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { MdOutlineArrowBackIos } from 'react-icons/md';
+import { RouteComponentProps } from 'react-router-dom';
+
+import { CustomtHeader, HeaderTitleNunito } from '@common/header';
+
+function FollowersHeader({ history }: RouteComponentProps) {
+  return (
+    <CustomtHeader>
+      <MdOutlineArrowBackIos onClick={() => history.goBack()} size={48} />
+      <HeaderTitleNunito>FOLLOWERS</HeaderTitleNunito>
+      <div />
+    </CustomtHeader>
+  );
+}
+
+export default FollowersHeader;

--- a/client/src/components/profile/followers-header.tsx
+++ b/client/src/components/profile/followers-header.tsx
@@ -1,15 +1,24 @@
 import React from 'react';
 import { MdOutlineArrowBackIos } from 'react-icons/md';
-import { RouteComponentProps } from 'react-router-dom';
+import { Link, RouteComponentProps } from 'react-router-dom';
+import styled from 'styled-components';
 
 import { CustomtHeader, HeaderTitleNunito } from '@common/header';
+
+const LogoTitle = styled(Link)`
+  font-family: "Bangers";
+  font-size: 32px;
+  text-decoration: none;
+  color: black;
+  text-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+`;
 
 function FollowersHeader({ history }: RouteComponentProps) {
   return (
     <CustomtHeader>
       <MdOutlineArrowBackIos onClick={() => history.goBack()} size={48} />
       <HeaderTitleNunito>FOLLOWERS</HeaderTitleNunito>
-      <div />
+      <LogoTitle to="/">NOGARIHOUSE</LogoTitle>
     </CustomtHeader>
   );
 }

--- a/client/src/components/profile/following-header.tsx
+++ b/client/src/components/profile/following-header.tsx
@@ -1,15 +1,24 @@
 import React from 'react';
 import { MdOutlineArrowBackIos } from 'react-icons/md';
-import { RouteComponentProps } from 'react-router-dom';
+import { Link, RouteComponentProps } from 'react-router-dom';
+import styled from 'styled-components';
 
 import { CustomtHeader, HeaderTitleNunito } from '@common/header';
+
+const LogoTitle = styled(Link)`
+  font-family: "Bangers";
+  font-size: 32px;
+  text-decoration: none;
+  color: black;
+  text-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+`;
 
 function FollowingHeader({ history }: RouteComponentProps) {
   return (
     <CustomtHeader>
       <MdOutlineArrowBackIos onClick={() => history.goBack()} size={48} />
       <HeaderTitleNunito>FOLLOWING</HeaderTitleNunito>
-      <div />
+      <LogoTitle to="/">NOGARIHOUSE</LogoTitle>
     </CustomtHeader>
   );
 }

--- a/client/src/components/profile/following-header.tsx
+++ b/client/src/components/profile/following-header.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { MdOutlineArrowBackIos } from 'react-icons/md';
+import { RouteComponentProps } from 'react-router-dom';
+
+import { CustomtHeader, HeaderTitleNunito } from '@common/header';
+
+function FollowingHeader({ history }: RouteComponentProps) {
+  return (
+    <CustomtHeader>
+      <MdOutlineArrowBackIos onClick={() => history.goBack()} size={48} />
+      <HeaderTitleNunito>FOLLOWING</HeaderTitleNunito>
+      <div />
+    </CustomtHeader>
+  );
+}
+
+export default FollowingHeader;

--- a/client/src/components/profile/profile-header.tsx
+++ b/client/src/components/profile/profile-header.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { IconType } from 'react-icons';
 import { MdOutlineArrowBackIos, MdSettings } from 'react-icons/md';
 import { HiShare } from 'react-icons/hi';
-import { useLocation } from 'react-router-dom';
+import { RouteComponentProps } from 'react-router-dom';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import { isOpenShareModalState } from '@atoms/is-open-modal';
@@ -31,16 +31,11 @@ const IconContainer = styled.div`
     filter: invert(88%) sepia(1%) saturate(4121%) hue-rotate(12deg) brightness(62%) contrast(79%);
   }
 `;
-
-const idRegex = /\/profile\/(.*)/;
-
-function ProfileHeader() {
+function ProfileHeader({ match }: RouteComponentProps<{id: string}>) {
   const BackIcon: IconAndLink = { Component: MdOutlineArrowBackIos, link: '/', key: 'main' };
   const SettingIcon: IconAndLink = { Component: MdSettings, link: '/settings', key: 'setting' };
   const user = useRecoilValue(userState);
   const setIsOpenModal = useSetRecoilState(isOpenShareModalState);
-  const location = useLocation();
-  const paths = location.pathname.match(idRegex);
 
   const changeModalState = () => {
     setIsOpenModal(true);
@@ -55,7 +50,7 @@ function ProfileHeader() {
         </HeaderTitleNunito>
         <IconContainer>
           <HiShare onClick={changeModalState} size={48} />
-          {(paths && (paths[1] === user.userId)) && makeIconToLink(SettingIcon)}
+          {(match.params.id === user.userId) && makeIconToLink(SettingIcon)}
         </IconContainer>
       </CustomtHeader>
     </>

--- a/client/src/components/profile/profile-header.tsx
+++ b/client/src/components/profile/profile-header.tsx
@@ -31,8 +31,7 @@ const IconContainer = styled.div`
     filter: invert(88%) sepia(1%) saturate(4121%) hue-rotate(12deg) brightness(62%) contrast(79%);
   }
 `;
-function ProfileHeader({ match }: RouteComponentProps<{id: string}>) {
-  const BackIcon: IconAndLink = { Component: MdOutlineArrowBackIos, link: '/', key: 'main' };
+function ProfileHeader({ match, history }: RouteComponentProps<{id: string}>) {
   const SettingIcon: IconAndLink = { Component: MdSettings, link: '/settings', key: 'setting' };
   const user = useRecoilValue(userState);
   const setIsOpenModal = useSetRecoilState(isOpenShareModalState);
@@ -44,7 +43,7 @@ function ProfileHeader({ match }: RouteComponentProps<{id: string}>) {
   return (
     <>
       <CustomtHeader>
-        {makeIconToLink(BackIcon)}
+        <MdOutlineArrowBackIos onClick={() => history.goBack()} size={48} />
         <HeaderTitleNunito>
           Profile
         </HeaderTitleNunito>

--- a/client/src/hooks/useIsFollowingRef.tsx
+++ b/client/src/hooks/useIsFollowingRef.tsx
@@ -1,0 +1,39 @@
+/* eslint-disable max-len */
+/* eslint-disable no-unused-expressions */
+import react, { useCallback, useRef } from 'react';
+import { useRecoilState } from 'recoil';
+
+import followingListState from '@src/recoil/atoms/following-list';
+
+const useIsFollowingRef = (setLoading: React.Dispatch<React.SetStateAction<boolean>>, isFollowDafult?: boolean)
+  : [react.MutableRefObject<boolean | undefined>, (isFollow: boolean, targetUserDocumentId: string) => void] => {
+  const isFollowingRef = useRef<boolean>(isFollowDafult as boolean);
+  const [followingList, setFollowingList] = useRecoilState(followingListState);
+
+  const fetchFollow = useCallback((isFollow: boolean, targetUserDocumentId: string) => {
+    setLoading(true);
+    const type = isFollow ? 'unfollow' : 'follow';
+    fetch(`${process.env.REACT_APP_API_URL}/api/user/follow`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      credentials: 'include',
+      body: JSON.stringify({ type, targetUserDocumentId }),
+    }).then((res) => res.json())
+      .then((json) => {
+        if (json.ok) {
+          isFollowingRef.current
+            ? setFollowingList((followList) => followList.filter((id) => id !== targetUserDocumentId))
+            : setFollowingList((followList) => [...followList, targetUserDocumentId]);
+          isFollowingRef.current = !isFollowingRef.current;
+        }
+        console.log(followingList);
+        setLoading(false);
+      });
+  }, [isFollowingRef.current]);
+
+  return [isFollowingRef, fetchFollow];
+};
+
+export default useIsFollowingRef;

--- a/client/src/routes/header.tsx
+++ b/client/src/routes/header.tsx
@@ -8,6 +8,8 @@ import InviteHeader from '@components/invite-header';
 import RecentSearchHeader from '@components/search/recent-search-header';
 import SearchHeader from '@components/search/search-header';
 import ProfileHeader from '@components/profile/profile-header';
+import FollowingHeader from '@components/profile/following-header';
+import FollowersHeader from '@components/profile/followers-header';
 
 function HeaderRouter() {
   return (
@@ -19,6 +21,8 @@ function HeaderRouter() {
       <Route exact path="/event" component={EventHeader} />
       <Route exact path="/invite" component={InviteHeader} />
       <Route exact path="/profile/:id" component={ProfileHeader} />
+      <Route exact path="/following/:id" component={FollowingHeader} />
+      <Route exact path="/followers/:id" component={FollowersHeader} />
       <Route path="/" component={DefaultHeader} />
     </Switch>
   );

--- a/client/src/views/followers-view.tsx
+++ b/client/src/views/followers-view.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import React, { useEffect, useState } from 'react';
+import { RouteComponentProps } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 
 import LoadingSpinner from '@common/loading-spinner';
@@ -8,30 +9,32 @@ import followingListState from '@atoms/following-list';
 import UserCard from '@common/user-card';
 import userState from '@atoms/user';
 
-function FollowerView({ match }:any) {
+interface IUserForCard{
+  _id: string,
+  userName: string,
+  userId: string,
+  description: string,
+  profileUrl: string,
+  isFollow?: boolean,
+}
+
+function FollowerView({ match }: RouteComponentProps<{id: string}>) {
   const userId = match.params.id;
-  const [nowItemList, nowItemType] = useFetchItems<any>(`/user/followers/${userId}`, 'followers');
+  const [nowItemList, nowItemType] = useFetchItems<Required<IUserForCard>>(`/user/followers/${userId}`, 'followers');
   const [loading, setLoading] = useState(true);
   const myFollowingList = useRecoilValue(followingListState);
   const user = useRecoilValue(userState);
 
-  const makeUserObjectIncludedIsFollow = (
-    userItem: {
-      _id: string,
-      userName:
-      string,
-      description: string,
-      profileUrl: string
-    },
-  ) => ({
+  const makeUserObjectIncludedIsFollow = (userItem: Required<IUserForCard>): IUserForCard => ({
     _id: userItem._id,
     userName: userItem.userName,
+    userId: userItem.userId,
     description: userItem.description,
     profileUrl: userItem.profileUrl,
     isFollow: !!myFollowingList.includes(userItem._id),
   });
 
-  const makeItemToCardForm = (item: any) => {
+  const makeItemToCardForm = (item: Required<IUserForCard>) => {
     const newUserItemForm = makeUserObjectIncludedIsFollow(item);
     if (newUserItemForm._id === user.userDocumentId) {
       return (

--- a/client/src/views/following-view.tsx
+++ b/client/src/views/following-view.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable no-underscore-dangle */
+/* eslint-disable  */
 import React, { useEffect, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 
@@ -8,30 +8,32 @@ import followingListState from '@atoms/following-list';
 import UserCard from '@common/user-card';
 import userState from '@atoms/user';
 
-function FollowingView({ match }:any) {
+interface IUserForCard{
+  _id: string,
+  userName: string,
+  userId: string,
+  description: string,
+  profileUrl: string,
+  isFollow?: boolean,
+}
+
+function FollowingView({ match }: any) {
   const userId = match.params.id;
-  const [nowItemList, nowItemType] = useFetchItems<any>(`/user/followings/${userId}`, 'followings');
+  const [nowItemList, nowItemType] = useFetchItems<Required<IUserForCard>>(`/user/followings/${userId}`, 'followings');
   const [loading, setLoading] = useState(true);
   const myFollowingList = useRecoilValue(followingListState);
   const user = useRecoilValue(userState);
 
-  const makeUserObjectIncludedIsFollow = (
-    userItem: {
-      _id: string,
-      userName:
-      string,
-      description: string,
-      profileUrl: string
-    },
-  ) => ({
+  const makeUserObjectIncludedIsFollow = (userItem: Required<IUserForCard>): IUserForCard => ({
     _id: userItem._id,
     userName: userItem.userName,
+    userId: match as string,
     description: userItem.description,
     profileUrl: userItem.profileUrl,
     isFollow: !!myFollowingList.includes(userItem._id),
   });
 
-  const makeItemToCardForm = (item: any) => {
+  const makeItemToCardForm = (item: Required<IUserForCard>) => {
     const newUserItemForm = makeUserObjectIncludedIsFollow(item);
     if (newUserItemForm._id === user.userDocumentId) {
       return (
@@ -50,7 +52,7 @@ function FollowingView({ match }:any) {
         key={newUserItemForm._id}
         cardType="follow"
         userData={newUserItemForm}
-      />
+        />
     );
   };
 

--- a/client/src/views/main-view.tsx
+++ b/client/src/views/main-view.tsx
@@ -40,6 +40,7 @@ const SectionLayout = styled.div`
 `;
 
 const ActiveFollowingLayout = styled.div`
+  height: 80vh;
   flex-grow: 1;
   margin: 10px;
   @media (max-width: 1024px) {
@@ -53,16 +54,17 @@ const MainSectionLayout = styled.div`
   min-width: 360px;
   flex-grow: 3;
   margin: 10px;
-
 `;
 
 const MainScrollSection = styled.div`
+  position: relative;
   width: 100%;
   height: 100%;
   ${ScrollBarStyle};
 `;
 
 const RoomLayout = styled.div`
+  height: 80vh;
   flex-grow: 2;
   margin: 10px;
 `;

--- a/client/src/views/profile-view.tsx
+++ b/client/src/views/profile-view.tsx
@@ -119,6 +119,7 @@ function ProfileView() {
   const profileId = paths[1];
 
   useEffect(() => {
+    setLoading(true);
     const getUserDetail = async () => {
       const result = await fetch(`${process.env.REACT_APP_API_URL}/api/user/${profileId}?type=userId`).then((res) => res.json());
       if (result.ok) {
@@ -129,7 +130,7 @@ function ProfileView() {
     };
 
     getUserDetail();
-  }, [isFollowingRef.current]);
+  }, [isFollowingRef.current, profileId]);
 
   if (loading) {
     return <LoadingSpinner />;

--- a/client/src/views/profile-view.tsx
+++ b/client/src/views/profile-view.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable */
-import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { useLocation, Link } from 'react-router-dom';
+import React, { useEffect, useRef, useState } from 'react';
+import { Link, RouteComponentProps } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
@@ -10,8 +10,6 @@ import LoadingSpinner from '@common/loading-spinner';
 import DefaultButton from '@common/default-button';
 import useIsFollowingRef from '@hooks/useIsFollowingRef';
 import scrollbarStyle from '@styles/scrollbar-style';
-
-const idRegex = /\/profile\/(.*)/;
 
 const ProfileViewLayout = styled.div`
   position:relative;
@@ -103,20 +101,18 @@ const makeDateToJoinDate = (dateString: string) => {
   return `${date.getMonth()+1}월 ${date.getDate()}, ${date.getFullYear()}`
 }
 
-function ProfileView() {
+function ProfileView({ match }: RouteComponentProps<{id: string}>) {
   const user = useRecoilValue(userState);
   const followingList = useRecoilValue(followingListState)
-  const location = useLocation();
-  const paths = location.pathname.match(idRegex);
   const [loading, setLoading] = useState(true);
   const userDetailInfo = useRef<IUserDetail>();
   const [isFollowingRef, fetchFollow] = useIsFollowingRef(setLoading);
 
-  if (!paths) {
+  if (!match) {
     return <div>존재하지 않는 사용자입니다.</div>;
   }
 
-  const profileId = paths[1];
+  const profileId = match.params.id;
 
   useEffect(() => {
     setLoading(true);

--- a/client/src/views/search-view.tsx
+++ b/client/src/views/search-view.tsx
@@ -106,14 +106,15 @@ function SearchView() {
   const makeUserObjectIncludedIsFollow = (
     userItem: {
       _id: string,
-      userName:
-      string,
+      userName: string,
+      userId: string,
       description: string,
       profileUrl: string
     },
   ) => ({
     _id: userItem._id,
     userName: userItem.userName,
+    userId: userItem.userId,
     description: userItem.description,
     profileUrl: userItem.profileUrl,
     isFollow: !!followingList.includes(userItem._id),

--- a/server/src/api/routes/user.ts
+++ b/server/src/api/routes/user.ts
@@ -34,7 +34,7 @@ export default (app: Router) => {
       res.status(200).json({ ok: true, userInfo });
     } else if (type === 'userId') {
       const userInfo = await usersService.findUserByUserId(id);
-      const userDetailInfo = userInfo && usersService.makeUserDetailInterface(userInfo);
+      const userDetailInfo = userInfo ? usersService.makeUserDetailInterface(userInfo) : res.json({ ok: false });
       res.json({ ok: true, userDetailInfo });
     } else {
       res.json({ ok: false });

--- a/server/src/services/users-service.ts
+++ b/server/src/services/users-service.ts
@@ -204,7 +204,7 @@ class UserService {
       const query = new RegExp(keyword, 'i');
       const res = await Users.find({
         $or: [{ userId: query }, { userName: query }, { description: query }],
-      }, ['userName', 'description', 'profileUrl']).sort({ date: 1 }).skip(count).limit(10);
+      }).sort({ date: 1 }).skip(count).limit(10);
       return res;
     } catch (e) {
       console.error(e);
@@ -240,7 +240,7 @@ class UserService {
 
   async findUsersById(documentIdList: Array<string>) {
     try {
-      const participantsInfo = Users.find({ _id: { $in: documentIdList } }, ['userId', 'userName', 'profileUrl', 'description']);
+      const participantsInfo = Users.find({ _id: { $in: documentIdList } });
       return participantsInfo;
     } catch (e) {
       console.log(e);


### PR DESCRIPTION
## 개요
- 팔로우 기능, 관련 기타 기능 구현
-  #98
## 작업사항
- 프로필 뷰에서 팔로우 기능이 활성화 되었습니다.
- Room에서 사용자의 프로필을 클릭하면서 이동하면 생기던 버그를 수정했습니다.
- 아이템들의 hover 스타일을 추가해줬습니다.
- userCard에서 userId를 보여주도록 하였습니다.
- userCard를 클릭하면 프로필 화면으로 이동합니다. (채팅에서는 제외)
- 프로필 화면에서 뒤로가기 버튼을 기존 "홈으로 이동" 에서 "뒤로 가기" 로 변경했습니다. (팔로우 페이지도 동일)

## 변경 후

![팔로우](https://user-images.githubusercontent.com/74816327/142457521-c58d515a-dac8-423c-b117-57eb4c357c1a.gif)


