### PR TITLE
💄 모바일 대응 반응형 스타일 구현

### DIFF
--- a/client/src/assets/styles/global-styles.ts
+++ b/client/src/assets/styles/global-styles.ts
@@ -26,6 +26,8 @@ const GlobalStyle = createGlobalStyle`
     font-style: normal;
     font-size: 16px;
     background-color: #F1F0E4;
+    width: 100vw;
+    min-width: 320px;
 
     overflow: hidden;
   }

--- a/client/src/assets/styles/keyframe.ts
+++ b/client/src/assets/styles/keyframe.ts
@@ -18,6 +18,15 @@ to{
 }
 `;
 
+export const slideXFromTo = (from: number, to: number) => keyframes`
+from{
+    transform: translateX(${from}px);
+}
+to{
+    transform: translateX(${to}px);
+}
+`;
+
 export const spinner = () => keyframes`
     from {transform: rotate(0deg); }
     to {transform: rotate(360deg);}

--- a/client/src/components/common/custom-inputbar.tsx
+++ b/client/src/components/common/custom-inputbar.tsx
@@ -1,16 +1,15 @@
 import styled from 'styled-components';
 
 export const CustomInputBar = styled.input`
+  font-size: min(5vw, 30px);
   border: none;
   background-color: #ffffff;
   width: 100%;
-  min-width: max-content;
   height: 60px;
   &:focus {
     outline: none;
   }
   margin: 10px;
-  font-size: 30px;
   padding: 0 30px;
   border-radius: 10px;
   box-shadow: 0 2px 2px 0 #d6d6d6;
@@ -22,6 +21,5 @@ export const CustomInputBox = styled.div`
   align-items: center;
   justify-content: space-between;
   width: 60%;
-  min-width: max-content;
   margin: 20px;
 `;

--- a/client/src/components/common/default-header.tsx
+++ b/client/src/components/common/default-header.tsx
@@ -5,17 +5,22 @@ import { IconType } from 'react-icons';
 import {
   HiOutlinePaperAirplane, HiSearch, HiOutlineMail, HiOutlineCalendar, HiOutlineBell,
 } from 'react-icons/hi';
-import { useRecoilValue, useResetRecoilState, useSetRecoilState } from 'recoil';
+import {
+  useRecoilState, useRecoilValue, useResetRecoilState, useSetRecoilState,
+} from 'recoil';
 
 import { makeIconToLink } from '@utils/index';
 import userState from '@atoms/user';
 import { nowFetchingState, nowItemsListState } from '@src/recoil/atoms/main-section-scroll';
+import isOpenSliderMenuState from '@atoms/is-open-slider-menu';
+import isOpenRoomState from '@atoms/is-open-room';
+import SliderMenu from '@common/menu-modal';
 
 const CustomDefaultHeader = styled.nav`
   position: relative;
   width: 95%;
   height: 48px;
-  padding: 24px 48px;
+  margin: 24px;
 
   display: flex;
   justify-content: space-between;
@@ -31,6 +36,19 @@ const MenuIconsLayout = styled.nav`
 
   display: flex;
   justify-content: space-between;
+`;
+
+const OpenMenuButton = styled.button`
+  @media (min-width: 1024px) {
+      display: none;
+  }
+`;
+
+const OpenRoomStateButton = styled.button`
+  margin-right: 24px;
+  @media (min-width: 768px) {
+      display: none;
+  }
 `;
 
 const IconContainer = styled.div`
