### PR TITLE
✨ 프로필 이미지 변경 기능 구현

### DIFF
--- a/client/src/components/left-sidebar.tsx
+++ b/client/src/components/left-sidebar.tsx
@@ -72,13 +72,13 @@ function LeftSideBar() {
     userSocketRef.current.on('user:hands', (handsData: { from: Partial<IActiveFollowingUser>, to: string }) => {
       if (handsData.to === user.userDocumentId) alert(`${handsData.from.userName}님이 손을 흔들었습니다.`);
     });
-
-    return () => {
-      if (userSocketRef.current) {
-        userSocketRef.current.disconnect();
-      }
-    };
   }, [user]);
+
+  useEffect(() => () => {
+    if (userSocketRef.current) {
+      userSocketRef.current.disconnect();
+    }
+  }, []);
 
   useEffect(() => {
     if (userSocketRef.current) {

--- a/client/src/components/profile/change-profile-image-modal.tsx
+++ b/client/src/components/profile/change-profile-image-modal.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable jsx-a11y/label-has-associated-control */
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilState } from 'recoil';
 
 import { isOpenChangeProfileImageModalState } from '@atoms/is-open-modal';
 import { ModalBox, BackgroundWrapper } from '@common/modal';
@@ -39,28 +39,6 @@ const CustomForm = styled.form`
   height: 100%;
 `;
 
-// const ImageLabel = styled.label`
-//     display: flex;
-//     align-items: center;
-//     justify-content: center;
-//     background-color: #9AACA1;
-//     border-radius: 30px;
-//     font-size: 20px;
-//     font-family: Nunito;
-//     color: #FFF;
-//     width: 100px;
-//     height: 40px;
-
-// `;
-
-// const HiddenInput = styled.input`
-//   width: 0;
-//   height: 0;
-//   padding: 0;
-//   overflow: hidden;
-//   border: 0;
-// `;
-
 const ButtonsLayout = styled.div`
   display: flex;
   flex-direction: column;
@@ -77,7 +55,7 @@ const CustomInput = styled.input`
 function ShareModal() {
   const [isOpenChangeProfileImageModal,
     setIsOpenChangeProfileImageModalState] = useRecoilState(isOpenChangeProfileImageModalState);
-  const user = useRecoilValue(userState);
+  const [user, setUser] = useRecoilState(userState);
   const [previewImageURL, setPreviewImageURL] = useState(user.profileUrl);
   const [potentialProfileImage, setPotentialProfileImage] = useState<any>(null);
 
@@ -95,7 +73,11 @@ function ShareModal() {
       const formData = new FormData();
       formData.append('profileImage', potentialProfileImage);
       formData.append('userDocumentId', user.userDocumentId);
-      await changeProfileImage(user.userDocumentId, formData);
+      // eslint-disable-next-line max-len
+      const response = await changeProfileImage(user.userDocumentId, formData) as any;
+      const { newProfileUrl } = response;
+      setUser({ ...user, profileUrl: newProfileUrl });
+      setIsOpenChangeProfileImageModalState(!isOpenChangeProfileImageModal);
     }
   };
 

--- a/client/src/views/profile-view.tsx
+++ b/client/src/views/profile-view.tsx
@@ -34,7 +34,7 @@ const LargeProfileImageBox = styled.img`
   border-radius: 30%;
 
   &:hover{
-    cursor: pointer;
+    cursor: ${(props: {isMine:boolean}) => (props.isMine && 'pointer')};
   };
 `;
 
@@ -117,7 +117,7 @@ function ProfileView({ match }: RouteComponentProps<{id: string}>) {
     };
 
     getUserDetail();
-  }, [isFollowingRef.current, profileId]);
+  }, [isFollowingRef.current, profileId, user]);
 
   if (loading) {
     return <LoadingSpinner />;
@@ -131,7 +131,8 @@ function ProfileView({ match }: RouteComponentProps<{id: string}>) {
       <ImageAndFollowButtonDiv>
         <LargeProfileImageBox
           src={userDetailInfo.current.profileUrl}
-          onClick={() => setIsOpenChangeProfileImageModalState(!isOpenChangeProfileImageModal)}
+          isMine={user.userId === profileId}
+          onClick={() => user.userId === profileId && setIsOpenChangeProfileImageModalState(!isOpenChangeProfileImageModal)}
         />
         {user.userId !== profileId
         && (

--- a/server/package.json
+++ b/server/package.json
@@ -26,7 +26,8 @@
     "multer": "^1.4.3",
     "multer-s3": "^2.10.0",
     "nodemailer": "^6.7.0",
-    "socket.io": "^4.3.2"
+    "socket.io": "^4.3.2",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@types/cookie-parser": "^1.4.2",
@@ -41,6 +42,7 @@
     "@types/node": "^16.11.6",
     "@types/nodemailer": "^6.4.4",
     "@types/socket.io": "^3.0.2",
+    "@types/uuid": "^8.3.3",
     "@typescript-eslint/eslint-plugin": "^5.2.0",
     "@typescript-eslint/parser": "^5.2.0",
     "eslint": "^7.32.0",

--- a/server/src/api/middlewares/image-upload.ts
+++ b/server/src/api/middlewares/image-upload.ts
@@ -20,7 +20,7 @@ const storage = multerS3({
   key(req:Request, file, cb) {
     const originFilename = file.originalname;
     const extension = originFilename.substring(originFilename.lastIndexOf('.'));
-    cb(null, `uploads/profile-images/${new Date().getTime()}${v4()}${extension}`);
+    cb(null, `uploads/profile-images/${new Date().getTime()}-${v4()}${extension}`);
   },
 });
 

--- a/server/src/api/middlewares/image-upload.ts
+++ b/server/src/api/middlewares/image-upload.ts
@@ -1,0 +1,27 @@
+import { Request } from 'express';
+import multer from 'multer';
+import multerS3 from 'multer-s3';
+import AWS from 'aws-sdk';
+import { v4 } from 'uuid';
+
+const s3 = new AWS.S3({
+  endpoint: new AWS.Endpoint(process.env.S3_ENDPOINT as string),
+  accessKeyId: process.env.AWS_ACCESSKEY,
+  secretAccessKey: process.env.AWS_SECRETKEY,
+  region: process.env.AWS_AWS_REGION,
+});
+
+const storage = multerS3({
+  s3,
+  bucket: process.env.S3_BUCKET as string,
+  contentType: multerS3.AUTO_CONTENT_TYPE,
+  acl: 'public-read',
+
+  key(req:Request, file, cb) {
+    const originFilename = file.originalname;
+    const extension = originFilename.substring(originFilename.lastIndexOf('.'));
+    cb(null, `uploads/profile-images/${new Date().getTime()}${v4()}${extension}`);
+  },
+});
+
+export default multer({ storage });

--- a/server/src/api/routes/user.ts
+++ b/server/src/api/routes/user.ts
@@ -5,7 +5,6 @@ import {
 import usersService from '@services/users-service';
 import authJWT from '@middlewares/auth';
 import imageUpload from '@middlewares/image-upload';
-import users from '@src/models/users';
 
 const userRouter = Router();
 

--- a/server/src/api/routes/user.ts
+++ b/server/src/api/routes/user.ts
@@ -1,16 +1,13 @@
 import {
   Router, Request, Response,
 } from 'express';
-import multer from 'multer';
 
 import usersService from '@services/users-service';
 import authJWT from '@middlewares/auth';
+import imageUpload from '@middlewares/image-upload';
+import users from '@src/models/users';
 
 const userRouter = Router();
-
-const upload = multer({
-  dest: 'uploads/',
-});
 
 export default (app: Router) => {
   app.use('/user', userRouter);
@@ -153,10 +150,14 @@ export default (app: Router) => {
     }
   });
 
-  userRouter.post('/profile-image', upload.single('profileImage'), async (req: Request, res: Response) => {
+  userRouter.post('/profile-image', imageUpload.single('profileImage'), async (req: Request, res: Response) => {
     const { userDocumentId } = req.body;
-
-    console.log(userDocumentId);
-    console.log(req.file);
+    const { location } = req.file as any;
+    try {
+      const result = await usersService.updateUserProfileUrl(userDocumentId, location);
+      res.json({ ok: result, newProfileUrl: location });
+    } catch (e) {
+      res.json({ ok: false });
+    }
   });
 };

--- a/server/src/services/users-service.ts
+++ b/server/src/services/users-service.ts
@@ -269,6 +269,15 @@ class UserService {
       return false;
     }
   }
+
+  async updateUserProfileUrl(userDocumentId: string, profileUrl: string) {
+    try {
+      await Users.updateOne({ _id: userDocumentId }, { profileUrl });
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
 }
 
 export default new UserService();

--- a/server/src/utils/jwt-util.ts
+++ b/server/src/utils/jwt-util.ts
@@ -8,8 +8,8 @@ export default {
     };
 
     return jwt.sign(payload, process.env.SECRET as string, {
-      algorithm: 'HS256',
-      expiresIn: '2h',
+      algorithm: process.env.ACCESSTOKEN_ALGORITHM as jwt.Algorithm,
+      expiresIn: process.env.ACCESSTOKEN_EXPIRESIN as string,
     });
   },
   verify: (token : any) => {
@@ -29,8 +29,8 @@ export default {
     }
   },
   refresh: () => jwt.sign({}, process.env.SECRET as string, {
-    algorithm: 'HS256',
-    expiresIn: '14d',
+    algorithm: process.env.REFRESHTOKEN_ALGORITHM as jwt.Algorithm,
+    expiresIn: process.env.REFRESHTOKEN_EXPIRESIN as string,
   }),
 
   refreshVerify: async (token : string) => {

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -856,6 +856,11 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
+"@types/uuid@^8.3.3":
+  version "8.3.3"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.3.tgz#c6a60686d953dbd1b1d45e66f4ecdbd5d471b4d0"
+  integrity sha512-0LbEEx1zxrYB3pgpd1M5lEhLcXjKJnYghvhTRgaBeUivLHMDM1TzF3IJ6hXU2+8uA4Xz+5BA63mtZo5DjVT8iA==
+
 "@types/webidl-conversions@*":
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/@types/webidl-conversions/-/webidl-conversions-6.1.1.tgz#e33bc8ea812a01f63f90481c666334844b12a09e"
@@ -5194,6 +5199,11 @@ uuid@3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
+
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8-compile-cache@^2.0.3:
   version "2.3.0"


### PR DESCRIPTION
## 개요
✨ 프로필 이미지 변경 기능 구현

## 작업사항
- ➕ uuid dependency 추가
  - 이미지 파일명의 중복을 막기 위해 uuid v4를 사용했습니다.
- ✨ 이미지 업로드 미들웨어 작성
  - 변경할 이미지를 담아 api요청을 보내면 multer를 이용해 object storage에 저장하는 미들웨어를 작성했스빈다.
- ✨ 프로필 이미지 Object Storage 저장 및 DB profileUrl 업데이트
  - object storage에 저장된 이미지 경로를 불러와 db의 user정보를 갱신시켜주었습니다.
- ♻️ useEffect userSocketRef disconnect 분리
  - 프로필 사진이 변경되면 active followingList에서 해당 유저가 사라지는 에러를 disconnect를 분리해줘서 해결했습니다.
- ♻️ 내 프로필 일때 이미지 사진 클릭, 수정 가능하도록 변경
  - 다른 사람의 프로필에서는 이미지 hover시 커서 변경과 클릭이 이루어지지 않도록 설정했습니다.
- ✨ 새로운 이미지 저장 후 경로 받아와 유저 정보 업데이트
  - API요청에서 응답으로 받아온 새 이미지의 경로를 전역으로 관리되고있는 user의 상태에도 반영해 주었습니다.
- ♻️ 토큰 알고리즘과 만료기한 환경변수로 설정
  - `jwt-util`에서 알고리즘과 만료기한을 리뷰받은 내용을 참고해 환경변수로 설정해주었습니다.

### 변경후

https://user-images.githubusercontent.com/59464537/143022800-aab5b793-c400-42a2-8466-091a6275cc3a.mov

