### PR TITLE
🐛  refreshToken으로 accessToken이 갱신되지 않는 오류 해결

### DIFF
--- a/server/src/api/middlewares/auth.ts
+++ b/server/src/api/middlewares/auth.ts
@@ -24,9 +24,8 @@ const authJWT = async (req:Request, res:Response, next:NextFunction) => {
         next();
       }
     }
-  }
-  else {
-    res.json({ ok: false })
+  } else {
+    res.json({ ok: false });
   }
 };
 

--- a/server/src/models/refresh-token.ts
+++ b/server/src/models/refresh-token.ts
@@ -2,12 +2,12 @@
 import { Schema, Document, model } from 'mongoose';
 
 export interface IRefreshTokenTypesModel extends Document{
-  userId: String,
+  userDocumentId: String,
   token: String,
 }
 
 const refreshTokenSchema = new Schema({
-  userId: String,
+  userDocumentId: String,
   token: String,
 });
 

--- a/server/src/services/users-service.ts
+++ b/server/src/services/users-service.ts
@@ -39,15 +39,14 @@ class UserService {
       const accessToken = jwtUtils.sign(user._id, user.userEmail);
       const refreshToken = jwtUtils.refresh();
 
-      // tokenService를 따로 만들어줘야하는가?
       const existingRefreshToken = await RefreshTokens.findOneAndUpdate(
-        { user_id: user._id },
+        { userDocumentId: user._id },
         { token: refreshToken },
       );
 
       if (!existingRefreshToken) {
         const usersRefreshTokens = new RefreshTokens({
-          user_id: user._id,
+          userDocumentId: user._id,
           token: refreshToken,
         });
         await usersRefreshTokens.save();
@@ -89,8 +88,8 @@ class UserService {
     return result;
   }
 
-  async getRefreshTokens(userId: string) {
-    const refreshToken = await RefreshTokens.findOne({ userId });
+  async getRefreshTokens(userDocumentId: string) {
+    const refreshToken = await RefreshTokens.findOne({ userDocumentId });
     if (!refreshToken) {
       return null;
     }
@@ -126,6 +125,7 @@ class UserService {
         userDocumentId: decoded.id,
       };
     }
+
     return {
       ok: true,
       msg: 'Acess token is not expired!',

--- a/server/src/utils/jwt-util.ts
+++ b/server/src/utils/jwt-util.ts
@@ -32,6 +32,7 @@ export default {
     algorithm: 'HS256',
     expiresIn: '14d',
   }),
+
   refreshVerify: async (token : string) => {
     try {
       jwt.verify(token, process.env.SECRET as string);


### PR DESCRIPTION
## 개요
🐛  refreshToken으로 accessToken이 갱신되지 않는 오류 해결

## 변경로직
일부 로직에서 userDocumentId 대신 userId를 사용했고, db에는 userId가, 찾는 로직에는 userDocumentId가 사용되어 일치한느 값을 찾지 못하고 있었습니다.
refreshToken 관련 id를 userDocumentId로 통일해주었습니다.