@@ -51,7 +69,7 @@ const LogoTitle = styled(Link)`
   left: 47.5%;
   transform: translateX(-47.5%);
   font-family: "Bangers";
-  font-size: 48px;
+  font-size: min(8vw, 48px);
   text-decoration: none;
   color: black;
   text-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
@@ -78,6 +96,9 @@ function DefaultHeader() {
   const user = useRecoilValue(userState);
   const setNowFetching = useSetRecoilState(nowFetchingState);
   const resetNowItemsList = useResetRecoilState(nowItemsListState);
+  const [isOpenMenu, setIsOpenMenu] = useRecoilState(isOpenSliderMenuState);
+  const [isOpenRoom, setIsOpenRoom] = useRecoilState(isOpenRoomState);
+
   const leftSideIcons: IconAndLink[] = [
     { Component: HiSearch, link: '/search', key: 'search' },
     { Component: HiOutlinePaperAirplane, link: '/chat-rooms', key: 'chat' },
@@ -88,18 +109,25 @@ function DefaultHeader() {
     { Component: HiOutlineBell, link: '/activity', key: 'activity' },
   ];
   return (
-    <CustomDefaultHeader>
-      <LogoTitle to="/" onClick={() => { resetNowItemsList(); setNowFetching(true); }}> NogariHouse </LogoTitle>
-      <MenuIconsLayout>
-        <IconContainer>
-          {leftSideIcons.map(makeIconToLink)}
-        </IconContainer>
-        <IconContainer>
-          {rightSideIcons.map(makeIconToLink)}
-          <Link to={`/profile/${user.userId}`}><ImageLayout src={user.profileUrl} alt="사용자" /></Link>
-        </IconContainer>
-      </MenuIconsLayout>
-    </CustomDefaultHeader>
+    <>
+      <CustomDefaultHeader>
+        <LogoTitle to="/" onClick={() => { resetNowItemsList(); setNowFetching(true); }}> NogariHouse </LogoTitle>
+        <OpenMenuButton onClick={() => { setIsOpenMenu(!isOpenMenu); }}>Menu</OpenMenuButton>
+        <OpenRoomStateButton onClick={() => { setIsOpenRoom(!isOpenRoom); }}>
+          Room
+        </OpenRoomStateButton>
+        <MenuIconsLayout>
+          <IconContainer>
+            {leftSideIcons.map(makeIconToLink)}
+          </IconContainer>
+          <IconContainer>
+            {rightSideIcons.map(makeIconToLink)}
+            <Link to={`/profile/${user.userId}`}><ImageLayout src={user.profileUrl} alt="사용자" /></Link>
+          </IconContainer>
+        </MenuIconsLayout>
+      </CustomDefaultHeader>
+      {isOpenMenu && <SliderMenu />}
+    </>
   );
 }
 

--- a/client/src/components/common/default-header.tsx
+++ b/client/src/components/common/default-header.tsx
@@ -13,10 +13,21 @@ import { nowFetchingState, nowItemsListState } from '@src/recoil/atoms/main-sect
 
 const CustomDefaultHeader = styled.nav`
   position: relative;
-  width: calc(100%-96px);
+  width: 95%;
   height: 48px;
-  min-width: 900px;
   padding: 24px 48px;
+
+  display: flex;
+  justify-content: space-between;
+`;
+
+const MenuIconsLayout = styled.nav`
+  @media (max-width: 1024px) {
+    display: none;
+  }
+  position: relative;
+  width: 100%;
+  height: 48px;
 
   display: flex;
   justify-content: space-between;
@@ -37,8 +48,8 @@ const IconContainer = styled.div`
 
 const LogoTitle = styled(Link)`
   position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
+  left: 47.5%;
+  transform: translateX(-47.5%);
   font-family: "Bangers";
   font-size: 48px;
   text-decoration: none;
@@ -78,14 +89,16 @@ function DefaultHeader() {
   ];
   return (
     <CustomDefaultHeader>
-      <IconContainer>
-        {leftSideIcons.map(makeIconToLink)}
-      </IconContainer>
       <LogoTitle to="/" onClick={() => { resetNowItemsList(); setNowFetching(true); }}> NogariHouse </LogoTitle>
-      <IconContainer>
-        {rightSideIcons.map(makeIconToLink)}
-        <Link to={`/profile/${user.userId}`}><ImageLayout src={user.profileUrl} alt="사용자" /></Link>
-      </IconContainer>
+      <MenuIconsLayout>
+        <IconContainer>
+          {leftSideIcons.map(makeIconToLink)}
+        </IconContainer>
+        <IconContainer>
+          {rightSideIcons.map(makeIconToLink)}
+          <Link to={`/profile/${user.userId}`}><ImageLayout src={user.profileUrl} alt="사용자" /></Link>
+        </IconContainer>
+      </MenuIconsLayout>
     </CustomDefaultHeader>
   );
 }

--- a/client/src/components/common/header.tsx
+++ b/client/src/components/common/header.tsx
@@ -2,9 +2,9 @@ import styled from 'styled-components';
 
 export const CustomtHeader = styled.nav`
   position: relative;
-  width: calc(100%-96px);
+  width: 99%;
   height: 48px;
-  min-width: 360px;
+  min-width: 320px;
   padding: 24px 48px;
 
   display: flex;

--- a/client/src/components/common/header.tsx
+++ b/client/src/components/common/header.tsx
@@ -2,10 +2,10 @@ import styled from 'styled-components';
 
 export const CustomtHeader = styled.nav`
   position: relative;
