### PR TITLE
[리팩토링] intersection observer 적용, itemFetch로직 수정

### DIFF
--- a/client/src/components/common/default-header.tsx
+++ b/client/src/components/common/default-header.tsx
@@ -11,7 +11,7 @@ import {
 
 import { makeIconToLink } from '@utils/index';
 import userState from '@atoms/user';
-import { nowFetchingState, nowItemsListState } from '@src/recoil/atoms/main-section-scroll';
+import { nowCountState, nowFetchingState, nowItemsListState } from '@atoms/main-section-scroll';
 import isOpenSliderMenuState from '@atoms/is-open-slider-menu';
 import isOpenRoomState from '@atoms/is-open-room';
 import SliderMenu from '@common/menu-modal';
@@ -98,6 +98,7 @@ function DefaultHeader() {
   const resetNowItemsList = useResetRecoilState(nowItemsListState);
   const [isOpenMenu, setIsOpenMenu] = useRecoilState(isOpenSliderMenuState);
   const [isOpenRoom, setIsOpenRoom] = useRecoilState(isOpenRoomState);
+  const setNowCount = useSetRecoilState(nowCountState);
 
   const leftSideIcons: IconAndLink[] = [
     { Component: HiSearch, link: '/search', key: 'search' },
@@ -111,7 +112,7 @@ function DefaultHeader() {
   return (
     <>
       <CustomDefaultHeader>
-        <LogoTitle to="/" onClick={() => { resetNowItemsList(); setNowFetching(true); }}> NogariHouse </LogoTitle>
+        <LogoTitle to="/" onClick={() => { resetNowItemsList(); setNowCount(0); setNowFetching(true); }}> NogariHouse </LogoTitle>
         <OpenMenuButton onClick={() => { setIsOpenMenu(!isOpenMenu); }}>Menu</OpenMenuButton>
         <OpenRoomStateButton onClick={() => { setIsOpenRoom(!isOpenRoom); }}>
           Room

--- a/client/src/hooks/useFetchItems.tsx
+++ b/client/src/hooks/useFetchItems.tsx
@@ -1,21 +1,6 @@
 import { nowCountState, nowFetchingState, nowItemsListState } from '@src/recoil/atoms/main-section-scroll';
-import { RefObject, useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useRecoilState, useResetRecoilState } from 'recoil';
-
-export const useCountRef = (): [RefObject<number>, Function, Function] => {
-  const countRef = useRef(0);
-
-  const resetCount = () => {
-    console.log('reset');
-    countRef.current = 0;
-    console.log(countRef.current);
-  };
-  const updateCountRef = (newItemsList: []) => {
-    countRef.current += Math.min(newItemsList.length, 10);
-  };
-
-  return [countRef, resetCount, updateCountRef];
-};
 
 const useFetchItems = <T extends {}>(apiPath : string, nowItemType: string)
 : [T[], string] => {

--- a/client/src/hooks/useFetchItems.tsx
+++ b/client/src/hooks/useFetchItems.tsx
@@ -1,34 +1,57 @@
-import { nowFetchingState, nowItemsListState } from '@src/recoil/atoms/main-section-scroll';
-import { useEffect, useRef } from 'react';
+import { nowCountState, nowFetchingState, nowItemsListState } from '@src/recoil/atoms/main-section-scroll';
+import { RefObject, useEffect, useRef } from 'react';
 import { useRecoilState, useResetRecoilState } from 'recoil';
 
-const useFetchItems = <T extends {}>(apiPath : string, nowItemType: string): [T[], string] => {
+export const useCountRef = (): [RefObject<number>, Function, Function] => {
+  const countRef = useRef(0);
+
+  const resetCount = () => {
+    console.log('reset');
+    countRef.current = 0;
+    console.log(countRef.current);
+  };
+  const updateCountRef = (newItemsList: []) => {
+    countRef.current += Math.min(newItemsList.length, 10);
+  };
+
+  return [countRef, resetCount, updateCountRef];
+};
+
+const useFetchItems = <T extends {}>(apiPath : string, nowItemType: string)
+: [T[], string] => {
   const [nowItemsList, setNowItemsList] = useRecoilState(nowItemsListState);
   const [nowFetching, setNowFetching] = useRecoilState(nowFetchingState);
   const resetItemList = useResetRecoilState(nowItemsListState);
   const nowItemTypeRef = useRef<string>('');
+  const [nowCount, setNowCount] = useRecoilState(nowCountState);
 
   useEffect(() => {
     resetItemList();
+    setNowCount(0);
     setNowFetching(true);
 
-    return () => resetItemList();
+    return () => {
+      resetItemList();
+      setNowCount(0);
+    };
   }, []);
 
   useEffect(() => {
     if (nowFetching) {
       const fetchItems = async () => {
         try {
-          const newItemsList = await fetch(`${process.env.REACT_APP_API_URL}/api${apiPath}?count=${nowItemsList.length}`)
+          const newItemsList = await fetch(`${process.env.REACT_APP_API_URL}/api${apiPath}?count=${nowCount}`)
             .then((res) => res.json())
             .then((json) => json.items);
           setNowItemsList([...nowItemsList, ...newItemsList]);
           nowItemTypeRef.current = nowItemType;
+          setNowCount((count) => count + Math.min(newItemsList.length, 10));
+          setNowFetching(false);
         } catch (e) {
           console.log(e);
         }
       };
-      fetchItems().then(() => setNowFetching(false));
+      fetchItems();
     }
   }, [nowFetching]);
 

--- a/client/src/hooks/useItemFetchObserver.tsx
+++ b/client/src/hooks/useItemFetchObserver.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useRef } from 'react';
+import { RefObject, useEffect, useRef } from 'react';
 import { useRecoilState } from 'recoil';
 
 import { nowFetchingState } from '@atoms/main-section-scroll';
 
-const useItemFecthObserver = (loading: boolean) => {
+const useItemFecthObserver = (loading: boolean): [RefObject<HTMLDivElement>] => {
   const [nowFetching, setNowFetching] = useRecoilState(nowFetchingState);
   const targetRef = useRef<HTMLDivElement>(null);
 

--- a/client/src/hooks/useItemFetchObserver.tsx
+++ b/client/src/hooks/useItemFetchObserver.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useRef } from 'react';
+import { useRecoilState } from 'recoil';
+
+import { nowFetchingState } from '@atoms/main-section-scroll';
+
+const useItemFecthObserver = (loading: boolean) => {
+  const [nowFetching, setNowFetching] = useRecoilState(nowFetchingState);
+  const targetRef = useRef<HTMLDivElement>(null);
+
+  const onIntersect = async (entries: IntersectionObserverEntry[]) => {
+    if (entries[0].isIntersecting && !nowFetching) {
+      setNowFetching(true);
+    }
+  };
+
+  useEffect(() => {
+    let observer: IntersectionObserver;
+    console.log(targetRef.current);
+    if (targetRef.current) {
+      observer = new IntersectionObserver(onIntersect, {
+        threshold: 0.4,
+      });
+      observer.observe(targetRef.current);
+    }
+    return () => observer?.disconnect();
+  }, [targetRef.current, loading]);
+
+  return [targetRef];
+};
+
+export default useItemFecthObserver;

--- a/client/src/hooks/useItemFetchObserver.tsx
+++ b/client/src/hooks/useItemFetchObserver.tsx
@@ -15,7 +15,6 @@ const useItemFecthObserver = (loading: boolean) => {
 
   useEffect(() => {
     let observer: IntersectionObserver;
-    console.log(targetRef.current);
     if (targetRef.current) {
       observer = new IntersectionObserver(onIntersect, {
         threshold: 0.4,

--- a/client/src/interfaces/index.ts
+++ b/client/src/interfaces/index.ts
@@ -1,0 +1,8 @@
+export interface IUserForCard{
+    _id: string,
+    userName: string,
+    userId: string,
+    description: string,
+    profileUrl: string,
+    isFollow?: boolean,
+  }

--- a/client/src/recoil/atoms/main-section-scroll.ts
+++ b/client/src/recoil/atoms/main-section-scroll.ts
@@ -9,3 +9,8 @@ export const nowItemsListState = atom<any[]>({ // any대신 item들의 타입이
   key: 'nowItemsCountState',
   default: [],
 });
+
+export const nowCountState = atom<number>({
+  key: 'nowCountState',
+  default: 0,
+});

--- a/client/src/views/event-view.tsx
+++ b/client/src/views/event-view.tsx
@@ -2,13 +2,16 @@
 import React, {
   MouseEvent, useEffect, useState,
 } from 'react';
+import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
-import useFetchItems from '@src/hooks/useFetchItems';
-import { makeDateToHourMinute } from '@src/utils';
+import { nowFetchingState } from '@atoms/main-section-scroll';
 import EventCard from '@common/event-card';
 import LoadingSpinner from '@common/loading-spinner';
+import useFetchItems from '@hooks/useFetchItems';
+import useItemFecthObserver from '@hooks/useItemFetchObserver';
 import useSetEventModal from '@hooks/useSetEventModal';
+import { makeDateToHourMinute } from '@src/utils';
 
 interface EventUser {
   userId: string,
@@ -30,6 +33,12 @@ const EventDiv = styled.div`
  }
 `;
 
+const ObserverBlock = styled.div`
+  position: relative;
+  width: 100%;
+  height: 100px;
+`;
+
 export const makeEventToCard = (event: EventCardProps) => (
   <EventCard
     key={event.key}
@@ -47,6 +56,8 @@ export function EventCardList({ eventList, setEventModal }: { eventList: EventCa
 function EventView() {
   const [nowItemList, nowItemType] = useFetchItems<EventCardProps>('/event', 'event');
   const [loading, setLoading] = useState(true);
+  const nowFetching = useRecoilValue(nowFetchingState);
+  const [targetRef] = useItemFecthObserver(loading);
   const setEventModal = useSetEventModal();
 
   useEffect(() => {
@@ -62,6 +73,9 @@ function EventView() {
   return (
     <>
       <EventCardList setEventModal={setEventModal} eventList={nowItemList} />
+      <ObserverBlock ref={targetRef}>
+        {nowFetching && <LoadingSpinner />}
+      </ObserverBlock>
     </>
   );
 }

--- a/client/src/views/event-view.tsx
+++ b/client/src/views/event-view.tsx
@@ -50,7 +50,7 @@ export const makeEventToCard = (event: EventCardProps) => (
 );
 
 export function EventCardList({ eventList, setEventModal }: { eventList: EventCardProps[], setEventModal: ((e: MouseEvent) => void) }) {
-  return <EventDiv onClick={setEventModal}>{eventList?.map(makeEventToCard)}</EventDiv>;
+  return <EventDiv onClick={setEventModal}>{eventList.map(makeEventToCard)}</EventDiv>;
 }
 
 function EventView() {

--- a/client/src/views/followers-view.tsx
+++ b/client/src/views/followers-view.tsx
@@ -8,15 +8,7 @@ import useFetchItems from '@src/hooks/useFetchItems';
 import followingListState from '@atoms/following-list';
 import UserCard from '@common/user-card';
 import userState from '@atoms/user';
-
-interface IUserForCard{
-  _id: string,
-  userName: string,
-  userId: string,
-  description: string,
-  profileUrl: string,
-  isFollow?: boolean,
-}
+import { IUserForCard } from '@src/interfaces';
 
 function FollowerView({ match }: RouteComponentProps<{id: string}>) {
   const userId = match.params.id;
@@ -26,11 +18,7 @@ function FollowerView({ match }: RouteComponentProps<{id: string}>) {
   const user = useRecoilValue(userState);
 
   const makeUserObjectIncludedIsFollow = (userItem: Required<IUserForCard>): IUserForCard => ({
-    _id: userItem._id,
-    userName: userItem.userName,
-    userId: userItem.userId,
-    description: userItem.description,
-    profileUrl: userItem.profileUrl,
+    ...userItem,
     isFollow: !!myFollowingList.includes(userItem._id),
   });
 

--- a/client/src/views/following-view.tsx
+++ b/client/src/views/following-view.tsx
@@ -7,15 +7,7 @@ import useFetchItems from '@src/hooks/useFetchItems';
 import followingListState from '@atoms/following-list';
 import UserCard from '@common/user-card';
 import userState from '@atoms/user';
-
-interface IUserForCard{
-  _id: string,
-  userName: string,
-  userId: string,
-  description: string,
-  profileUrl: string,
-  isFollow?: boolean,
-}
+import { IUserForCard } from '@src/interfaces';
 
 function FollowingView({ match }: any) {
   const userId = match.params.id;
@@ -25,11 +17,7 @@ function FollowingView({ match }: any) {
   const user = useRecoilValue(userState);
 
   const makeUserObjectIncludedIsFollow = (userItem: Required<IUserForCard>): IUserForCard => ({
-    _id: userItem._id,
-    userName: userItem.userName,
-    userId: match as string,
-    description: userItem.description,
-    profileUrl: userItem.profileUrl,
+    ...userItem,
     isFollow: !!myFollowingList.includes(userItem._id),
   });
 

--- a/client/src/views/main-view.tsx
+++ b/client/src/views/main-view.tsx
@@ -1,8 +1,6 @@
 import React, {
-  UIEvent,
   useCallback,
   useEffect,
-  useRef,
   useState,
 } from 'react';
 import {
@@ -12,7 +10,6 @@ import { useCookies } from 'react-cookie';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { nowFetchingState } from '@atoms/main-section-scroll';
 import userState from '@atoms/user';
 import followingListState from '@atoms/following-list';
 import LargeLogo from '@components/sign/large-logo';
@@ -101,24 +98,9 @@ function MainView() {
   const setFollowingList = useSetRecoilState(followingListState);
   const resetUser = useResetRecoilState(userState);
   const [loading, setLoading] = useState(true);
-  const setNowFetching = useSetRecoilState(nowFetchingState);
-  const nowFetchingRef = useRef<boolean>(false);
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [cookies, setCookie] = useCookies(['accessToken']);
   const isOpenRoom = useRecoilValue(isOpenRoomState);
-
-  const scrollBarChecker = useCallback((e: UIEvent<HTMLDivElement>) => {
-    if (!nowFetchingRef.current) {
-      const diff = e.currentTarget.scrollHeight - e.currentTarget.scrollTop;
-      if (diff < 700) {
-        setNowFetching(true);
-        nowFetchingRef.current = true;
-        setTimeout(() => {
-          nowFetchingRef.current = false;
-        }, 200);
-      }
-    }
-  }, []);
 
   const updateUserState = useCallback(async (json) => {
     const {
@@ -165,7 +147,7 @@ function MainView() {
             <LeftSideBar />
           </ActiveFollowingLayout>
           <MainSectionLayout>
-            <MainScrollSection onScroll={scrollBarChecker}>
+            <MainScrollSection>
               <MainRouter />
             </MainScrollSection>
           </MainSectionLayout>

--- a/client/src/views/room-view.tsx
+++ b/client/src/views/room-view.tsx
@@ -1,16 +1,17 @@
 /* eslint-disable max-len */
 /* eslint-disable no-underscore-dangle */
 import React, {
-  MouseEvent, useEffect, useRef, useState,
+  MouseEvent, useEffect, useState,
 } from 'react';
 import styled from 'styled-components';
-import { useRecoilState, useSetRecoilState } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import RoomCard from '@common/room-card';
 import useFetchItems from '@src/hooks/useFetchItems';
 import LoadingSpinner from '@common/loading-spinner';
 import roomViewType from '@atoms/room-view-type';
 import roomDocumentIdState from '@atoms/room-document-id';
+import useItemFecthObserver from '@src/hooks/useItemFetchObserver';
 import { nowFetchingState } from '@src/recoil/atoms/main-section-scroll';
 
 interface Participants{
@@ -57,9 +58,9 @@ export function RoomCardList({ roomList, roomCardClickHandler }:
 
 function RoomView() {
   const [nowItemList, nowItemType] = useFetchItems<RoomCardProps>('/room', 'room');
-  const [nowFetching, setNowFetching] = useRecoilState(nowFetchingState);
-  const targetRef = useRef<HTMLDivElement>(null);
+  const nowFetching = useRecoilValue(nowFetchingState);
   const [loading, setLoading] = useState(true);
+  const [targetRef] = useItemFecthObserver(loading);
   const setRoomView = useSetRecoilState(roomViewType);
   const setRoomDocumentId = useSetRecoilState(roomDocumentIdState);
 
@@ -70,23 +71,6 @@ function RoomView() {
     if (roomDocumentId) setRoomDocumentId(roomDocumentId);
     else console.error('no room-id');
   };
-
-  const onIntersect = async (entries: IntersectionObserverEntry[]) => {
-    if (entries[0].isIntersecting && !nowFetching) {
-      setNowFetching(true);
-    }
-  };
-
-  useEffect(() => {
-    let observer: IntersectionObserver;
-    if (targetRef.current) {
-      observer = new IntersectionObserver(onIntersect, {
-        threshold: 0.4,
-      });
-      observer.observe(targetRef.current);
-    }
-    return () => observer?.disconnect();
-  }, [targetRef.current, loading]);
 
   useEffect(() => {
     if (nowItemList && nowItemType === 'room') {

--- a/client/src/views/room-view.tsx
+++ b/client/src/views/room-view.tsx
@@ -6,13 +6,13 @@ import React, {
 import styled from 'styled-components';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 
-import RoomCard from '@common/room-card';
-import useFetchItems from '@src/hooks/useFetchItems';
-import LoadingSpinner from '@common/loading-spinner';
 import roomViewType from '@atoms/room-view-type';
 import roomDocumentIdState from '@atoms/room-document-id';
-import useItemFecthObserver from '@src/hooks/useItemFetchObserver';
-import { nowFetchingState } from '@src/recoil/atoms/main-section-scroll';
+import { nowFetchingState } from '@atoms/main-section-scroll';
+import LoadingSpinner from '@common/loading-spinner';
+import RoomCard from '@common/room-card';
+import useFetchItems from '@hooks/useFetchItems';
+import useItemFecthObserver from '@hooks/useItemFetchObserver';
 
 interface Participants{
   _id: string,
@@ -58,8 +58,8 @@ export function RoomCardList({ roomList, roomCardClickHandler }:
 
 function RoomView() {
   const [nowItemList, nowItemType] = useFetchItems<RoomCardProps>('/room', 'room');
-  const nowFetching = useRecoilValue(nowFetchingState);
   const [loading, setLoading] = useState(true);
+  const nowFetching = useRecoilValue(nowFetchingState);
   const [targetRef] = useItemFecthObserver(loading);
   const setRoomView = useSetRecoilState(roomViewType);
   const setRoomDocumentId = useSetRecoilState(roomDocumentIdState);

--- a/client/src/views/search-view.tsx
+++ b/client/src/views/search-view.tsx
@@ -26,6 +26,7 @@ import userState from '@atoms/user';
 import UserCard from '@common/user-card';
 import useItemFecthObserver from '@src/hooks/useItemFetchObserver';
 import useFetchItems from '@src/hooks/useFetchItems';
+import { IUserForCard } from '@src/interfaces';
 
 const ObserverBlock = styled.div`
   position: relative;
@@ -79,20 +80,8 @@ function SearchView() {
     else console.error('no room-id');
   };
 
-  const makeUserObjectIncludedIsFollow = (
-    userItem: {
-      _id: string,
-      userName: string,
-      userId: string,
-      description: string,
-      profileUrl: string
-    },
-  ) => ({
-    _id: userItem._id,
-    userName: userItem.userName,
-    userId: userItem.userId,
-    description: userItem.description,
-    profileUrl: userItem.profileUrl,
+  const makeUserObjectIncludedIsFollow = (userItem: Required<IUserForCard>): IUserForCard => ({
+    ...userItem,
     isFollow: !!followingList.includes(userItem._id),
   });
 

--- a/client/src/views/search-view.tsx
+++ b/client/src/views/search-view.tsx
@@ -2,13 +2,14 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 import React, {
-  useRef, useCallback, UIEvent, useEffect, useState, MouseEvent,
+  useRef, useEffect, useState, MouseEvent,
 } from 'react';
 import {
   useRecoilState, useRecoilValue, useResetRecoilState, useSetRecoilState,
 } from 'recoil';
+import styled from 'styled-components';
 
-import { nowFetchingState, nowItemsListState } from '@atoms/main-section-scroll';
+import { nowCountState, nowFetchingState, nowItemsListState } from '@atoms/main-section-scroll';
 import searchTypeState from '@atoms/search-type';
 import OptionBar from '@components/search/option-bar';
 import {
@@ -23,40 +24,35 @@ import roomDocumentIdState from '@atoms/room-document-id';
 import followingListState from '@atoms/following-list';
 import userState from '@atoms/user';
 import UserCard from '@common/user-card';
+import useItemFecthObserver from '@src/hooks/useItemFetchObserver';
+import useFetchItems from '@src/hooks/useFetchItems';
+
+const ObserverBlock = styled.div`
+  position: relative;
+  width: 100%;
+  height: 100px;
+`;
 
 function SearchView() {
   const searchType = useRecoilValue(searchTypeState);
   const inputKeywordRef = useRef<HTMLInputElement>(null);
-  const nowFetchingRef = useRef<boolean>(false);
   const [loading, setLoading] = useState(true);
-  const [searchDataCount, setSearchDataCount] = useState(0);
+  const [targetRef] = useItemFecthObserver(loading);
   const user = useRecoilValue(userState);
-  const [nowItemsList, setNowItemsList] = useRecoilState(nowItemsListState);
   const [nowFetching, setNowFetching] = useRecoilState(nowFetchingState);
   const followingList = useRecoilValue(followingListState);
   const resetItemList = useResetRecoilState(nowItemsListState);
-  const nowItemTypeRef = useRef<string>('');
   const searchInfo = useRef({ keyword: 'recent', option: 'all' });
+  const [nowItemsList, nowItemType] = useFetchItems<any>(`/search/${searchInfo.current.option}/${searchInfo.current.keyword || 'recent'}`, searchInfo.current.keyword);
+  const setNowCount = useSetRecoilState(nowCountState);
 
   const setEventModal = useSetEventModal();
-
-  const fetchItems = async () => {
-    try {
-      const newItemsList = await fetch(`${process.env.REACT_APP_API_URL}/api/search/${searchInfo.current.option}/${searchInfo.current.keyword || 'recent'}?count=${searchDataCount}`)
-        .then((res) => res.json())
-        .then((json) => json.items);
-      setNowItemsList([...nowItemsList, ...newItemsList]);
-      nowItemTypeRef.current = searchInfo.current.keyword;
-    } catch (e) {
-      console.log(e);
-    }
-  };
 
   const searchRequestHandler = () => {
     searchInfo.current.keyword = inputKeywordRef.current?.value as string;
     searchInfo.current.option = searchType.toLocaleLowerCase();
     resetItemList();
-    setSearchDataCount(0);
+    setNowCount(0);
     setNowFetching(true);
   };
 
@@ -65,30 +61,10 @@ function SearchView() {
   }, [searchType]);
 
   useEffect(() => {
-    if (nowFetching) {
-      fetchItems().then(() => setNowFetching(false));
-    }
-  }, [nowFetching]);
-
-  useEffect(() => {
-    if (nowItemsList && (nowItemTypeRef.current === 'recent' || nowItemTypeRef.current === inputKeywordRef.current?.value)) {
+    if (nowItemsList && (nowItemType === 'recent' || nowItemType === inputKeywordRef.current?.value)) {
       setLoading(false);
     } else {
       setLoading(true);
-    }
-  }, []);
-
-  const scrollBarChecker = useCallback((e: UIEvent<HTMLDivElement>) => {
-    if (!nowFetchingRef.current) {
-      const diff = e.currentTarget.scrollHeight - e.currentTarget.scrollTop;
-      if (diff < 700) {
-        setSearchDataCount(searchDataCount + 10);
-        setNowFetching(true);
-        nowFetchingRef.current = true;
-        setTimeout(() => {
-          nowFetchingRef.current = false;
-        }, 200);
-      }
     }
   }, []);
 
@@ -163,10 +139,13 @@ function SearchView() {
         {/* 너무 빨리 입력하는 경우 놓치게되어서 onChange, onKeyup을 둘 다 달았습니다..  */}
         <OptionBar />
       </SearchBarLayout>
-      <SearchScrollSection onScroll={scrollBarChecker}>
+      <SearchScrollSection>
         {loading
           ? <LoadingSpinner />
           : showList()}
+        <ObserverBlock ref={targetRef}>
+          {nowFetching && <LoadingSpinner />}
+        </ObserverBlock>
       </SearchScrollSection>
     </SearchViewLayout>
   );

--- a/client/tsconfig.path.json
+++ b/client/tsconfig.path.json
@@ -10,6 +10,7 @@
           "@common/*": [ "src/components/common/*" ], 
           "@styles/*": ["src/assets/styles/*"],
 		      "@hooks/*": [ "src/hooks/*" ],
+		      "@interfaces/*": [ "src/interfaces/*" ],
 		      "@recoil/*": [ "src/recoil/*" ],  
           "@atoms/*": [ "src/recoil/atoms/*" ],  
 		      "@selectors/*": [ "src/recoil/selectors/*" ],  


### PR DESCRIPTION
## 개요
[리팩토링] intersection observer 적용, itemFetch로직 수정

## 작업사항
- 기존 스크롤 이벤트를 통해서 구현한 무한 스크롤을 intersection observer를 이용하도록 변경
- 기존 `nowItemsList.length`  로 skip할 데이터의 크기를 API 호출 시 쿼리로 넘겨주었는데, All search 에서의 호환성을 위해서 nowCount라는 전역변수를 생성하여 nowCount에 의존하여 skip 개수를 요청하도록 변경
- interfaces 폴더를 만들었습니다. 한번에 모든 interfaces를 분리하기 보다는 구현이나 리팩토링 하면서 하나씩 공통요소를 넣어서 관리하면 좋을 것 같습니다.

기술 블로그 적어봤어요
그래도 설명이 좀 부족한 것 같은데 질문이나 개선사항 환영합니다!

https://www.notion.so/mulgyeoljung/Intersection-Observer-b44d1733e4234bf9adc105602def0588




 