### PR TITLE
✨ 프로필 이미지 변경 - 서버에 저장

### DIFF
--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -315,3 +315,22 @@ export const setUnCheckedMsg0 = async (chatDocumentId: string, userDocumentId: s
     console.log(e);
   }
 };
+
+export const changeProfileImage = async (userDocumentId: string, imageData: FormData) => {
+  try {
+    let response = await fetch(
+      `${process.env.REACT_APP_API_URL}/api/user/profile-image/${userDocumentId}`,
+      {
+        method: 'post',
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+        body: JSON.stringify({ imageData }),
+      },
+    );
+    response = await response.json();
+    return response;
+  } catch (e) {
+    console.log(e);
+  }
+};

--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -316,16 +316,13 @@ export const setUnCheckedMsg0 = async (chatDocumentId: string, userDocumentId: s
   }
 };
 
-export const changeProfileImage = async (userDocumentId: string, imageData: FormData) => {
+export const changeProfileImage = async (userDocumentId: string, formData: FormData) => {
   try {
     let response = await fetch(
       `${process.env.REACT_APP_API_URL}/api/user/profile-image`,
       {
         method: 'post',
-        headers: {
-          'Content-Type': 'multipart/form-data',
-        },
-        body: JSON.stringify({ imageData, userDocumentId }),
+        body: formData,
       },
     );
     response = await response.json();

--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -319,13 +319,13 @@ export const setUnCheckedMsg0 = async (chatDocumentId: string, userDocumentId: s
 export const changeProfileImage = async (userDocumentId: string, imageData: FormData) => {
   try {
     let response = await fetch(
-      `${process.env.REACT_APP_API_URL}/api/user/profile-image/${userDocumentId}`,
+      `${process.env.REACT_APP_API_URL}/api/user/profile-image`,
       {
         method: 'post',
         headers: {
           'Content-Type': 'multipart/form-data',
         },
-        body: JSON.stringify({ imageData }),
+        body: JSON.stringify({ imageData, userDocumentId }),
       },
     );
     response = await response.json();

--- a/client/src/assets/styles/global-styles.ts
+++ b/client/src/assets/styles/global-styles.ts
@@ -28,7 +28,7 @@ const GlobalStyle = createGlobalStyle`
     background-color: #F1F0E4;
     width: 100vw;
     min-width: 320px;
-
+    user-select: none;
     overflow: hidden;
   }
 `;

--- a/client/src/components/body-modal.tsx
+++ b/client/src/components/body-modal.tsx
@@ -1,25 +1,44 @@
 import { useRecoilValue } from 'recoil';
 
 import {
+<<<<<<< HEAD
   isOpenEventModalState, isOpenEventRegisterModalState, isOpenShareModalState, isOpenRoomModalState,
+=======
+  isOpenEventModalState,
+  isOpenEventRegisterModalState,
+  isOpenShareModalState,
+  isOpenChangeProfileImageModalState,
+>>>>>>> f67bb11 (✨프로필 페이지의 이미지 클릭시 changeImageModal 을 열도록 구현)
 } from '@src/recoil/atoms/is-open-modal';
 import EventModal from '@components/event/event-modal';
 import EventRegisterModal from '@components/event/event-register-modal';
 import ShareModal from '@components/profile/share-modal';
+<<<<<<< HEAD
 import FollowerSelectModal from '@src/components/room/follower-select-room-modal';
+=======
+import ChangeProfileImageModal from '@components/profile/change-profile-image-modal';
+>>>>>>> f67bb11 (✨프로필 페이지의 이미지 클릭시 changeImageModal 을 열도록 구현)
 
 function BodyModal() {
   const isOpenEventModal = useRecoilValue(isOpenEventModalState);
   const isOpenEventRegisterModal = useRecoilValue(isOpenEventRegisterModalState);
   const isOpenShareModal = useRecoilValue(isOpenShareModalState);
+<<<<<<< HEAD
   const isOpenRoomModal = useRecoilValue(isOpenRoomModalState);
+=======
+  const isOpenChangeProfileImageModal = useRecoilValue(isOpenChangeProfileImageModalState);
+>>>>>>> f67bb11 (✨프로필 페이지의 이미지 클릭시 changeImageModal 을 열도록 구현)
 
   return (
     <>
       {isOpenEventModal && <EventModal />}
       {isOpenEventRegisterModal && <EventRegisterModal />}
       {isOpenShareModal && <ShareModal />}
+<<<<<<< HEAD
       {isOpenRoomModal && <FollowerSelectModal />}
+=======
+      {isOpenChangeProfileImageModal && <ChangeProfileImageModal />}
+>>>>>>> f67bb11 (✨프로필 페이지의 이미지 클릭시 changeImageModal 을 열도록 구현)
     </>
   );
 }

--- a/client/src/components/body-modal.tsx
+++ b/client/src/components/body-modal.tsx
@@ -1,44 +1,32 @@
 import { useRecoilValue } from 'recoil';
 
 import {
-<<<<<<< HEAD
-  isOpenEventModalState, isOpenEventRegisterModalState, isOpenShareModalState, isOpenRoomModalState,
-=======
   isOpenEventModalState,
   isOpenEventRegisterModalState,
   isOpenShareModalState,
+  isOpenRoomModalState,
   isOpenChangeProfileImageModalState,
->>>>>>> f67bb11 (✨프로필 페이지의 이미지 클릭시 changeImageModal 을 열도록 구현)
 } from '@src/recoil/atoms/is-open-modal';
 import EventModal from '@components/event/event-modal';
 import EventRegisterModal from '@components/event/event-register-modal';
 import ShareModal from '@components/profile/share-modal';
-<<<<<<< HEAD
 import FollowerSelectModal from '@src/components/room/follower-select-room-modal';
-=======
 import ChangeProfileImageModal from '@components/profile/change-profile-image-modal';
->>>>>>> f67bb11 (✨프로필 페이지의 이미지 클릭시 changeImageModal 을 열도록 구현)
 
 function BodyModal() {
   const isOpenEventModal = useRecoilValue(isOpenEventModalState);
   const isOpenEventRegisterModal = useRecoilValue(isOpenEventRegisterModalState);
   const isOpenShareModal = useRecoilValue(isOpenShareModalState);
-<<<<<<< HEAD
   const isOpenRoomModal = useRecoilValue(isOpenRoomModalState);
-=======
   const isOpenChangeProfileImageModal = useRecoilValue(isOpenChangeProfileImageModalState);
->>>>>>> f67bb11 (✨프로필 페이지의 이미지 클릭시 changeImageModal 을 열도록 구현)
 
   return (
     <>
       {isOpenEventModal && <EventModal />}
       {isOpenEventRegisterModal && <EventRegisterModal />}
       {isOpenShareModal && <ShareModal />}
-<<<<<<< HEAD
       {isOpenRoomModal && <FollowerSelectModal />}
-=======
       {isOpenChangeProfileImageModal && <ChangeProfileImageModal />}
->>>>>>> f67bb11 (✨프로필 페이지의 이미지 클릭시 changeImageModal 을 열도록 구현)
     </>
   );
 }

--- a/client/src/components/profile/change-profile-image-modal.tsx
+++ b/client/src/components/profile/change-profile-image-modal.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { useRecoilState } from 'recoil';
+
+import { isOpenChangeProfileImageModalState } from '@atoms/is-open-modal';
+import { ModalBox, BackgroundWrapper } from '@common/modal';
+
+function ShareModal() {
+  const [isOpenChangeProfileImageModal,
+    setIsOpenChangeProfileImageModalState] = useRecoilState(isOpenChangeProfileImageModalState);
+
+  return (
+    <>
+      <BackgroundWrapper />
+      <ModalBox>
+        <div>SHARE</div>
+        <button type="button" aria-label="test" onClick={() => setIsOpenChangeProfileImageModalState(!isOpenChangeProfileImageModal)}>cancle</button>
+      </ModalBox>
+    </>
+  );
+}
+
+export default ShareModal;

--- a/client/src/components/profile/change-profile-image-modal.tsx
+++ b/client/src/components/profile/change-profile-image-modal.tsx
@@ -81,7 +81,9 @@ function ShareModal() {
 
   return (
     <>
-      <BackgroundWrapper />
+      <BackgroundWrapper
+        onClick={() => setIsOpenChangeProfileImageModalState(!isOpenChangeProfileImageModal)}
+      />
       <ModalBox>
         <ChangePofileImageLayout>
           <PreviewProfileImage src={previewImage} />

--- a/client/src/components/profile/change-profile-image-modal.tsx
+++ b/client/src/components/profile/change-profile-image-modal.tsx
@@ -18,9 +18,9 @@ const ChangePofileImageLayout = styled.div`
 `;
 
 const PreviewProfileImage = styled.img`
-  width: 200px;
-  height: 200px;
-  min-height: 200px;
+  width: 150px;
+  height: 150px;
+  min-height: 150px;
   object-fit: contain;
   margin: 20px;
   border-radius: 30px;
@@ -68,6 +68,12 @@ const ButtonsLayout = styled.div`
   height: 120px;
 `;
 
+const CustomInput = styled.input`
+  padding:0;
+  margin-bottom: 20px;
+  width : 200px;
+`;
+
 function ShareModal() {
   const [isOpenChangeProfileImageModal,
     setIsOpenChangeProfileImageModalState] = useRecoilState(isOpenChangeProfileImageModalState);
@@ -81,15 +87,15 @@ function ShareModal() {
       const imageUrl = URL.createObjectURL(imageFile);
       setPreviewImageURL(imageUrl);
       setPotentialProfileImage(imageFile);
-      console.log(imageFile);
     }
   };
 
   const changeImageHandler = async () => {
     if (potentialProfileImage) {
-      const datas = new FormData();
-      datas.append('image', potentialProfileImage, potentialProfileImage.name);
-      await changeProfileImage(user.userDocumentId, datas);
+      const formData = new FormData();
+      formData.append('profileImage', potentialProfileImage);
+      formData.append('userDocumentId', user.userDocumentId);
+      await changeProfileImage(user.userDocumentId, formData);
     }
   };
 
@@ -101,12 +107,10 @@ function ShareModal() {
       <ModalBox>
         <ChangePofileImageLayout>
           <PreviewProfileImage src={previewImageURL} />
-          <CustomForm action="/uploadFileWithOriginalFilename" method="post">
-            <input type="file" id="image-file" accept="image/gif, image/jpeg, image/png" onChange={inputOnChange} />
+          <CustomForm>
+            <CustomInput type="file" accept="image/gif, image/jpeg, image/png" onChange={inputOnChange} />
             <ButtonsLayout>
-              <DefaultButton buttonType="secondary" size="medium" onClick={() => changeImageHandler()}>
-                Change
-              </DefaultButton>
+              <DefaultButton buttonType="secondary" size="medium" onClick={() => changeImageHandler()}>Change</DefaultButton>
               <DefaultButton buttonType="thirdly" size="medium" onClick={() => setIsOpenChangeProfileImageModalState(!isOpenChangeProfileImageModal)}>
                 Cancel
               </DefaultButton>

--- a/client/src/components/profile/change-profile-image-modal.tsx
+++ b/client/src/components/profile/change-profile-image-modal.tsx
@@ -7,6 +7,7 @@ import { isOpenChangeProfileImageModalState } from '@atoms/is-open-modal';
 import { ModalBox, BackgroundWrapper } from '@common/modal';
 import userState from '@atoms/user';
 import DefaultButton from '@common/default-button';
+import { changeProfileImage } from '@src/api';
 
 const ChangePofileImageLayout = styled.div`
   width: 100%;
@@ -72,7 +73,7 @@ function ShareModal() {
     setIsOpenChangeProfileImageModalState] = useRecoilState(isOpenChangeProfileImageModalState);
   const user = useRecoilValue(userState);
   const [previewImageURL, setPreviewImageURL] = useState(user.profileUrl);
-  const [potentialProfileImage, setPotentialProfileImage] = useState<FormData | null>(null);
+  const [potentialProfileImage, setPotentialProfileImage] = useState<any>(null);
 
   const inputOnChange = (e : any) => {
     if (e.target.files[0]) {
@@ -86,7 +87,9 @@ function ShareModal() {
 
   const changeImageHandler = async () => {
     if (potentialProfileImage) {
-      console.log(potentialProfileImage);
+      const datas = new FormData();
+      datas.append('image', potentialProfileImage, potentialProfileImage.name);
+      await changeProfileImage(user.userDocumentId, datas);
     }
   };
 

--- a/client/src/components/profile/change-profile-image-modal.tsx
+++ b/client/src/components/profile/change-profile-image-modal.tsx
@@ -1,19 +1,103 @@
-import React from 'react';
-import { useRecoilState } from 'recoil';
+/* eslint-disable jsx-a11y/label-has-associated-control */
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { useRecoilState, useRecoilValue } from 'recoil';
 
 import { isOpenChangeProfileImageModalState } from '@atoms/is-open-modal';
 import { ModalBox, BackgroundWrapper } from '@common/modal';
+import userState from '@atoms/user';
+import DefaultButton from '@common/default-button';
+
+const ChangePofileImageLayout = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const PreviewProfileImage = styled.img`
+  width: 200px;
+  height: 200px;
+  margin: 20px;
+  border-radius: 30%;
+  border: 0.1px solid #b8b8b8;
+
+  &:hover{
+    cursor: pointer;
+  };
+`;
+
+const CustomForm = styled.form`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+  height: 100%;
+`;
+
+// const ImageLabel = styled.label`
+//     display: flex;
+//     align-items: center;
+//     justify-content: center;
+//     background-color: #9AACA1;
+//     border-radius: 30px;
+//     font-size: 20px;
+//     font-family: Nunito;
+//     color: #FFF;
+//     width: 100px;
+//     height: 40px;
+
+// `;
+
+// const HiddenInput = styled.input`
+//   width: 0;
+//   height: 0;
+//   padding: 0;
+//   overflow: hidden;
+//   border: 0;
+// `;
+
+const ButtonsLayout = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 120px;
+`;
 
 function ShareModal() {
   const [isOpenChangeProfileImageModal,
     setIsOpenChangeProfileImageModalState] = useRecoilState(isOpenChangeProfileImageModalState);
+  const user = useRecoilValue(userState);
+  const [previewImage, setPreviewImage] = useState(user.profileUrl);
+
+  const inputOnChange = (e : any) => {
+    if (e.target.files[0]) {
+      const imageFile = e.target.files[0];
+      const imageUrl = URL.createObjectURL(imageFile);
+      setPreviewImage(imageUrl);
+    }
+  };
 
   return (
     <>
       <BackgroundWrapper />
       <ModalBox>
-        <div>SHARE</div>
-        <button type="button" aria-label="test" onClick={() => setIsOpenChangeProfileImageModalState(!isOpenChangeProfileImageModal)}>cancle</button>
+        <ChangePofileImageLayout>
+          <PreviewProfileImage src={previewImage} />
+          <CustomForm action="/uploadFileWithOriginalFilename" method="post">
+            <input type="file" id="image-file" accept="image/gif, image/jpeg, image/png" onChange={inputOnChange} />
+            <ButtonsLayout>
+              <DefaultButton buttonType="secondary" size="medium">
+                Change
+              </DefaultButton>
+              <DefaultButton buttonType="thirdly" size="medium" onClick={() => setIsOpenChangeProfileImageModalState(!isOpenChangeProfileImageModal)}>
+                Cancel
+              </DefaultButton>
+            </ButtonsLayout>
+          </CustomForm>
+        </ChangePofileImageLayout>
+
       </ModalBox>
     </>
   );

--- a/client/src/components/profile/change-profile-image-modal.tsx
+++ b/client/src/components/profile/change-profile-image-modal.tsx
@@ -19,8 +19,10 @@ const ChangePofileImageLayout = styled.div`
 const PreviewProfileImage = styled.img`
   width: 200px;
   height: 200px;
+  min-height: 200px;
+  object-fit: contain;
   margin: 20px;
-  border-radius: 30%;
+  border-radius: 30px;
   border: 0.1px solid #b8b8b8;
 
   &:hover{
@@ -69,13 +71,22 @@ function ShareModal() {
   const [isOpenChangeProfileImageModal,
     setIsOpenChangeProfileImageModalState] = useRecoilState(isOpenChangeProfileImageModalState);
   const user = useRecoilValue(userState);
-  const [previewImage, setPreviewImage] = useState(user.profileUrl);
+  const [previewImageURL, setPreviewImageURL] = useState(user.profileUrl);
+  const [potentialProfileImage, setPotentialProfileImage] = useState<FormData | null>(null);
 
   const inputOnChange = (e : any) => {
     if (e.target.files[0]) {
       const imageFile = e.target.files[0];
       const imageUrl = URL.createObjectURL(imageFile);
-      setPreviewImage(imageUrl);
+      setPreviewImageURL(imageUrl);
+      setPotentialProfileImage(imageFile);
+      console.log(imageFile);
+    }
+  };
+
+  const changeImageHandler = async () => {
+    if (potentialProfileImage) {
+      console.log(potentialProfileImage);
     }
   };
 
@@ -86,11 +97,11 @@ function ShareModal() {
       />
       <ModalBox>
         <ChangePofileImageLayout>
-          <PreviewProfileImage src={previewImage} />
+          <PreviewProfileImage src={previewImageURL} />
           <CustomForm action="/uploadFileWithOriginalFilename" method="post">
             <input type="file" id="image-file" accept="image/gif, image/jpeg, image/png" onChange={inputOnChange} />
             <ButtonsLayout>
-              <DefaultButton buttonType="secondary" size="medium">
+              <DefaultButton buttonType="secondary" size="medium" onClick={() => changeImageHandler()}>
                 Change
               </DefaultButton>
               <DefaultButton buttonType="thirdly" size="medium" onClick={() => setIsOpenChangeProfileImageModalState(!isOpenChangeProfileImageModal)}>

--- a/client/src/interfaces/index.ts
+++ b/client/src/interfaces/index.ts
@@ -1,22 +1,34 @@
 export interface IUserForCard{
-    _id: string,
-    userName: string,
-    userId: string,
-    description: string,
-    profileUrl: string,
-    isFollow?: boolean,
-  }
+  _id: string,
+  userName: string,
+  userId: string,
+  description: string,
+  profileUrl: string,
+  isFollow?: boolean,
+}
 
 export interface Participants{
-    _id: string,
-    userName: string,
-    profileUrl: string,
-    isAnonymous: boolean
-  }
+  _id: string,
+  userName: string,
+  profileUrl: string,
+  isAnonymous: boolean,
+}
 
 export interface RoomCardProps {
-    _id: string,
-    title: string,
-    isAnonymous: boolean,
-    participantsInfo: Array<Participants>,
-  }
+  _id: string,
+  title: string,
+  isAnonymous: boolean,
+  participantsInfo: Array<Participants>,
+}
+
+export interface IUserDetail {
+  _id: string,
+  userName: string,
+  userId: string,
+  userEmail: string,
+  description: string,
+  followings: string[],
+  followers: string[],
+  joinDate: string,
+  profileUrl: string
+}

--- a/client/src/recoil/atoms/is-open-modal.ts
+++ b/client/src/recoil/atoms/is-open-modal.ts
@@ -19,3 +19,8 @@ export const isOpenRoomModalState = atom<boolean>({
   key: 'isOpenRoomModalState',
   default: false,
 });
+
+export const isOpenChangeProfileImageModalState = atom<boolean>({
+  key: 'isOpenChangeProfileImageModalState',
+  default: false,
+});

--- a/client/src/views/profile-view.tsx
+++ b/client/src/views/profile-view.tsx
@@ -1,14 +1,16 @@
 /* eslint-disable no-underscore-dangle, max-len */
 import React, { useEffect, useRef, useState } from 'react';
 import { Link, RouteComponentProps } from 'react-router-dom';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValue, useRecoilState } from 'recoil';
 import styled from 'styled-components';
 
 import followingListState from '@atoms/following-list';
+import { isOpenChangeProfileImageModalState } from '@atoms/is-open-modal';
 import userState from '@atoms/user';
 import LoadingSpinner from '@common/loading-spinner';
 import DefaultButton from '@common/default-button';
 import useIsFollowingRef from '@hooks/useIsFollowingRef';
+import { IUserDetail } from '@src/interfaces';
 
 const ProfileViewLayout = styled.div`
   position:relative;
@@ -84,18 +86,6 @@ const JoinDateDiv = styled.div`
   margin-top: 50px;
 `;
 
-interface IUserDetail {
-  _id: string,
-  userName: string,
-  userId: string,
-  userEmail: string,
-  description: string,
-  followings: string[],
-  followers: string[],
-  joinDate: string,
-  profileUrl: string
-}
-
 const makeDateToJoinDate = (dateString: string) => {
   const date = new Date(dateString);
   return `${date.getMonth() + 1}월 ${date.getDate()}, ${date.getFullYear()}`;
@@ -107,6 +97,7 @@ function ProfileView({ match }: RouteComponentProps<{id: string}>) {
   const [loading, setLoading] = useState(true);
   const userDetailInfo = useRef<IUserDetail>();
   const [isFollowingRef, fetchFollow] = useIsFollowingRef(setLoading);
+  const [isOpenChangeProfileImageModal, setIsOpenChangeProfileImageModalState] = useRecoilState(isOpenChangeProfileImageModalState);
 
   if (!match) {
     return <div>존재하지 않는 사용자입니다.</div>;
@@ -138,7 +129,10 @@ function ProfileView({ match }: RouteComponentProps<{id: string}>) {
   return (
     <ProfileViewLayout>
       <ImageAndFollowButtonDiv>
-        <LargeProfileImageBox src={userDetailInfo.current.profileUrl} />
+        <LargeProfileImageBox
+          src={userDetailInfo.current.profileUrl}
+          onClick={() => setIsOpenChangeProfileImageModalState(!isOpenChangeProfileImageModal)}
+        />
         {user.userId !== profileId
         && (
         <DefaultButton

--- a/client/src/views/profile-view.tsx
+++ b/client/src/views/profile-view.tsx
@@ -30,6 +30,10 @@ const LargeProfileImageBox = styled.img`
   width: 100px;
   height: 100px;
   border-radius: 30%;
+
+  &:hover{
+    cursor: pointer;
+  };
 `;
 
 const UserNameDiv = styled.div`

--- a/server/package.json
+++ b/server/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@types/bcrypt": "^5.0.0",
     "@types/redis": "^2.8.32",
+    "aws-sdk": "^2.1033.0",
     "bcrypt": "^5.0.1",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",
@@ -22,6 +23,8 @@
     "jsonwebtoken": "^8.5.1",
     "module-alias": "^2.2.2",
     "mongoose": "^6.0.12",
+    "multer": "^1.4.3",
+    "multer-s3": "^2.10.0",
     "nodemailer": "^6.7.0",
     "socket.io": "^4.3.2"
   },
@@ -33,6 +36,8 @@
     "@types/helmet": "^4.0.0",
     "@types/jsonwebtoken": "^8.5.5",
     "@types/mongoose": "^5.11.97",
+    "@types/multer": "^1.4.7",
+    "@types/multer-s3": "^2.7.11",
     "@types/node": "^16.11.6",
     "@types/nodemailer": "^6.4.4",
     "@types/socket.io": "^3.0.2",

--- a/server/src/api/routes/user.ts
+++ b/server/src/api/routes/user.ts
@@ -147,4 +147,14 @@ export default (app: Router) => {
       res.json({ ok: false });
     }
   });
+
+  userRouter.post('/profile-image', async (req: Request, res: Response) => {
+    const { imageData, userDocumentId } = req.body;
+    try {
+      const newProfileUrl = await usersService.changeProfileImage(userDocumentId, imageData);
+      res.status(200).json({ ok: true, newProfileUrl });
+    } catch (e) {
+      res.json({ ok: false });
+    }
+  });
 };

--- a/server/src/api/routes/user.ts
+++ b/server/src/api/routes/user.ts
@@ -1,11 +1,16 @@
 import {
   Router, Request, Response,
 } from 'express';
+import multer from 'multer';
 
 import usersService from '@services/users-service';
 import authJWT from '@middlewares/auth';
 
 const userRouter = Router();
+
+const upload = multer({
+  dest: 'uploads/',
+});
 
 export default (app: Router) => {
   app.use('/user', userRouter);
@@ -148,13 +153,10 @@ export default (app: Router) => {
     }
   });
 
-  userRouter.post('/profile-image', async (req: Request, res: Response) => {
-    const { imageData, userDocumentId } = req.body;
-    try {
-      const newProfileUrl = await usersService.changeProfileImage(userDocumentId, imageData);
-      res.status(200).json({ ok: true, newProfileUrl });
-    } catch (e) {
-      res.json({ ok: false });
-    }
+  userRouter.post('/profile-image', upload.single('profileImage'), async (req: Request, res: Response) => {
+    const { userDocumentId } = req.body;
+
+    console.log(userDocumentId);
+    console.log(req.file);
   });
 };


### PR DESCRIPTION
## 개요
바꿀 이미지를 선택해서 서버에 저장

## 작업사항
- 💄 프로필 페이지 이미지에 hover시 포인터로 커서 변경
- ♻️ IUserDetail를 interface 폴더의 파일 내부로 이동
- ✨프로필 페이지의 이미지 클릭시 changeImageModal 을 열도록 구현
- 🐛 요소에 커서가 깜빡이는 버그 해결
- ✨ 이미지 선택, 미리보기 구현
- ✨ 배경을 누르면 창 닫힘 구현
- ✨ changeImageHandler 함수 틀
- ✨ 프로필 이미지 변경 API 구현(Client)
- ✨ 프로필 이미지 변경 API 작성(Server)
- ➕ dependecies 추가
  - aws-sdk
  - multer
  - multer-s3
- ✨ server에 이미지 저장 기능 구현
  - object Storage 저장 미구현
- 💄 profile-image 모달 미리보기 사진 크기 조정