-  width: 99%;
+  width: 95%;
   height: 48px;
   min-width: 320px;
-  padding: 24px 48px;
+  margin: 24px 24px;
 
   display: flex;
   justify-content: space-between;
@@ -18,10 +18,10 @@ export const CustomtHeader = styled.nav`
 export const HeaderTitleNunito = styled.div`
   position: absolute;
   line-height: 48px;
-  left: 50%;
-  transform: translateX(-50%);
+  left: 47.5%;
+  transform: translateX(-47.5%);
   font-weight: bold;
-  font-size: 32px;
+  font-size: min(4.4vw, 32px);
   text-decoration: none;
   text-align: center;
   color: black;

--- a/client/src/components/common/interest-item.tsx
+++ b/client/src/components/common/interest-item.tsx
@@ -1,17 +1,19 @@
 import { MouseEvent, useState } from 'react';
-import styeld from 'styled-components';
+import styled from 'styled-components';
 
 interface InterestItemLayoutProps {
     selected : boolean,
 }
 
-const InterestItemLayout = styeld.div`
+const InterestItemLayout = styled.div`
   color: ${(props: InterestItemLayoutProps) => (props.selected ? 'white' : 'black')};
   font-weight: ${(props) => (props.selected ? 'bold' : 'normal')};
   padding: 10px;
   background: ${(props) => (props.selected ? '#586A9A' : '#FFFFFF')};
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
   border-radius: 15px;
+  width: max-content;
+  font-size: min(3vw, 16px);
 `;
 
 interface InterestItemProps {

--- a/client/src/components/common/menu-modal.tsx
+++ b/client/src/components/common/menu-modal.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Link } from 'react-router-dom';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { slideXFromTo } from '@src/assets/styles/keyframe';
+import { BackgroundWrapper } from '@common/modal';
+
+import isOpenSliderMenuState from '@atoms/is-open-slider-menu';
+import userState from '@atoms/user';
+
+const MenuModalBox = styled.div`
+  position: fixed;
+  width: 300px;
+  height: 100vh;
+  top: 0px;
+  display: ${(props: { state : boolean}) => (props.state ? 'flex' : 'hidden')};
+  flex-direction: column;
+  justify-content: space-between;
+  background-color: #F1F0E4;
+  box-shadow: rgb(0 0 0 / 55%) 0px 10px 25px;
+  z-index: 990;
+  opacity: 1;
+  animation-duration: 0.5s;
+  animation-timing-function: ease-out;
+  animation-name: ${slideXFromTo(-300, 0)};
+  animation-fill-mode: forward;
+   ;
+`;
+
+const ProfileBox = styled.div`
+  width: 100%-20px;
+  display: flex;
+  align-items: center;
+  padding: 10px;
+  text-decoration: none;
+  color: black;
+  border-bottom: 1px solid #B6B6B6;
+
+  &:hover {
+  cursor: default;
+  background-color: #eeebe4e4;
+  box-shadow: 0px 2px 4px rgb(0 0 0 / 25%);
+  }
+`;
+
+const ProfileInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-left: 5px;
+`;
+
+const ProfileUserName = styled.div`
+  font-size: 18px;
+`;
+
+const ProfileUserId = styled.div`
+  font-weight: bold;
+`;
+
+const ImageLayout = styled.img`
+    width: 48px;
+    min-width: 48px;
+    height: 48px;
+    margin-right: 10px;
+    border-radius: 70%;
+    overflow: hidden;
+`;
+
+const LinkMenu = styled.div`
+  width: 100% - 10px;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  padding-left: 10px;
+  text-decoration: none;
+  color: black;
+  border-bottom: 1px solid #e6e6e6;
+
+  &:hover {
+  cursor: default;
+  background-color: #eeebe4e4;
+  box-shadow: 0px 2px 4px rgb(0 0 0 / 25%);
+  }
+`;
+
+const StyledLink = styled(Link)`
+    text-decoration: none;
+
+    &:focus, &:hover, &:visited, &:link, &:active {
+        text-decoration: none;
+    }
+`;
+
+function SliderMenu() {
+  const user = useRecoilValue(userState);
+  const [isOpenMenu, setIsOpenMenu] = useRecoilState(isOpenSliderMenuState);
+  return (
+    <>
+      <BackgroundWrapper />
+      <MenuModalBox state={isOpenMenu}>
+        <div>
+          <StyledLink to={`/profile/${user.userId}`}>
+            <ProfileBox>
+              <ImageLayout src={user.profileUrl} alt="사용자" />
+              <ProfileInfo>
+                <ProfileUserName>
+                  { user.userName}
+                </ProfileUserName>
+                <ProfileUserId>
+                  @
+                  { user.userId}
+                </ProfileUserId>
+              </ProfileInfo>
+            </ProfileBox>
+          </StyledLink>
+          <StyledLink to="/search">
+            <LinkMenu>Search</LinkMenu>
+          </StyledLink>
+          <StyledLink to="/chat-rooms">
+            <LinkMenu>Message</LinkMenu>
+          </StyledLink>
+          <StyledLink to="/invite">
+            <LinkMenu>Invite</LinkMenu>
+          </StyledLink>
+          <StyledLink to="/activity">
+            <LinkMenu>Activity</LinkMenu>
+          </StyledLink>
+          <StyledLink to="/event">
+            <LinkMenu>Event</LinkMenu>
+          </StyledLink>
+        </div>
+
+        <button type="button" onClick={() => setIsOpenMenu(!isOpenMenu)}>close</button>
+      </MenuModalBox>
+    </>
+  );
+}
+
+export default SliderMenu;

