### PR TITLE
이벤트 관련 view 일부 수정

### DIFF
--- a/client/src/components/common/modal.tsx
+++ b/client/src/components/common/modal.tsx
@@ -8,13 +8,13 @@ export const ModalBox = styled.div`
   top: 20%;
   display: flex;
   flex-direction: column;
-  background-color: rgb(255, 255, 255);
   border-radius: 32px;
   padding: 56px;
   margin-left: calc(25% - 56px);
   box-shadow: rgb(0 0 0 / 55%) 0px 10px 25px;
   z-index: 990;
   opacity: 1;
+  background-color: #F1F0E4;
   
   animation-duration: 0.5s;
   animation-timing-function: ease-out;

--- a/client/src/components/event/event-header.tsx
+++ b/client/src/components/event/event-header.tsx
@@ -38,8 +38,8 @@ function EventHeader() {
     <>
       <CustomtHeader>
         {makeIconToLink(Icon)}
-        <HeaderTitleNunito onClick={() => alert('test modal')}>
-          UPCOMING FOR YOU ▼
+        <HeaderTitleNunito>
+          UPCOMING FOR EVERYONE
         </HeaderTitleNunito>
         <EventAddButton>
           <BiCalendarPlus onClick={changeModalState} size={48} />

--- a/client/src/components/event/event-register-modal.tsx
+++ b/client/src/components/event/event-register-modal.tsx
@@ -14,6 +14,7 @@ const CustomEventRegisterModal = styled(ModalBox)`
   align-items: center;
   min-width: 500px;
   min-height: 500px;
+  padding: 0px;
   background-color:white;
   border-radius: 30px;
 `;

--- a/client/src/components/event/event-register-modal.tsx
+++ b/client/src/components/event/event-register-modal.tsx
@@ -7,7 +7,7 @@ import { ModalBox, BackgroundWrapper } from '@common/modal';
 import { postEvent } from '@api/index';
 
 const CustomEventRegisterModal = styled(ModalBox)`
-  top: 50px;
+  top: 15vh;
   flex-grow: 3;
   display: flex;
   flex-direction: column;

--- a/client/src/components/event/event-register-modal.tsx
+++ b/client/src/components/event/event-register-modal.tsx
@@ -17,6 +17,7 @@ const CustomEventRegisterModal = styled(ModalBox)`
   padding: 0px;
   background-color:white;
   border-radius: 30px;
+  background-color: #F1F0E4;
 `;
 
 const ModalHeader = styled.div`
@@ -37,7 +38,7 @@ const CustomFormBox = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  background-color: #F1F0E4;
+  background-color: #FFF;
   width: 100%;
   border-radius: 10px;
   margin-bottom: 10px;
@@ -47,7 +48,7 @@ const CustomFormBox = styled.div`
 const CancelButton = styled.button`
   color : #58964F;
   border: none;
-  background-color: #FFFFFF;
+  background-color: #F1F0E4;
   &:hover {
     cursor: pointer;
   }
@@ -56,7 +57,7 @@ const CancelButton = styled.button`
 const PublishButton = styled.button`
   color :  #586A9A;
   border: none;
-  background-color: #FFFFFF;
+  background-color: #F1F0E4;
   &:hover {
     cursor: pointer;
   }
@@ -70,7 +71,7 @@ const PublishButton = styled.button`
 
 const CustomInput = styled.input`
   border: none;
-  background-color: #F1F0E4;
+  background-color: #FFF;
   width: 80%;
   &:focus {outline:none;}
   margin: 5px;
@@ -84,7 +85,7 @@ margin: 5px;`;
 
 const CustomTextArea = styled.textarea`
   border: none;
-  background-color: #F1F0E4;
+  background-color: #FFF;
   width: 80%;
   height: 200px;
   margin: 5px;

--- a/client/src/views/event-view.tsx
+++ b/client/src/views/event-view.tsx
@@ -11,7 +11,7 @@ import LoadingSpinner from '@common/loading-spinner';
 import useFetchItems from '@hooks/useFetchItems';
 import useItemFecthObserver from '@hooks/useItemFetchObserver';
 import useSetEventModal from '@hooks/useSetEventModal';
-import { makeDateToHourMinute } from '@src/utils';
+import { makeDateToHourMinute, makeDateToMonthDate } from '@src/utils';
 
 interface EventUser {
   userId: string,
@@ -42,7 +42,7 @@ const ObserverBlock = styled.div`
 export const makeEventToCard = (event: EventCardProps) => (
   <EventCard
     key={event.key}
-    time={makeDateToHourMinute(new Date(event.time))}
+    time={`${makeDateToMonthDate(new Date(event.time))} ${makeDateToHourMinute(new Date(event.time))}`}
     title={event.title}
     participants={event.participants}
     description={event.description}


### PR DESCRIPTION

## 작업사항
- 이벤트 등록 모달 패딩 제거
- 이벤트 필터링 삭제 (헤더 이름 변경)
- 모달 배경색 수정


### 변경후

![image](https://user-images.githubusercontent.com/74816327/142879974-a010e009-56e7-4e42-bdb5-84476f0f178b.png)

![image](https://user-images.githubusercontent.com/74816327/142880007-eb4d90cd-e5f6-4be9-9235-b03d906c9b01.png)

## 기타
- 클럽하우스에서 이벤트를 클릭하면 특별한 정보가 더 보여지기 보다는 Share 하거나 Calendar에 등록할 수 있는 버튼들이 제공되고 있습니다. 그래서 딱히 모달창에 띄울 정보가 없어서 이벤트 클릭 시 모달창 기능 삭제하려는데 어떠신가요?

- 대신에 이벤트 Card에 알림 구독 버튼을 만들어서 구독 시 ACTIVITY에 하나의 활동이 생기고 이벤트 1시간 전이라던지 미리 알림을 제공해보고 싶은데 어떠신가요? 

- 이벤트 목록은 이제 현재 시각 이후의 이벤트만 불러오도록 수정할 에정입니다.