### PR TITLE
채팅방 내부 및 채팅방 목록 추가 구현

### DIFF
--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -231,3 +231,25 @@ export const getChattingLog = async (chatDocumentId: string) => {
     console.log(e);
   }
 };
+
+interface IChattingLog {
+  userDocumentId: string,
+  message: string,
+  date: Date,
+}
+
+export const postChattingMsg = async (chattingLog: IChattingLog, chatDocumentId: string) => {
+  try {
+    let response = await fetch(`${process.env.REACT_APP_API_URL}/api/chat-rooms/chat-log`, {
+      method: 'post',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ chattingLog, chatDocumentId }),
+    });
+    response = await response.json();
+    return response;
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 /* eslint-disable consistent-return */
 // eslint-disable-next-line consistent-return
 export const getRoomInfo = async (roomDocumentId: string) => {
@@ -238,18 +239,36 @@ interface IChattingLog {
   date: Date,
 }
 
-export const postChattingMsg = async (chattingLog: IChattingLog, chatDocumentId: string) => {
+export const postChattingMsg = async (chattingLog: IChattingLog, chatDocumentId: string, userDocumentId: string) => {
   try {
     let response = await fetch(`${process.env.REACT_APP_API_URL}/api/chat-rooms/chat-log`, {
       method: 'post',
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ chattingLog, chatDocumentId }),
+      body: JSON.stringify({ chattingLog, chatDocumentId, userDocumentId }),
     });
     response = await response.json();
     return response;
   } catch (error) {
     console.error(error);
+  }
+};
+
+export const setUnCheckedMsg0 = async (chatDocumentId: string, userDocumentId: string) => {
+  try {
+    let response = await fetch(
+      `${process.env.REACT_APP_API_URL}/api/chat-rooms/setUnCheckedMsg/${chatDocumentId}/${userDocumentId}`,
+      {
+        method: 'get',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+    response = await response.json();
+    return response;
+  } catch (e) {
+    console.log(e);
   }
 };

--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -213,3 +213,21 @@ export const postChatRoom = async (participants: Array<string>) => {
     console.error(error);
   }
 };
+
+export const getChattingLog = async (chatDocumentId: string) => {
+  try {
+    let response = await fetch(
+      `${process.env.REACT_APP_API_URL}/api/chat-rooms/chat-log/${chatDocumentId}`,
+      {
+        method: 'get',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+    response = await response.json();
+    return response;
+  } catch (e) {
+    console.log(e);
+  }
+};

--- a/client/src/components/chat/chat-room-footer.tsx
+++ b/client/src/components/chat/chat-room-footer.tsx
@@ -5,6 +5,8 @@ import { FiSend } from 'react-icons/fi';
 import { useRecoilValue } from 'recoil';
 
 import userType from '@atoms/user';
+import { makeDateToHourMinute } from '@utils/index';
+import { postChattingMsg } from '@api/index';
 
 const ChatRoomFooterStyle = styled.div`
   position: absolute;
@@ -46,15 +48,17 @@ const SendBtnDiv = styled.div`
   transform: translateY(10px);
 `;
 
-export default function ChatRoomFooter({ addChattingLog }: any) {
+export default function ChatRoomFooter({ addChattingLog, chatDocumentId }: any) {
   const messageInput = useRef(null);
   const user = useRecoilValue(userType);
 
-  const sendEvent = () => {
+  const sendEvent = async () => {
     const message = (messageInput as any).current.value;
     (messageInput as any).current.value = '';
+    const res : any = await postChattingMsg({ userDocumentId: user.userDocumentId, message, date: new Date() }, chatDocumentId);
+    if (!res.ok) return;
     addChattingLog({
-      userDocumentId: user.userDocumentId, userName: user.userName, profileUrl: user.profileUrl, message,
+      userDocumentId: user.userDocumentId, userName: user.userName, profileUrl: user.profileUrl, message, date: makeDateToHourMinute(new Date()),
     });
   };
 

--- a/client/src/components/chat/chat-room-footer.tsx
+++ b/client/src/components/chat/chat-room-footer.tsx
@@ -55,7 +55,7 @@ export default function ChatRoomFooter({ addChattingLog, chatDocumentId }: any) 
   const sendEvent = async () => {
     const message = (messageInput as any).current.value;
     (messageInput as any).current.value = '';
-    const res : any = await postChattingMsg({ userDocumentId: user.userDocumentId, message, date: new Date() }, chatDocumentId);
+    const res : any = await postChattingMsg({ userDocumentId: user.userDocumentId, message, date: new Date() }, chatDocumentId, user.userDocumentId);
     if (!res.ok) return;
     addChattingLog({
       userDocumentId: user.userDocumentId, userName: user.userName, profileUrl: user.profileUrl, message, date: makeDateToHourMinute(new Date()),

--- a/client/src/components/chat/chat-room-footer.tsx
+++ b/client/src/components/chat/chat-room-footer.tsx
@@ -1,6 +1,10 @@
+/* eslint-disable max-len */
 import { useRef } from 'react';
 import styled from 'styled-components';
 import { FiSend } from 'react-icons/fi';
+import { useRecoilValue } from 'recoil';
+
+import userType from '@atoms/user';
 
 const ChatRoomFooterStyle = styled.div`
   position: absolute;
@@ -29,15 +33,8 @@ const MsgInput = styled.textarea`
   }
 
   &::-webkit-scrollbar {
-    width: 5px;
-    height: 8px;
-    background: #C4C4C4;
+    display: none;
   }
-  &::-webkit-scrollbar-thumb {
-    border-radius: 10px;
-    background-color: #DCD9CD;
-  }
-  overflow-y: scroll;
 `;
 
 const SendBtnDiv = styled.div`
@@ -51,11 +48,14 @@ const SendBtnDiv = styled.div`
 
 export default function ChatRoomFooter({ addChattingLog }: any) {
   const messageInput = useRef(null);
+  const user = useRecoilValue(userType);
 
   const sendEvent = () => {
     const message = (messageInput as any).current.value;
     (messageInput as any).current.value = '';
-    addChattingLog(message);
+    addChattingLog({
+      userDocumentId: user.userDocumentId, userName: user.userName, profileUrl: user.profileUrl, message,
+    });
   };
 
   const keyPressHandler = (e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/client/src/components/chat/chat-room-footer.tsx
+++ b/client/src/components/chat/chat-room-footer.tsx
@@ -1,0 +1,76 @@
+import { useRef } from 'react';
+import styled from 'styled-components';
+import { FiSend } from 'react-icons/fi';
+
+const ChatRoomFooterStyle = styled.div`
+  position: absolute;
+  bottom: 3%;
+
+  width: 99%;
+  height: 50px;
+`;
+
+const MsgInput = styled.textarea`
+  position: absolute;
+  left: 8%;
+
+  width: 70%;
+  height: auto;
+
+  border: none;
+  border-radius: 10px;
+  background-color: #C4C4C4;
+
+  font-family: 'Nunito';
+  font-size: 20px;
+
+  &:focus {
+    outline: 0;
+  }
+
+  &::-webkit-scrollbar {
+    width: 5px;
+    height: 8px;
+    background: #C4C4C4;
+  }
+  &::-webkit-scrollbar-thumb {
+    border-radius: 10px;
+    background-color: #DCD9CD;
+  }
+  overflow-y: scroll;
+`;
+
+const SendBtnDiv = styled.div`
+  position: absolute;
+  right: 8%;
+
+  width: 32px;
+  height: 32px;
+  transform: translateY(10px);
+`;
+
+export default function ChatRoomFooter({ addChattingLog }: any) {
+  const messageInput = useRef(null);
+
+  const sendEvent = () => {
+    const message = (messageInput as any).current.value;
+    (messageInput as any).current.value = '';
+    addChattingLog(message);
+  };
+
+  const keyPressHandler = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      if (!e.shiftKey) {
+        e.preventDefault();
+        sendEvent();
+      }
+    }
+  };
+
+  return (
+    <ChatRoomFooterStyle onKeyPress={keyPressHandler}>
+      <MsgInput ref={messageInput} />
+      <SendBtnDiv onClick={sendEvent}><FiSend size={32} /></SendBtnDiv>
+    </ChatRoomFooterStyle>
+  );
+}

--- a/client/src/components/chat/chat-room-header.tsx
+++ b/client/src/components/chat/chat-room-header.tsx
@@ -4,6 +4,7 @@ import { MdOutlineArrowBackIos } from 'react-icons/md';
 
 import { ChatHeaderStyle } from '@components/chat/style';
 import { makeIconToLink } from '@utils/index';
+import React from 'react';
 
 const BackBtn = styled.div`
   position: absolute;
@@ -57,7 +58,7 @@ const ParticipantsName = styled.div`
   text-align: center;
 `;
 
-export default ({ participantsInfo }: any) => {
+export default React.memo(({ participantsInfo }: any) => {
   const userNames = participantsInfo.map((user:any) => user.userName).join(', ');
 
   return (
@@ -75,4 +76,4 @@ export default ({ participantsInfo }: any) => {
       </ParticipantsDiv>
     </ChatHeaderStyle>
   );
-};
+});

--- a/client/src/components/chat/chat-user-card.tsx
+++ b/client/src/components/chat/chat-user-card.tsx
@@ -12,6 +12,8 @@ interface chatUserCardProps {
   participantsInfo: Array<Participants>,
   lastMsg: string,
   clickEvent(): void,
+  recentActive: string,
+  unCheckedMsg: number,
 }
 
 type ProfileProps = { profileUrl: string, length: number };
@@ -89,7 +91,28 @@ const LastChatMsg = styled.p`
   font-size: 20px;
 `;
 
-const ChatUserCard = ({ participantsInfo, lastMsg, clickEvent } : chatUserCardProps) => {
+const ExInfoDiv = styled.div`
+  margin-left: 20px;
+  p {
+    margin: 5px 0px 10px 0px;
+    transform: translateY(25px);
+    font-size: 20px;
+    font-family: "Nunito";
+  }
+`;
+
+const UnCheckMsg = styled.p`
+  width: 25px;
+  height: 25px;
+  background-color: #C4CDC0;
+
+  border-radius: 20px;
+  text-align: center;
+`;
+
+const ChatUserCard = ({
+  participantsInfo, lastMsg, recentActive, clickEvent, unCheckedMsg,
+} : chatUserCardProps) => {
   const userNames = participantsInfo.map((participant) => participant.userName).join(', ');
   return (
     <ChatUserCardLayout onClick={clickEvent}>
@@ -101,6 +124,10 @@ const ChatUserCard = ({ participantsInfo, lastMsg, clickEvent } : chatUserCardPr
         <UserNameInfo>{userNames}</UserNameInfo>
         <LastChatMsg>{lastMsg}</LastChatMsg>
       </ChatUserCardInfo>
+      <ExInfoDiv>
+        <p style={{ color: '#C4CDC0' }}>{recentActive}</p>
+        {unCheckedMsg > 0 ? <UnCheckMsg>{unCheckedMsg}</UnCheckMsg> : ''}
+      </ExInfoDiv>
     </ChatUserCardLayout>
   );
 };

--- a/client/src/components/chat/style.ts
+++ b/client/src/components/chat/style.ts
@@ -37,3 +37,8 @@ export const ChatHeaderStyle = styled.div`
     margin: 0px;
   }
 `;
+
+export const ChattingLog = styled.div`
+  width: 99%;
+  height: 300px;
+`;

--- a/client/src/components/chat/style.ts
+++ b/client/src/components/chat/style.ts
@@ -39,6 +39,8 @@ export const ChatHeaderStyle = styled.div`
 `;
 
 export const ChattingLog = styled.div`
-  width: 99%;
-  height: 300px;
+  width: 100%;
+  height: 520px;
+
+  ${ScrollBarStyle};
 `;

--- a/client/src/components/common/room-card.tsx
+++ b/client/src/components/common/room-card.tsx
@@ -128,7 +128,7 @@ interface IProfileList {
 }
 
 const makeParticipantsInfoToUserNames = (acc: IUserName[], participant: Participants, idx: number) => {
-  if (idx > 3) return acc;
+  if (idx > 2) return acc;
   acc.push({ name: participant.userName, key: participant._id });
   return acc;
 };
@@ -157,7 +157,6 @@ export default function RoomCard({
   const thumbnailUrl = participantsInfo
   .filter((val, idx) => idx < 2)
   .map((participant, idx) => ({ profileUrl: participant.profileUrl, Style: ProfileStyleArray[idx] }));
-
 
   return (
     <RoomCardLayout>

--- a/client/src/utils/index.tsx
+++ b/client/src/utils/index.tsx
@@ -26,6 +26,7 @@ export const generateURLQuery = (params: Params) => Object.keys(params).map((k) 
 
 // Date객체 -> 시간 : 분 string 으로 변환
 export const makeDateToHourMinute = (date : Date) => `${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
+export const makeDateToMonthDate = (date: Date) => `${String(date.getMonth() + 1)}월${String(date.getDate())}일`;
 
 const emailRule = /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$/i;
 

--- a/client/src/views/chat-room-detail-view.tsx
+++ b/client/src/views/chat-room-detail-view.tsx
@@ -9,7 +9,7 @@ import { useParams, useLocation } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 
-import { getChattingLog } from '@api/index';
+import { getChattingLog, setUnCheckedMsg0 } from '@api/index';
 import { ChatRoomsLayout, ChattingLog } from '@components/chat/style';
 import ChatRoomHeader from '@components/chat/chat-room-header';
 import ChatRoomFooter from '@components/chat/chat-room-footer';
@@ -88,6 +88,7 @@ function ChatRoomDetailView() {
   useEffect(() => {
     getChattingLog(chatDocumentId)
       .then((res: any) => {
+        setUnCheckedMsg0(chatDocumentId, user.userDocumentId);
         setChattingLog(res.chattingLog.map((chat: any) => {
           if (chat.userDocumentId === user.userDocumentId) {
             return ({
@@ -109,6 +110,11 @@ function ChatRoomDetailView() {
         }));
         (chattingLogDiv as any).current.scrollTop = (chattingLogDiv as any).current.scrollHeight - (chattingLogDiv as any).current.clientHeight;
       });
+    return () => {
+      setUnCheckedMsg0(chatDocumentId, user.userDocumentId).then(() => {
+
+      });
+    };
   }, [chatDocumentId]);
 
   useEffect(() => {

--- a/client/src/views/chat-room-detail-view.tsx
+++ b/client/src/views/chat-room-detail-view.tsx
@@ -1,18 +1,28 @@
-import React from 'react';
+/* eslint-disable prefer-template */
+import React, { useState } from 'react';
 import { useParams, useLocation } from 'react-router-dom';
-import { ChatRoomsLayout } from '@components/chat/style';
+import { ChatRoomsLayout, ChattingLog } from '@components/chat/style';
 import ChatRoomHeader from '@components/chat/chat-room-header';
+import ChatRoomFooter from '@components/chat/chat-room-footer';
 
 type urlParams = { chatDocumentId: string };
 
 function ChatRoomDetailView() {
   const { chatDocumentId } = useParams<urlParams>();
   const location = useLocation<any>();
+  const [chattingLog, setChattingLog] = useState<any>([]);
+
+  const addChattingLog = (message: string) => {
+    setChattingLog([...chattingLog, message]);
+  };
+
+  console.log(chatDocumentId);
 
   return (
     <ChatRoomsLayout>
       <ChatRoomHeader participantsInfo={location.state.participantsInfo} />
-      <h1>{chatDocumentId}</h1>
+      <ChattingLog>{chattingLog.map((message: string) => <div style={{ whiteSpace: 'pre-line' }}>{message}</div>)}</ChattingLog>
+      <ChatRoomFooter addChattingLog={addChattingLog} />
     </ChatRoomsLayout>
   );
 }

--- a/client/src/views/chat-room-detail-view.tsx
+++ b/client/src/views/chat-room-detail-view.tsx
@@ -134,7 +134,7 @@ function ChatRoomDetailView() {
           </Chat>
         ))}
       </ChattingLog>
-      <ChatRoomFooter addChattingLog={addChattingLog} />
+      <ChatRoomFooter addChattingLog={addChattingLog} chatDocumentId={chatDocumentId} />
     </ChatRoomsLayout>
   );
 }

--- a/client/src/views/chat-room-detail-view.tsx
+++ b/client/src/views/chat-room-detail-view.tsx
@@ -1,27 +1,101 @@
+/* eslint-disable react/no-array-index-key */
+/* eslint-disable react/no-unused-prop-types */
+/* eslint-disable max-len */
 /* eslint-disable prefer-template */
-import React, { useState } from 'react';
+import React, {
+  useEffect, useState, useRef,
+} from 'react';
 import { useParams, useLocation } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+import styled from 'styled-components';
+
 import { ChatRoomsLayout, ChattingLog } from '@components/chat/style';
 import ChatRoomHeader from '@components/chat/chat-room-header';
 import ChatRoomFooter from '@components/chat/chat-room-footer';
+import userType from '@atoms/user';
 
 type urlParams = { chatDocumentId: string };
+
+const Chat = styled.div< { isMyMsg: boolean } >`
+  display: flex;
+  width: auto;
+  max-width: 99%;
+
+  margin: 10px;
+  ${({ isMyMsg }: any) => {
+    if (isMyMsg) return 'flex-direction: row-reverse';
+    return '';
+  }};
+`;
+
+const Message = styled.div< { isMyMsg: boolean } >`
+  white-space: pre-line;
+
+  width: auto;
+  max-width: 60%;
+  word-break: break-all;
+
+  border-radius: 20px;
+
+  background-color: ${({ isMyMsg }: any) => {
+    if (isMyMsg) return '#F1F0E4';
+    return '#C4CDC0';
+  }};
+
+  p {
+    margin: 10px;
+  }
+`;
+
+const UserProfile = styled.img`
+  width: 36px;
+  height: 36px;
+  margin: 10px;
+
+  border-radius: 15px;
+`;
+
+interface IChattingLog {
+  message: string,
+  profileUrl: string,
+  userName: string,
+  userDocumentId: string,
+}
 
 function ChatRoomDetailView() {
   const { chatDocumentId } = useParams<urlParams>();
   const location = useLocation<any>();
-  const [chattingLog, setChattingLog] = useState<any>([]);
+  const [chattingLog, setChattingLog] = useState<any>([{
+    message: 'test', userDocumentId: '1', profileUrl: 'https://avatars.githubusercontent.com/u/51700274?v=4', userName: 'caj',
+  }]);
+  const user = useRecoilValue(userType);
+  const chattingLogDiv = useRef(null);
+
+  console.log(chatDocumentId);
 
   const addChattingLog = (message: string) => {
     setChattingLog([...chattingLog, message]);
   };
 
-  console.log(chatDocumentId);
+  useEffect(() => {
+    (chattingLogDiv as any).current.scrollTop = (chattingLogDiv as any).current.scrollHeight - (chattingLogDiv as any).current.clientHeight;
+  }, [chattingLog]);
 
   return (
     <ChatRoomsLayout>
       <ChatRoomHeader participantsInfo={location.state.participantsInfo} />
-      <ChattingLog>{chattingLog.map((message: string) => <div style={{ whiteSpace: 'pre-line' }}>{message}</div>)}</ChattingLog>
+      <ChattingLog ref={chattingLogDiv}>
+        {chattingLog.map(({
+          message, profileUrl, userName, userDocumentId,
+        } : IChattingLog, index: number) => (
+          <Chat key={index} isMyMsg={userDocumentId === user.userDocumentId}>
+            <UserProfile src={profileUrl} />
+            <Message isMyMsg={userDocumentId === user.userDocumentId}>
+              <p>{`${userName}\n${message}`}</p>
+            </Message>
+          </Chat>
+        ))}
+      </ChattingLog>
       <ChatRoomFooter addChattingLog={addChattingLog} />
     </ChatRoomsLayout>
   );

--- a/client/src/views/chat-rooms-view.tsx
+++ b/client/src/views/chat-rooms-view.tsx
@@ -10,6 +10,7 @@ import ChatUserCard from '@components/chat/chat-user-card';
 import { ChatRoomsLayout } from '@components/chat/style';
 import LoadingSpinner from '@common/loading-spinner';
 import { getChatRooms } from '@api/index';
+import { makeDateToHourMinute, makeDateToMonthDate } from '@utils/index';
 
 interface IChatUserType {
   userDocumentId: string,
@@ -21,6 +22,8 @@ interface IChatRoom {
   chatDocumentId: string,
   participants: Array<IChatUserType>,
   lastMsg: string,
+  recentActive: Date,
+  unCheckedMsg: number,
 }
 
 function ChatRoomsViews() {
@@ -48,7 +51,21 @@ function ChatRoomsViews() {
   return (
     <ChatRoomsLayout>
       <ChatRoomListHeader />
-      {chatRooms?.map((chatRoom: IChatRoom) => <ChatUserCard key={chatRoom.chatDocumentId} clickEvent={() => clickEvent(chatRoom.chatDocumentId, chatRoom.participants)} participantsInfo={chatRoom.participants} lastMsg={chatRoom.lastMsg} />)}
+      {chatRooms?.map((chatRoom: IChatRoom) => {
+        const date = new Date(chatRoom.recentActive);
+        return (
+          <ChatUserCard
+            key={chatRoom.chatDocumentId}
+            clickEvent={
+        () => clickEvent(chatRoom.chatDocumentId, chatRoom.participants)
+        }
+            participantsInfo={chatRoom.participants}
+            lastMsg={chatRoom.lastMsg}
+            recentActive={date.getDate() === (new Date()).getDate() ? makeDateToHourMinute(date) : makeDateToMonthDate(date)}
+            unCheckedMsg={chatRoom.unCheckedMsg}
+          />
+        );
+      })}
     </ChatRoomsLayout>
   );
 }

--- a/client/src/views/chat-rooms-view.tsx
+++ b/client/src/views/chat-rooms-view.tsx
@@ -5,7 +5,7 @@ import { useRecoilValue } from 'recoil';
 import { useHistory } from 'react-router-dom';
 
 import userType from '@atoms/user';
-import ChatRoomListHeader from '@src/components/chat/chat-list-header';
+import ChatRoomListHeader from '@components/chat/chat-list-header';
 import ChatUserCard from '@components/chat/chat-user-card';
 import { ChatRoomsLayout } from '@components/chat/style';
 import LoadingSpinner from '@common/loading-spinner';

--- a/server/src/api/routes/chats.ts
+++ b/server/src/api/routes/chats.ts
@@ -46,13 +46,25 @@ export default (app: Router) => {
 
   chatRouter.post('/chat-log', async (req: Request, res: Response) => {
     try {
-      const { chattingLog, chatDocumentId } = req.body;
+      const { chattingLog, chatDocumentId, userDocumentId } = req.body;
 
-      await chatService.addChattingLog(chattingLog, chatDocumentId);
+      await chatService.addChattingLog(chattingLog, chatDocumentId, userDocumentId);
 
       res.status(200).json({ ok: true });
     } catch (e) {
       res.json({ ok: false });
+    }
+  });
+
+  chatRouter.get('/setUnCheckedMsg/:chatDocumentId/:userDocumentId', async (req: Request, res: Response) => {
+    try {
+      const { chatDocumentId, userDocumentId } = req.params;
+
+      await chatService.setUnCheckedMsg(chatDocumentId, userDocumentId);
+
+      res.status(200).json({ ok: true });
+    } catch (e) {
+      res.status(404).json({ ok: false });
     }
   });
 };

--- a/server/src/api/routes/chats.ts
+++ b/server/src/api/routes/chats.ts
@@ -43,4 +43,16 @@ export default (app: Router) => {
       res.json({ ok: false });
     }
   });
+
+  chatRouter.post('/chat-log', async (req: Request, res: Response) => {
+    try {
+      const { chattingLog, chatDocumentId } = req.body;
+
+      await chatService.addChattingLog(chattingLog, chatDocumentId);
+
+      res.status(200).json({ ok: true });
+    } catch (e) {
+      res.json({ ok: false });
+    }
+  });
 };

--- a/server/src/api/routes/chats.ts
+++ b/server/src/api/routes/chats.ts
@@ -16,7 +16,7 @@ export default (app: Router) => {
 
       res.status(200).json({ chatRoomId });
     } catch (error) {
-      console.log(error);
+      res.json({ ok: false });
     }
   });
 
@@ -28,7 +28,19 @@ export default (app: Router) => {
 
       res.status(200).json(chatRoomInfo);
     } catch (error) {
-      console.error(error);
+      res.json({ ok: false });
+    }
+  });
+
+  chatRouter.get('/chat-log/:chatDocumentId', async (req: Request, res: Response) => {
+    try {
+      const { chatDocumentId } = req.params;
+
+      const chattingLog = await chatService.getChattingLog(chatDocumentId);
+
+      res.status(200).json(chattingLog);
+    } catch (e) {
+      res.json({ ok: false });
     }
   });
 };

--- a/server/src/models/chats.ts
+++ b/server/src/models/chats.ts
@@ -5,14 +5,17 @@ interface IChattingLog {
     date: Date,
 }
 
-type IUnCheckedMsg = { [userDocumentId: string]: number };
+interface IUnReadMsg {
+  userDocumentId: string,
+  count: number,
+}
 
 interface IChatTypesModel extends Document {
   participants: Array<string>,
   chattingLog: Array<IChattingLog>,
   lastMsg: string,
   recentActive: Date,
-  unCheckedMsg: IUnCheckedMsg,
+  unReadMsg: Array<IUnReadMsg>,
 }
 
 const chatSchema = new Schema({
@@ -32,9 +35,9 @@ const chatSchema = new Schema({
     type: Date,
     default: new Date(),
   },
-  unCheckedMsg: {
-    type: Object,
-    default: {},
+  unReadMsg: {
+    type: [Object],
+    default: [],
   },
 });
 

--- a/server/src/models/chats.ts
+++ b/server/src/models/chats.ts
@@ -5,11 +5,14 @@ interface IChattingLog {
     date: Date,
 }
 
+type IUnCheckedMsg = { [userDocumentId: string]: number };
+
 interface IChatTypesModel extends Document {
   participants: Array<string>,
   chattingLog: Array<IChattingLog>,
   lastMsg: string,
   recentActive: Date,
+  unCheckedMsg: IUnCheckedMsg,
 }
 
 const chatSchema = new Schema({
@@ -28,6 +31,10 @@ const chatSchema = new Schema({
   recentActive: {
     type: Date,
     default: new Date(),
+  },
+  unCheckedMsg: {
+    type: Object,
+    default: {},
   },
 });
 

--- a/server/src/services/chat-service.ts
+++ b/server/src/services/chat-service.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-return-assign */
 /* eslint-disable no-return-await */
 /* eslint-disable no-underscore-dangle */
 /* eslint-disable consistent-return */
@@ -20,17 +21,23 @@ class ChatService {
     const chatRoomList = await Users.findOne({ _id: userDocumentId }, ['chatRooms']);
 
     const chatRoomInfoArray = await Promise.all((chatRoomList!.chatRooms).map(async (chatDocumentId: string) => {
-      const chatRoomInfo = await Chats.findOne({ _id: chatDocumentId }, ['participants', 'lastMsg', 'recentActive']);
+      const chatRoomInfo = await Chats.findOne({ _id: chatDocumentId }, ['participants', 'lastMsg', 'recentActive', 'unCheckedMsg']);
       const UserInfo : any = [];
       await Promise.all((chatRoomInfo)!.participants.map(async (_id) => {
         if (_id === userDocumentId) return;
         const info = await Users.findOne({ _id }, ['userName', 'profileUrl']);
         UserInfo.push({ userDocumentId: info!._id, userName: info!.userName, profileUrl: info!.profileUrl });
       }));
+
       return ({
-        chatDocumentId, participants: UserInfo, lastMsg: chatRoomInfo?.lastMsg, recentActive: chatRoomInfo?.recentActive,
+        chatDocumentId,
+        participants: UserInfo,
+        lastMsg: chatRoomInfo?.lastMsg,
+        recentActive: chatRoomInfo?.recentActive,
+        unCheckedMsg: chatRoomInfo?.unCheckedMsg[userDocumentId],
       });
     }));
+
     return chatRoomInfoArray.sort((a: any, b: any) => {
       if (a.recentActive < b.recentActive) return 1;
       if (a.recentActive > b.recentActive) return -1;
@@ -42,7 +49,9 @@ class ChatService {
     const chatRoom = await Chats.findOne({ participants }, ['participants']);
     if (chatRoom) return chatRoom._id;
 
-    const newChatRoom = new Chats({ participants });
+    const unCheckedMsg : any = {};
+    participants.forEach((userDocumentId: string) => unCheckedMsg[userDocumentId] = 0);
+    const newChatRoom = new Chats({ participants, unCheckedMsg });
     await newChatRoom.save();
 
     participants.forEach(async (userDocumentId) => await Users.findOneAndUpdate({ _id: userDocumentId }, { $push: { chatRooms: newChatRoom._id } }));

--- a/server/src/services/chat-service.ts
+++ b/server/src/services/chat-service.ts
@@ -49,6 +49,11 @@ class ChatService {
 
     return newChatRoom._id;
   }
+
+  async getChattingLog(chatDocumentId: string) {
+    const chattingLog = await Chats.findOne({ _id: chatDocumentId }, ['chattingLog']);
+    return chattingLog;
+  }
 }
 
 export = new ChatService();

--- a/server/src/services/chat-service.ts
+++ b/server/src/services/chat-service.ts
@@ -54,6 +54,13 @@ class ChatService {
     const chattingLog = await Chats.findOne({ _id: chatDocumentId }, ['chattingLog']);
     return chattingLog;
   }
+
+  async addChattingLog(chattingLog: any, chatDocumentId: string) {
+    await Chats.findOneAndUpdate({ _id: chatDocumentId }, {
+      $push: { chattingLog },
+      $set: { recentActive: chattingLog.date, lastMsg: chattingLog.message },
+    });
+  }
 }
 
 export = new ChatService();

--- a/server/src/services/chat-service.ts
+++ b/server/src/services/chat-service.ts
@@ -21,20 +21,21 @@ class ChatService {
     const chatRoomList = await Users.findOne({ _id: userDocumentId }, ['chatRooms']);
 
     const chatRoomInfoArray = await Promise.all((chatRoomList!.chatRooms).map(async (chatDocumentId: string) => {
-      const chatRoomInfo = await Chats.findOne({ _id: chatDocumentId }, ['participants', 'lastMsg', 'recentActive', 'unCheckedMsg']);
+      const chatRoomInfo = await Chats.findOne({ _id: chatDocumentId }, ['participants', 'lastMsg', 'recentActive', 'unReadMsg']);
       const UserInfo : any = [];
       await Promise.all((chatRoomInfo)!.participants.map(async (_id) => {
         if (_id === userDocumentId) return;
         const info = await Users.findOne({ _id }, ['userName', 'profileUrl']);
         UserInfo.push({ userDocumentId: info!._id, userName: info!.userName, profileUrl: info!.profileUrl });
       }));
+      const myUnReadMsg = chatRoomInfo!.unReadMsg.filter((user) => user.userDocumentId === userDocumentId);
 
       return ({
         chatDocumentId,
         participants: UserInfo,
         lastMsg: chatRoomInfo?.lastMsg,
         recentActive: chatRoomInfo?.recentActive,
-        unCheckedMsg: chatRoomInfo?.unCheckedMsg[userDocumentId],
+        unCheckedMsg: myUnReadMsg[0].count,
       });
     }));
 
@@ -49,9 +50,8 @@ class ChatService {
     const chatRoom = await Chats.findOne({ participants }, ['participants']);
     if (chatRoom) return chatRoom._id;
 
-    const unCheckedMsg : any = {};
-    participants.forEach((userDocumentId: string) => unCheckedMsg[userDocumentId] = 0);
-    const newChatRoom = new Chats({ participants, unCheckedMsg });
+    const unReadMsg = participants.map((userDocumentId: string) => ({ userDocumentId, count: 0 }));
+    const newChatRoom = new Chats({ participants, unReadMsg });
     await newChatRoom.save();
 
     participants.forEach(async (userDocumentId) => await Users.findOneAndUpdate({ _id: userDocumentId }, { $push: { chatRooms: newChatRoom._id } }));
@@ -64,11 +64,20 @@ class ChatService {
     return chattingLog;
   }
 
-  async addChattingLog(chattingLog: any, chatDocumentId: string) {
-    await Chats.findOneAndUpdate({ _id: chatDocumentId }, {
+  async addChattingLog(chattingLog: any, chatDocumentId: string, userDocumentId: string) {
+    const chat = await Chats.findOneAndUpdate({ _id: chatDocumentId }, {
       $push: { chattingLog },
       $set: { recentActive: chattingLog.date, lastMsg: chattingLog.message },
     });
+    chat?.participants.forEach(async (id) => {
+      if (id === userDocumentId) return;
+      await Chats.findOneAndUpdate({ _id: chatDocumentId, 'unReadMsg.userDocumentId': id }, { $inc: { 'unReadMsg.$.count': 1 } });
+    });
+  }
+
+  async setUnCheckedMsg(chatDocumentId: string, userDocumentId: string) {
+    await Chats.findOneAndUpdate({ _id: chatDocumentId, 'unReadMsg.userDocumentId': userDocumentId },
+      { $set: { 'unReadMsg.$.count': 0 } });
   }
 }
 


### PR DESCRIPTION
## 개요
- 채팅방 내부 구현
- 채팅방에 읽지 않은 메세지 숫자 + 최근 메세지 시간 정보 추가
## 작업사항
- 채팅방 내부 메세지 전송 로직
    - 엔터 입력시 메세지 전송
    - 쉬프트 엔터시 줄바꿈
    - 메세지 전송시 DB에 해당 정보 저장
 - 채팅 로그 관련 구현
     - 채팅 로그 POST, GET API 구현
     - 채팅 로그 디자인 구현
     - 메세지 보낸 시간 추가
- 채팅방 목록에 확인하지 않은 메세지 숫자 추가
- 최근 메세지 온 시간 추가
## 변경로직
- chat model에 unReadMsg가 field가 추가되었습니다.
- participants에 unReadMsg를 추가해서 새로운 field를 추가하지 않는게 가장 좋긴한데... 이렇게 하면 너무 많은 로직을 바꿔야할것 같아서... 일단은 새로운 field를 새로 만들어주는걸로 구현하였습니다.
### 변경후

https://user-images.githubusercontent.com/51700274/142771363-b6a2d567-e4dc-4d59-885a-26ae0955741f.mov

## 사용방법
- 채팅방에 들어가서 메세지를 주고 받으면 됩니다.
- socket 부분은 전혀 구현되어있지 않기 때문에 실시간 채팅은 불가능 합니다.
## 기타
- 현재 채팅 기록을 불러오는 API 부분에서 최근 N개의 메세지만 가져오는 기능이 구현되어있지 않습니다...
- 이 부분은 추후에 구현해보도록 하겠습니다 :)