--- a/client/src/components/room/right-sidebar.tsx
+++ b/client/src/components/room/right-sidebar.tsx
@@ -15,8 +15,7 @@ const RoomModalLayout = styled.div`
   border-radius: 30px;
   width: 100%;
   height: 100%;
-  min-width: 400px;
-  max-width: 500px;
+  min-width: 320px;
   margin-bottom: 10%;
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
   position: relative;

--- a/client/src/components/sign/sign-title.tsx
+++ b/client/src/components/sign/sign-title.tsx
@@ -6,11 +6,10 @@ interface SignTitleProps {
 }
 
 const TitleDiv = styled.div`
-  height: 70px;
-  width: calc(740px*100vw/1440px);
-  font-size: 4rem;
-  min-width: 650px;
+  width: max-content;
+  font-size: min(6vw, 60px);
   text-align: center;
+  
 `;
 
 function SignTitle({

--- a/client/src/recoil/atoms/is-open-room.ts
+++ b/client/src/recoil/atoms/is-open-room.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export default atom<boolean>({
+  key: 'isOpenRoomState', // 해당 atom의 고유 key
+  default: false, // 기본값
+});

--- a/client/src/recoil/atoms/is-open-slider-menu.ts
+++ b/client/src/recoil/atoms/is-open-slider-menu.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export default atom<boolean>({
+  key: 'isOpenSliderMenuState',
+  default: false,
+});

--- a/client/src/views/main-view.tsx
+++ b/client/src/views/main-view.tsx
@@ -49,10 +49,9 @@ const ActiveFollowingLayout = styled.div`
 `;
 const MainSectionLayout = styled.div`
   position: relative;
-  width: 100%;
   height: 80vh;
-  min-width: 360px;
-  flex-grow: 3;
+  min-width: 320px;
+  flex-grow: 10;
   margin: 10px;
 `;
 
@@ -65,8 +64,11 @@ const MainScrollSection = styled.div`
 
 const RoomLayout = styled.div`
   height: 80vh;
-  flex-grow: 2;
+  flex-grow: 1;
   margin: 10px;
+  @media (max-width: 768px) {
+    display: none;
+  }
 `;
 
 const ButtonLayout = styled.div`

--- a/client/src/views/main-view.tsx
+++ b/client/src/views/main-view.tsx
@@ -5,7 +5,9 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { useRecoilState, useResetRecoilState, useSetRecoilState } from 'recoil';
+import {
+  useRecoilState, useResetRecoilState, useSetRecoilState, useRecoilValue,
+} from 'recoil';
 import { useCookies } from 'react-cookie';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
@@ -22,6 +24,8 @@ import DefaultButton from '@common/default-button';
 import ScrollBarStyle from '@styles/scrollbar-style';
 import LoadingSpinner from '@common/loading-spinner';
 import { getFollowingsList } from '@src/api';
+import isOpenRoomState from '@atoms/is-open-room';
+import { slideXFromTo } from '@src/assets/styles/keyframe';
 
 const MainLayout = styled.div`
   display: flex;
