### PR TITLE
이벤트 등록 모달 기능 추가

### DIFF
--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -162,7 +162,7 @@ export const getSearchResult = async (searchInfo: {keyword:string, option:string
   }
 };
 
-export const findUsersById = async (findUserList: Array<string>) => {
+export const findUsersByIdList = async (findUserList: Array<string>) => {
   try {
     let response = await fetch(`${process.env.REACT_APP_API_URL}/api/user/info`, {
       method: 'post',

--- a/client/src/components/activity-header.tsx
+++ b/client/src/components/activity-header.tsx
@@ -19,7 +19,7 @@ function ActivityHeader() {
   return (
     <CustomtHeader>
       {makeIconToLink(Icon)}
-      <HeaderTitleNunito>ACTIVITY</HeaderTitleNunito>
+      <HeaderTitleNunito to="/activity">ACTIVITY</HeaderTitleNunito>
       <div />
     </CustomtHeader>
   );

--- a/client/src/components/common/header.tsx
+++ b/client/src/components/common/header.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
 export const CustomtHeader = styled.nav`
@@ -15,7 +16,7 @@ export const CustomtHeader = styled.nav`
   }
 `;
 
-export const HeaderTitleNunito = styled.div`
+export const HeaderTitleNunito = styled(Link)`
   position: absolute;
   line-height: 48px;
   left: 47.5%;

--- a/client/src/components/common/user-card-list.tsx
+++ b/client/src/components/common/user-card-list.tsx
@@ -20,7 +20,7 @@ interface UserCardProps {
 
 const makeUserToCard = ({ cardType, userList }: UserCardProps) => (
   userList.map((user) => (
-    <div key={user._id} className="userCard" data-id={user._id} data-username={user.userName}>
+    <div key={user._id} className="userCard" data-id={user._id} data-userId={user.userId} data-username={user.userName}>
       <UserCard
       // eslint-disable-next-line no-underscore-dangle
         key={user._id}

--- a/client/src/components/event/event-header.tsx
+++ b/client/src/components/event/event-header.tsx
@@ -1,13 +1,15 @@
+/* eslint-disable max-len */
 import React from 'react';
 import styled from 'styled-components';
 import { IconType } from 'react-icons';
 import { MdOutlineArrowBackIos } from 'react-icons/md';
 import { BiCalendarPlus } from 'react-icons/bi';
-import { useSetRecoilState } from 'recoil';
+import { useResetRecoilState, useSetRecoilState } from 'recoil';
 
 import { CustomtHeader, HeaderTitleNunito } from '@common/header';
 import { makeIconToLink } from '@utils/index';
 import { isOpenEventRegisterModalState } from '@atoms/is-open-modal';
+import { nowCountState, nowFetchingState, nowItemsListState } from '@src/recoil/atoms/main-section-scroll';
 
 interface IconAndLink {
   Component:IconType,
@@ -29,6 +31,9 @@ const EventAddButton = styled.div`
 function EventHeader() {
   const Icon: IconAndLink = { Component: MdOutlineArrowBackIos, link: '/', key: 'main' };
   const setIsOpenModal = useSetRecoilState(isOpenEventRegisterModalState);
+  const setNowFetching = useSetRecoilState(nowFetchingState);
+  const resetNowItemsList = useResetRecoilState(nowItemsListState);
+  const setNowCount = useSetRecoilState(nowCountState);
 
   const changeModalState = () => {
     setIsOpenModal(true);
@@ -38,7 +43,7 @@ function EventHeader() {
     <>
       <CustomtHeader>
         {makeIconToLink(Icon)}
-        <HeaderTitleNunito>
+        <HeaderTitleNunito to="/event" onClick={() => { resetNowItemsList(); setNowCount(0); setNowFetching(true); }}>
           UPCOMING FOR EVERYONE
         </HeaderTitleNunito>
         <EventAddButton>

--- a/client/src/components/event/event-modal.tsx
+++ b/client/src/components/event/event-modal.tsx
@@ -11,6 +11,7 @@ function EventModal() {
     <>
       <BackgroundWrapper onClick={() => setIsOpenEventModal(false)} />
       <ModalBox>
+        <h1>Detailed page is not available yet.</h1>
         <button type="button" aria-label="test" onClick={() => setIsOpenEventModal(false)}>cancle</button>
       </ModalBox>
     </>

--- a/client/src/components/event/event-register-modal.tsx
+++ b/client/src/components/event/event-register-modal.tsx
@@ -1,11 +1,12 @@
 /* eslint-disable max-len */
 import React, { useRef, useState } from 'react';
 import styled from 'styled-components';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useResetRecoilState, useSetRecoilState } from 'recoil';
 
 import { isOpenEventRegisterModalState } from '@atoms/is-open-modal';
 import { ModalBox, BackgroundWrapper } from '@common/modal';
 import { postEvent } from '@api/index';
+import { nowCountState, nowFetchingState, nowItemsListState } from '@src/recoil/atoms/main-section-scroll';
 import EventSelectUserDropdown from './event-select-uesr-dropdown';
 
 const CustomEventRegisterModal = styled(ModalBox)`
@@ -125,6 +126,9 @@ function EventRegisterModal() {
   const textDescRef = useRef<HTMLTextAreaElement>(null);
   const [selectedList, setSelectedList] = useState<string[]>([]);
   const [isOpenSelectedList, setisOpenSelectedList] = useState(false);
+  const setNowFetching = useSetRecoilState(nowFetchingState);
+  const resetNowItemsList = useResetRecoilState(nowItemsListState);
+  const setNowCount = useSetRecoilState(nowCountState);
 
   const changeModalState = () => {
     setIsOpenModal(!isOpenModal);
@@ -153,6 +157,9 @@ function EventRegisterModal() {
       .catch((err) => console.error(err));
 
     changeModalState();
+    resetNowItemsList();
+    setNowCount(0);
+    setNowFetching(true);
   };
 
   if (isOpenModal) {

--- a/client/src/components/event/event-register-modal.tsx
+++ b/client/src/components/event/event-register-modal.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 import React, { useRef, useState } from 'react';
 import styled from 'styled-components';
 import { useRecoilState } from 'recoil';
@@ -5,6 +6,7 @@ import { useRecoilState } from 'recoil';
 import { isOpenEventRegisterModalState } from '@atoms/is-open-modal';
 import { ModalBox, BackgroundWrapper } from '@common/modal';
 import { postEvent } from '@api/index';
+import EventSelectUserDropdown from './event-select-uesr-dropdown';
 
 const CustomEventRegisterModal = styled(ModalBox)`
   top: 15vh;
@@ -92,8 +94,26 @@ const CustomTextArea = styled.textarea`
   &:focus {outline:none;}
 `;
 
+const SelectUserComponent = styled.div`
+  padding: 0px 5px;
+  background-color: #F1F0E4;
+  border-radius: 30px;
+
+  font-family: 'Nunito';
+  color: #819C88;
+
+  cursor: default;
+`;
+
 const InputDescSpan = styled.span`
   color : gray;
+`;
+
+const AddGuestSpan = styled.span`
+  color : gray;
+  &:hover {
+    cursor: pointer;
+  }
 `;
 
 function EventRegisterModal() {
@@ -103,6 +123,8 @@ function EventRegisterModal() {
   const inputDateRef = useRef<HTMLInputElement>(null);
   const inputTimeRef = useRef<HTMLInputElement>(null);
   const textDescRef = useRef<HTMLTextAreaElement>(null);
+  const [selectedList, setSelectedList] = useState<string[]>([]);
+  const [isOpenSelectedList, setisOpenSelectedList] = useState(false);
 
   const changeModalState = () => {
     setIsOpenModal(!isOpenModal);
@@ -121,7 +143,7 @@ function EventRegisterModal() {
   const publishButtonHandler = () => {
     const eventInfo = {
       title: inputTitleRef.current?.value,
-      participants: ['test'],
+      participants: selectedList,
       date: new Date(`${inputDateRef.current?.value} ${inputTimeRef.current?.value}`),
       description: textDescRef.current?.value,
     };
@@ -148,10 +170,15 @@ function EventRegisterModal() {
               <CustomInput type="text" ref={inputTitleRef} name="title" placeholder="Event Name" onChange={inputOnChange} />
               <CustomInputDiv>
                 <InputDescSpan>with</InputDescSpan>
-                <div />
+                {selectedList.map((userId: string) => (
+                  <SelectUserComponent key={userId} data-id={userId}>
+                    {userId}
+                  </SelectUserComponent>
+                ))}
               </CustomInputDiv>
               <CustomInputDiv>
-                <InputDescSpan>Add a Co-host or Guest</InputDescSpan>
+                <AddGuestSpan onClick={() => setisOpenSelectedList((now) => (!now))}>Add a Co-host or Guest</AddGuestSpan>
+                <EventSelectUserDropdown isOpenSelectedList={isOpenSelectedList} setSelectedList={setSelectedList} />
               </CustomInputDiv>
             </CustomFormBox>
             <CustomFormBox>

--- a/client/src/components/event/event-register-modal.tsx
+++ b/client/src/components/event/event-register-modal.tsx
@@ -172,7 +172,7 @@ function EventRegisterModal() {
                 <InputDescSpan>with</InputDescSpan>
                 {selectedList.map((userId: string) => (
                   <SelectUserComponent key={userId} data-id={userId}>
-                    {userId}
+                    {`@${userId}`}
                   </SelectUserComponent>
                 ))}
               </CustomInputDiv>

--- a/client/src/components/event/event-register-modal.tsx
+++ b/client/src/components/event/event-register-modal.tsx
@@ -81,10 +81,17 @@ const CustomInput = styled.input`
 `;
 
 const CustomInputDiv = styled.div`
-display: flex;
-height:20px;
-width: 80%;
-margin: 5px;`;
+  display: flex;
+  height:20px;
+  width: 80%;
+  margin: 5px;
+  overflow-x: scroll;
+  -ms-overflow-style: none; 
+  scrollbar-width: none; 
+  &::-webkit-scrollbar {
+    display: none;
+    }
+`;
 
 const CustomTextArea = styled.textarea`
   border: none;

--- a/client/src/components/event/event-select-uesr-dropdown.tsx
+++ b/client/src/components/event/event-select-uesr-dropdown.tsx
@@ -1,0 +1,71 @@
+/* eslint-disable max-len */
+import React, { useState, useEffect, MouseEvent } from 'react';
+import { useRecoilValue } from 'recoil';
+import styled from 'styled-components';
+
+import followingListState from '@atoms/following-list';
+import UserCardList from '@components/common/user-card-list';
+import { findUsersByIdList } from '@src/api';
+import { IUserForCard } from '@interfaces/index';
+import LoadingSpinner from '@common/loading-spinner';
+
+interface IEventSelectUserDropdownProps {
+  setSelectedList: React.Dispatch<React.SetStateAction<string[]>>,
+  isOpenSelectedList: boolean,
+}
+
+const DropDownWrapper = styled.div`
+  display: ${(props: { isOpenSelectedList: boolean}) => !props.isOpenSelectedList && 'none'};
+  position: absolute;
+  top: 30%;
+  width: 200px;
+  max-height: 300px;
+  overflow-y: scroll;
+  background-color: #F1F0E4;
+  border-radius: 30px;
+  -ms-overflow-style: none; 
+  scrollbar-width: none; 
+  &::-webkit-scrollbar {
+    display: none;
+    }
+`;
+
+const EventSelectUserDropdown = React.memo(({ setSelectedList, isOpenSelectedList }: IEventSelectUserDropdownProps) => {
+  const followingList = useRecoilValue(followingListState);
+  const [userList, setUserList] = useState<IUserForCard[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const clickSelectedList = (e: MouseEvent) => {
+    const userCardDiv = (e.target as HTMLDivElement).closest('.userCard');
+    const userName = userCardDiv?.getAttribute('data-username');
+    if (!userName) return;
+    setSelectedList((list) => {
+      if (list.includes(userName)) {
+        return list.filter((inListUserId) => inListUserId !== userName);
+      }
+      return [...list.filter((inListUserId) => inListUserId !== userName), userName];
+    });
+  };
+
+  useEffect(() => {
+    findUsersByIdList(followingList)
+      .then((res: any) => setUserList(res.userList))
+      .then(() => setLoading(false));
+  }, [followingList]);
+
+  if (loading) {
+    return (
+      <DropDownWrapper isOpenSelectedList={isOpenSelectedList}>
+        <LoadingSpinner />
+      </DropDownWrapper>
+    );
+  }
+
+  return (
+    <DropDownWrapper isOpenSelectedList={isOpenSelectedList}>
+      <UserCardList cardType="others" userList={userList} clickEvent={clickSelectedList} />
+    </DropDownWrapper>
+  );
+});
+
+export default EventSelectUserDropdown;

--- a/client/src/components/event/event-select-uesr-dropdown.tsx
+++ b/client/src/components/event/event-select-uesr-dropdown.tsx
@@ -37,13 +37,13 @@ const EventSelectUserDropdown = React.memo(({ setSelectedList, isOpenSelectedLis
 
   const clickSelectedList = (e: MouseEvent) => {
     const userCardDiv = (e.target as HTMLDivElement).closest('.userCard');
-    const userName = userCardDiv?.getAttribute('data-username');
-    if (!userName) return;
+    const userId = userCardDiv?.getAttribute('data-userId');
+    if (!userId) return;
     setSelectedList((list) => {
-      if (list.includes(userName)) {
-        return list.filter((inListUserId) => inListUserId !== userName);
+      if (list.includes(userId)) {
+        return list.filter((inListUserId) => inListUserId !== userId);
       }
-      return [...list.filter((inListUserId) => inListUserId !== userName), userName];
+      return [...list.filter((inListUserId) => inListUserId !== userId), userId];
     });
   };
 

--- a/client/src/components/invite-header.tsx
+++ b/client/src/components/invite-header.tsx
@@ -19,7 +19,7 @@ function InviteHeader() {
   return (
     <CustomtHeader>
       {makeIconToLink(Icon)}
-      <HeaderTitleNunito>INVITE</HeaderTitleNunito>
+      <HeaderTitleNunito to="/invite">INVITE</HeaderTitleNunito>
       <div />
     </CustomtHeader>
   );

--- a/client/src/components/profile/followers-header.tsx
+++ b/client/src/components/profile/followers-header.tsx
@@ -13,11 +13,11 @@ const LogoTitle = styled(Link)`
   text-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
 `;
 
-function FollowersHeader({ history }: RouteComponentProps) {
+function FollowersHeader({ history, location }: RouteComponentProps) {
   return (
     <CustomtHeader>
       <MdOutlineArrowBackIos onClick={() => history.goBack()} size={48} />
-      <HeaderTitleNunito>FOLLOWERS</HeaderTitleNunito>
+      <HeaderTitleNunito to={location.pathname}>FOLLOWERS</HeaderTitleNunito>
       <LogoTitle to="/">NOGARIHOUSE</LogoTitle>
     </CustomtHeader>
   );

--- a/client/src/components/profile/following-header.tsx
+++ b/client/src/components/profile/following-header.tsx
@@ -13,11 +13,11 @@ const LogoTitle = styled(Link)`
   text-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
 `;
 
-function FollowingHeader({ history }: RouteComponentProps) {
+function FollowingHeader({ history, location }: RouteComponentProps) {
   return (
     <CustomtHeader>
       <MdOutlineArrowBackIos onClick={() => history.goBack()} size={48} />
-      <HeaderTitleNunito>FOLLOWING</HeaderTitleNunito>
+      <HeaderTitleNunito to={location.pathname}>FOLLOWING</HeaderTitleNunito>
       <LogoTitle to="/">NOGARIHOUSE</LogoTitle>
     </CustomtHeader>
   );

--- a/client/src/components/profile/profile-header.tsx
+++ b/client/src/components/profile/profile-header.tsx
@@ -31,7 +31,7 @@ const IconContainer = styled.div`
     filter: invert(88%) sepia(1%) saturate(4121%) hue-rotate(12deg) brightness(62%) contrast(79%);
   }
 `;
-function ProfileHeader({ match, history }: RouteComponentProps<{id: string}>) {
+function ProfileHeader({ match, history, location }: RouteComponentProps<{id: string}>) {
   const SettingIcon: IconAndLink = { Component: MdSettings, link: '/settings', key: 'setting' };
   const user = useRecoilValue(userState);
   const setIsOpenModal = useSetRecoilState(isOpenShareModalState);
@@ -44,7 +44,7 @@ function ProfileHeader({ match, history }: RouteComponentProps<{id: string}>) {
     <>
       <CustomtHeader>
         <MdOutlineArrowBackIos onClick={() => history.goBack()} size={48} />
-        <HeaderTitleNunito>
+        <HeaderTitleNunito to={location.pathname}>
           Profile
         </HeaderTitleNunito>
         <IconContainer>

--- a/client/src/components/room/follower-select-room-modal.tsx
+++ b/client/src/components/room/follower-select-room-modal.tsx
@@ -10,7 +10,7 @@ import roomViewState from '@atoms/room-view-type';
 import { BackgroundWrapper } from '@common/modal';
 import UserCardList from '@components/common/user-card-list';
 import FollowerSelectRoomHeader from '@components/room/follower-select-room-header';
-import { findUsersById } from '@api/index';
+import { findUsersByIdList } from '@api/index';
 import Scroll from '@styles/scrollbar-style';
 import { slideYFromTo } from '@src/assets/styles/keyframe';
 import DefaultButton from '@src/components/common/default-button';
@@ -151,7 +151,7 @@ function FollowerSelectModal() {
   };
 
   useEffect(() => {
-    findUsersById(followingList).then((res: any) => {
+    findUsersByIdList(followingList).then((res: any) => {
       const selectedUserIds = selectedUsers.map((user: any) => user.userDocumentId);
       setAllUserList(res.userList);
       setFilteredUserList(res.userList.filter((user: any) => selectedUserIds.indexOf(user._id) === -1));

--- a/client/src/components/search/recent-search-header.tsx
+++ b/client/src/components/search/recent-search-header.tsx
@@ -19,7 +19,7 @@ function RecentSearchHeader() {
   return (
     <CustomtHeader>
       {makeIconToLink(Icon)}
-      <HeaderTitleNunito>Recently Listened to</HeaderTitleNunito>
+      <HeaderTitleNunito to="/search/recent">Recently Listened to</HeaderTitleNunito>
       <div />
     </CustomtHeader>
   );

--- a/client/src/components/search/search-header.tsx
+++ b/client/src/components/search/search-header.tsx
@@ -22,7 +22,7 @@ function SearchHeader() {
   return (
     <CustomtHeader>
       {Icons.map(makeIconToLink)}
-      <HeaderTitleNunito>Explore</HeaderTitleNunito>
+      <HeaderTitleNunito to="/search">Explore</HeaderTitleNunito>
     </CustomtHeader>
   );
 }

--- a/client/src/views/chat-rooms-new-view.tsx
+++ b/client/src/views/chat-rooms-new-view.tsx
@@ -7,7 +7,7 @@ import { useRecoilValue, useRecoilState } from 'recoil';
 import NewChatRoomHeader from '@src/components/chat/chat-new-header';
 import { ChatRoomsLayout } from '@components/chat/style';
 import UserCardList from '@components/common/user-card-list';
-import { findUsersById } from '@api/index';
+import { findUsersByIdList } from '@api/index';
 import followType from '@atoms/following-list';
 import selectedUserType from '@atoms/chat-selected-users';
 
@@ -110,7 +110,7 @@ function ChatRoomsNewView() {
   };
 
   useEffect(() => {
-    findUsersById(followingList).then((res: any) => {
+    findUsersByIdList(followingList).then((res: any) => {
       const selectedUserIds = selectedUsers.map((user: any) => user.userDocumentId);
       setAllUserList(res.userList);
       setFilteredUserList(res.userList.filter((user: any) => selectedUserIds.indexOf(user._id) === -1));

--- a/server/src/api/routes/event.ts
+++ b/server/src/api/routes/event.ts
@@ -9,9 +9,13 @@ export default (app: Router) => {
 
   eventRouter.get('/', async (req:Request, res:Response) => {
     const { count } = req.query;
-    const items = (await eventsService.get10EventItems(Number(count)))
-      ?.map(eventsService.makeItemToEventInterface);
-    res.json({ items });
+    const rawItems = await eventsService.get10EventItems(Number(count));
+    if (!rawItems) {
+      res.json({ ok: false });
+    } else {
+      const items = await Promise.all(rawItems.map(eventsService.makeItemToEventInterface));
+      res.json({ ok: true, items });
+    }
   });
 
   eventRouter.post('/', async (req: Request, res: Response) => {

--- a/server/src/api/routes/event.ts
+++ b/server/src/api/routes/event.ts
@@ -4,17 +4,16 @@ import eventsService from '@services/events-service';
 
 const eventRouter = Router();
 
-const get10EventItems = async (req:Request, res:Response) => {
-  const { count } = req.query;
-  const items = (await eventsService.get10EventItems(Number(count)))
-    ?.map(eventsService.makeItemToEventInterface);
-  res.json({ items });
-};
-
 export default (app: Router) => {
   app.use('/event', eventRouter);
 
-  eventRouter.get('/', get10EventItems);
+  eventRouter.get('/', async (req:Request, res:Response) => {
+    const { count } = req.query;
+    const items = (await eventsService.get10EventItems(Number(count)))
+      ?.map(eventsService.makeItemToEventInterface);
+    res.json({ items });
+  });
+
   eventRouter.post('/', async (req: Request, res: Response) => {
     try {
       const {

--- a/server/src/api/routes/user.ts
+++ b/server/src/api/routes/user.ts
@@ -77,7 +77,7 @@ export default (app: Router) => {
       const { userId } = req.params;
       const { count } = req.query;
       const documentIdOffollowingList = await usersService.getFollowingsList(userId, Number(count));
-      const followingList = await usersService.findUsersById(documentIdOffollowingList!.followings);
+      const followingList = await usersService.findUsersByIdList(documentIdOffollowingList!.followings);
       res.status(200).json({
         result: true,
         items: followingList,
@@ -92,7 +92,7 @@ export default (app: Router) => {
       const { userId } = req.params;
       const { count } = req.query;
       const documentIdOfFollowerList = await usersService.getFollowersList(userId, Number(count));
-      const followerList = await usersService.findUsersById(documentIdOfFollowerList!.followers);
+      const followerList = await usersService.findUsersByIdList(documentIdOfFollowerList!.followers);
       res.status(200).json({
         result: true,
         items: followerList,
@@ -145,7 +145,7 @@ export default (app: Router) => {
   userRouter.post('/info', async (req: Request, res: Response) => {
     const userDocumentIdList = req.body;
     try {
-      const userList = (await usersService.findUsersById(userDocumentIdList.userList))
+      const userList = (await usersService.findUsersByIdList(userDocumentIdList.userList))
         ?.map(usersService.makeItemToUserInterface);
       res.json({ ok: true, userList });
     } catch (e) {

--- a/server/src/services/events-service.ts
+++ b/server/src/services/events-service.ts
@@ -1,6 +1,7 @@
 /* eslint-disable consistent-return */
 /* eslint-disable no-underscore-dangle */
 import Events, { IEventsTypesModel } from '@models/events';
+import usersService from './users-service';
 
 export default {
   get10EventItems: async (count : number) => {
@@ -22,15 +23,18 @@ export default {
     }
   },
 
-  makeItemToEventInterface: (item : IEventsTypesModel & {_id: number}) => (
-    {
+  makeItemToEventInterface: async (item : IEventsTypesModel & {_id: number}) => {
+    const participantsList = await Promise.all(item.participants
+      .map(async (userId) => usersService.findUserByUserId(userId)));
+    return {
       key: item._id,
       time: String(item.date),
       title: item.title,
-      participants: item.participants,
+      participants: participantsList,
       description: item.description,
       type: 'event',
-    }),
+    };
+  },
 
   makeDateToHour: (stringDate : string):string => {
     const date = new Date(stringDate);

--- a/server/src/services/events-service.ts
+++ b/server/src/services/events-service.ts
@@ -5,9 +5,8 @@ import usersService from './users-service';
 
 export default {
   get10EventItems: async (count : number) => {
-    const gmtDate = (new Date()).getTime();
     try {
-      const items = await Events.find({ date: { $gte: new Date(gmtDate + 9 * 60 * 60 * 1000) } })
+      const items = await Events.find({ date: { $gte: new Date() } })
         .sort({ date: 1 })
         .skip(count)
         .limit(10);
@@ -40,16 +39,11 @@ export default {
     };
   },
 
-  makeDateToHour: (stringDate : string):string => {
-    const date = new Date(stringDate);
-    return `${((date.getHours).toString()).padStart(2, '0')}:${((date.getMinutes).toString()).padStart(2, '0')}`;
-  },
-
   setEvent: (title:string, participants:object, date:Date, description:string) => {
     const newEvent = new Events({
       title,
       participants,
-      date,
+      date: new Date(date),
       description,
     });
     return newEvent.save();

--- a/server/src/services/events-service.ts
+++ b/server/src/services/events-service.ts
@@ -6,7 +6,10 @@ import usersService from './users-service';
 export default {
   get10EventItems: async (count : number) => {
     try {
-      const items = await Events.find({}).sort({ date: 1 }).skip(count).limit(10);
+      const items = await Events.find({ date: { $gte: new Date() } })
+        .sort({ date: 1 })
+        .skip(count)
+        .limit(10);
       return items;
     } catch (e) {
       console.error(e);

--- a/server/src/services/events-service.ts
+++ b/server/src/services/events-service.ts
@@ -5,8 +5,9 @@ import usersService from './users-service';
 
 export default {
   get10EventItems: async (count : number) => {
+    const gmtDate = (new Date()).getTime();
     try {
-      const items = await Events.find({ date: { $gte: new Date() } })
+      const items = await Events.find({ date: { $gte: new Date(gmtDate + 9 * 60 * 60 * 1000) } })
         .sort({ date: 1 })
         .skip(count)
         .limit(10);

--- a/server/src/services/users-service.ts
+++ b/server/src/services/users-service.ts
@@ -238,7 +238,7 @@ class UserService {
     }
   }
 
-  async findUsersById(documentIdList: Array<string>) {
+  async findUsersByIdList(documentIdList: Array<string>) {
     try {
       const participantsInfo = Users.find({ _id: { $in: documentIdList } });
       return participantsInfo;


### PR DESCRIPTION
## 개요
이벤트 등록 모달 기능 추가

## 작업사항
- 이벤트 등록 모달에서 함께할 인원을 선택할 수 있습니다.
- 이벤트 화면에서 헤더 글씨를 클릭하면 이벤트 리스트를 새로고침합니다.
- 이벤트를 현재 시각 기준으로 이후의 이벤트만 보여줍니다.

## 기타
- 오늘 작업 마무리에서 설명한 것에서 크게 추가된 것이 없습니다..!