@@ -63,11 +67,23 @@ const MainScrollSection = styled.div`
 `;
 
 const RoomLayout = styled.div`
-  height: 80vh;
-  flex-grow: 1;
-  margin: 10px;
+  @media (minx-width: 768px) {
+    margin: 10px;
+    height: 80vh;
+    flex-grow: 1;
+  }
+  
   @media (max-width: 768px) {
-    display: none;
+    position: fixed;
+    display: ${(props: { state : boolean}) => (props.state ? 'flex' : 'none')};;
+    z-index: 100;
+    height: 85vh;
+    width: 96%;
+    margin-left: 10px;
+    animation-duration: 0.5s;
+    animation-timing-function: ease-out;
+    animation-name: ${slideXFromTo(300, 0)};
+    animation-fill-mode: forward;
   }
 `;
 
@@ -89,6 +105,7 @@ function MainView() {
   const nowFetchingRef = useRef<boolean>(false);
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [cookies, setCookie] = useCookies(['accessToken']);
+  const isOpenRoom = useRecoilValue(isOpenRoomState);
 
   const scrollBarChecker = useCallback((e: UIEvent<HTMLDivElement>) => {
     if (!nowFetchingRef.current) {
@@ -152,7 +169,7 @@ function MainView() {
               <MainRouter />
             </MainScrollSection>
           </MainSectionLayout>
-          <RoomLayout>
+          <RoomLayout state={isOpenRoom}>
             <RightSideBar />
           </RoomLayout>
         </SectionLayout>

--- a/client/src/views/signup-info-view.tsx
+++ b/client/src/views/signup-info-view.tsx
@@ -14,11 +14,12 @@ import InterestItem from '@common/interest-item';
 import { postSignUpUserInfo } from '@src/api';
 
 const InterestItemWarapper = styled.div`
-  width: 50%;
+  width: 100%;
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
   div {
-    margin-right: 5%;
+    margin-right: 10px;
     margin-bottom: 5%;
   }
   margin-top: 5%;
@@ -26,6 +27,7 @@ const InterestItemWarapper = styled.div`
 `;
 
 const CustomInfoInputBar = styled(CustomInputBar)`
+  font-size: min(5vw, 30px);
   width: 70%;
 `;
 


### PR DESCRIPTION
## 개요
💄 모바일 대응 반응형 스타일 구현
## 작업사항
- 💄 회원가입, 로그인 모바일 반응형 스타일 구현
  - min-width 수정
  - 글씨크기를 vw단위로 수정 후 최대 사이즈 지정
- 💄 로그인 이후 view 모바일 반응형 개선 양쪽 사이드바 감추기
  - 미디어 쿼리를 적용해 active following list와 room modal을 사라지도록 구현 
- 💄 1024px 이하 헤더 메뉴아이콘 사라지도록 구현
  - 모바일용 슬라이딩 메뉴를 따로 구현하기 위해 사라지도록 설정
- ✨ X축 슬라이드 구현
  - 기존 모달용 Y축 슬라이드를 응용해 X축 슬라이더 작성 
- 💄 슬라이딩 메뉴, 룸 사이드바 슬라이딩 구현
  - 모바일용 슬라이딩 메뉴, 룸 모달 슬라이딩 구현

## 변경로직
- 기존 width와 min-width를 많이 수정했습니다.
- right-sidebar는 모바일 뷰 부터 슬라이딩으로 구현되도록 했습니다.
- 각각 스타일 구현 방법이 다양해서,, 아직 padding이나 margin으로 조금씩의 오류가 있습니다,,
- menu 슬라이더와 Room 슬라이더의 open 상태를 전역으로 추가했습니다.

### 변경후

https://user-images.githubusercontent.com/59464537/142766603-91732dc7-f970-42e0-afc5-1807e1c94ecc.mov


## 기타
- 메뉴와 룸 버튼 스타일링을 더 해줘야 합니다.
- 제 로컬에서는 방 생성시 DB에 participants가 추가 되지 않아서, room이 보이지 않는 상태에서도 대화가 지속되는지 테스트를 해보지 못했습니다
- 각 view에 따른 헤더의 뒤로가기 버튼, 가장 오른쪽 아이콘의 크기와 위치값 수정이 더 필요합니다.
