### PR TITLE
✨ 로그아웃 기능 구현 & 반응형 마무리

### DIFF
--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -324,3 +324,19 @@ export const getRandomRoomDocumentId = async () => {
     console.error(error);
   }
 };
+
+export const deleteRefreshToken = async (userDocumentId: string) => {
+  try {
+    let response = await fetch(`${process.env.REACT_APP_API_URL}/api/user/signout`, {
+      method: 'post',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ userDocumentId }),
+    });
+    response = await response.json();
+    return response;
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/client/src/assets/styles/global-styles.ts
+++ b/client/src/assets/styles/global-styles.ts
@@ -21,6 +21,9 @@ const GlobalStyle = createGlobalStyle`
   }
 
   body {
+    @media (min-width: 1025px) {
+      height: 100vh;
+    }
     font-family: 'Nunito';
     font-weight: normal;
     font-style: normal;

--- a/client/src/assets/styles/global-styles.ts
+++ b/client/src/assets/styles/global-styles.ts
@@ -30,6 +30,8 @@ const GlobalStyle = createGlobalStyle`
     font-size: 16px;
     background-color: #F1F0E4;
     width: 100vw;
+    height: 100vh;
+    max-height: -webkit-fill-available;
     min-width: 320px;
     user-select: none;
     overflow: hidden;

--- a/client/src/components/activity-header.tsx
+++ b/client/src/components/activity-header.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { IconType } from 'react-icons';
 import { MdOutlineArrowBackIos } from 'react-icons/md';
 
-import { CustomtHeader, HeaderTitleNunito } from '@common/header';
+import { CustomtHeader, HeaderTitleNunito, CustomMenuIconsLayout } from '@common/header';
 import { makeIconToLink } from '@utils/index';
 
 interface IconAndLink {
@@ -18,7 +18,9 @@ function ActivityHeader() {
 
   return (
     <CustomtHeader>
-      {makeIconToLink(Icon)}
+      <CustomMenuIconsLayout>
+        {makeIconToLink(Icon)}
+      </CustomMenuIconsLayout>
       <HeaderTitleNunito to="/activity">ACTIVITY</HeaderTitleNunito>
       <div />
     </CustomtHeader>

--- a/client/src/components/common/default-header.tsx
+++ b/client/src/components/common/default-header.tsx
@@ -30,6 +30,7 @@ const CustomDefaultHeader = styled.nav`
 
   display: flex;
   justify-content: space-between;
+  align-items: center;
 `;
 
 const MenuIconsLayout = styled.nav`
@@ -153,7 +154,7 @@ function DefaultHeader() {
           <OpenMenuButton onClick={() => { setIsOpenMenu(!isOpenMenu); }}>
             <HiMenu size="48" />
           </OpenMenuButton>
-          <OpenRoomStateButton onClick={() => { setIsOpenRoom(!isOpenRoom); }}>
+          <OpenRoomStateButton className="open-room-button" onClick={() => { setIsOpenRoom(!isOpenRoom); }}>
             <HiTable size="48" />
           </OpenRoomStateButton>
         </ResponsiveMenuIconsLayout>

--- a/client/src/components/common/default-header.tsx
+++ b/client/src/components/common/default-header.tsx
@@ -16,13 +16,12 @@ import {
   useRecoilState, useRecoilValue, useResetRecoilState, useSetRecoilState,
 } from 'recoil';
 
-import { makeIconToLink, removeAccessToken } from '@utils/index';
+import { makeIconToLink, signOutHandler } from '@utils/index';
 import userState from '@atoms/user';
 import { nowCountState, nowFetchingState, nowItemsListState } from '@atoms/main-section-scroll';
 import isOpenSliderMenuState from '@atoms/is-open-slider-menu';
 import isOpenRoomState from '@atoms/is-open-room';
 import SliderMenu from '@common/menu-modal';
-import { deleteRefreshToken } from '@src/api';
 
 const CustomDefaultHeader = styled.nav`
   width: 100%;
@@ -145,12 +144,6 @@ function DefaultHeader() {
     { Component: HiOutlineCalendar, link: '/event', key: 'event' },
     { Component: HiOutlineBell, link: '/activity', key: 'activity' },
   ];
-
-  const signOutHandler = async () => {
-    removeAccessToken();
-    await deleteRefreshToken(user.userDocumentId);
-    window.location.reload();
-  };
 
   return (
     <>

--- a/client/src/components/common/default-header.tsx
+++ b/client/src/components/common/default-header.tsx
@@ -3,7 +3,14 @@ import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import { IconType } from 'react-icons';
 import {
-  HiOutlinePaperAirplane, HiSearch, HiOutlineMail, HiOutlineCalendar, HiOutlineBell, HiOutlineLogout,
+  HiOutlinePaperAirplane,
+  HiSearch,
+  HiOutlineMail,
+  HiOutlineCalendar,
+  HiOutlineBell,
+  HiOutlineLogout,
+  HiMenu,
+  HiTable,
 } from 'react-icons/hi';
 import {
   useRecoilState, useRecoilValue, useResetRecoilState, useSetRecoilState,
@@ -55,6 +62,13 @@ const OpenMenuButton = styled.button`
   @media (min-width: 1025px) {
       display: none;
   }
+  background: inherit ;
+  border:none;
+  box-shadow:none;
+  border-radius:0;
+  padding:0;
+  overflow:visible;
+  cursor:pointer;
   margin-left: 24px;
 `;
 
@@ -63,6 +77,13 @@ const OpenRoomStateButton = styled.button`
       display: none;
   }
 
+  background: inherit ;
+  border:none;
+  box-shadow:none;
+  border-radius:0;
+  padding:0;
+  overflow:visible;
+  cursor:pointer;
   margin-right: 24px;
 `;
 
@@ -136,9 +157,11 @@ function DefaultHeader() {
       <CustomDefaultHeader>
         <LogoTitle to="/" onClick={() => { resetNowItemsList(); setNowCount(0); setNowFetching(true); }}> NogariHouse </LogoTitle>
         <ResponsiveMenuIconsLayout>
-          <OpenMenuButton onClick={() => { setIsOpenMenu(!isOpenMenu); }}>Menu</OpenMenuButton>
+          <OpenMenuButton onClick={() => { setIsOpenMenu(!isOpenMenu); }}>
+            <HiMenu size="48" />
+          </OpenMenuButton>
           <OpenRoomStateButton onClick={() => { setIsOpenRoom(!isOpenRoom); }}>
-            Room
+            <HiTable size="48" />
           </OpenRoomStateButton>
         </ResponsiveMenuIconsLayout>
         <MenuIconsLayout>

--- a/client/src/components/common/default-header.tsx
+++ b/client/src/components/common/default-header.tsx
@@ -40,7 +40,7 @@ const MenuIconsLayout = styled.nav`
   position: relative;
   width: 100%;
   height: 48px;
-  margin: 0 24px;
+  margin: 0 min(1vw,24px);
 
   display: flex;
   justify-content: space-between;
@@ -52,7 +52,7 @@ const ResponsiveMenuIconsLayout = styled.nav`
   }
   width: 100%;
   height: 48px;
-  margin: 0 24px;
+  margin: 0 min(1vw,24px);
 
   display: flex;
   justify-content: space-between;
@@ -69,7 +69,7 @@ const OpenMenuButton = styled.button`
   padding:0;
   overflow:visible;
   cursor:pointer;
-  margin-left: 24px;
+  margin-left: min(2vw,24px);
 `;
 
 const OpenRoomStateButton = styled.button`
@@ -84,7 +84,7 @@ const OpenRoomStateButton = styled.button`
   padding:0;
   overflow:visible;
   cursor:pointer;
-  margin-right: 24px;
+  margin-right: min(2vw,24px);
 `;
 
 const IconContainer = styled.div`

--- a/client/src/components/common/default-header.tsx
+++ b/client/src/components/common/default-header.tsx
@@ -3,24 +3,24 @@ import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import { IconType } from 'react-icons';
 import {
-  HiOutlinePaperAirplane, HiSearch, HiOutlineMail, HiOutlineCalendar, HiOutlineBell,
+  HiOutlinePaperAirplane, HiSearch, HiOutlineMail, HiOutlineCalendar, HiOutlineBell, HiOutlineLogout,
 } from 'react-icons/hi';
 import {
   useRecoilState, useRecoilValue, useResetRecoilState, useSetRecoilState,
 } from 'recoil';
 
-import { makeIconToLink } from '@utils/index';
+import { makeIconToLink, removeAccessToken } from '@utils/index';
 import userState from '@atoms/user';
 import { nowCountState, nowFetchingState, nowItemsListState } from '@atoms/main-section-scroll';
 import isOpenSliderMenuState from '@atoms/is-open-slider-menu';
 import isOpenRoomState from '@atoms/is-open-room';
 import SliderMenu from '@common/menu-modal';
+import { deleteRefreshToken } from '@src/api';
 
 const CustomDefaultHeader = styled.nav`
-  position: relative;
-  width: 95%;
+  width: 100%;
   height: 48px;
-  margin: 24px;
+  margin: 24px 0;
 
   display: flex;
   justify-content: space-between;
@@ -33,29 +33,44 @@ const MenuIconsLayout = styled.nav`
   position: relative;
   width: 100%;
   height: 48px;
+  margin: 0 24px;
+
+  display: flex;
+  justify-content: space-between;
+`;
+
+const ResponsiveMenuIconsLayout = styled.nav`
+  @media (min-width: 1025px) {
+    display: none;
+  }
+  width: 100%;
+  height: 48px;
+  margin: 0 24px;
 
   display: flex;
   justify-content: space-between;
 `;
 
 const OpenMenuButton = styled.button`
-  @media (min-width: 1024px) {
+  @media (min-width: 1025px) {
       display: none;
   }
+  margin-left: 24px;
 `;
 
 const OpenRoomStateButton = styled.button`
-  margin-right: 24px;
   @media (min-width: 768px) {
       display: none;
   }
+
+  margin-right: 24px;
 `;
 
 const IconContainer = styled.div`
   display: flex;
   justify-content: space-between;
 
-  a:not(:last-child) {
+  a {
     margin-right: 30px;
   }
 
@@ -66,8 +81,8 @@ const IconContainer = styled.div`
 
 const LogoTitle = styled(Link)`
   position: absolute;
-  left: 47.5%;
-  transform: translateX(-47.5%);
+  left: 50%;
+  transform: translateX(-50%);
   font-family: "Bangers";
   font-size: min(8vw, 48px);
   text-decoration: none;
@@ -80,7 +95,6 @@ const ImageLayout = styled.img`
     width: 48px;
     min-width: 48px;
     height: 48px;
-    margin-right: 10px;
     border-radius: 70%;
     overflow: hidden;
 `;
@@ -110,21 +124,31 @@ function DefaultHeader() {
     { Component: HiOutlineCalendar, link: '/event', key: 'event' },
     { Component: HiOutlineBell, link: '/activity', key: 'activity' },
   ];
+
+  const signOutHandler = async () => {
+    removeAccessToken();
+    await deleteRefreshToken(user.userDocumentId);
+    window.location.reload();
+  };
+
   return (
     <>
       <CustomDefaultHeader>
         <LogoTitle to="/" onClick={() => { resetNowItemsList(); setNowCount(0); setNowFetching(true); }}> NogariHouse </LogoTitle>
-        <OpenMenuButton onClick={() => { setIsOpenMenu(!isOpenMenu); }}>Menu</OpenMenuButton>
-        <OpenRoomStateButton onClick={() => { setIsOpenRoom(!isOpenRoom); }}>
-          Room
-        </OpenRoomStateButton>
+        <ResponsiveMenuIconsLayout>
+          <OpenMenuButton onClick={() => { setIsOpenMenu(!isOpenMenu); }}>Menu</OpenMenuButton>
+          <OpenRoomStateButton onClick={() => { setIsOpenRoom(!isOpenRoom); }}>
+            Room
+          </OpenRoomStateButton>
+        </ResponsiveMenuIconsLayout>
         <MenuIconsLayout>
           <IconContainer>
+            <Link to={`/profile/${user.userId}`}><ImageLayout src={user.profileUrl} alt="사용자" /></Link>
             {leftSideIcons.map(makeIconToLink)}
           </IconContainer>
           <IconContainer>
             {rightSideIcons.map(makeIconToLink)}
-            <Link to={`/profile/${user.userId}`}><ImageLayout src={user.profileUrl} alt="사용자" /></Link>
+            <HiOutlineLogout size="48" onClick={signOutHandler} />
           </IconContainer>
         </MenuIconsLayout>
       </CustomDefaultHeader>

--- a/client/src/components/common/header.tsx
+++ b/client/src/components/common/header.tsx
@@ -3,24 +3,30 @@ import styled from 'styled-components';
 
 export const CustomtHeader = styled.nav`
   position: relative;
-  width: 95%;
+  width: 100%;
   height: 48px;
   min-width: 320px;
-  margin: 24px 24px;
+  margin: 24px 0;
 
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
+  align-items: center;
 
   svg:hover {
     filter: invert(88%) sepia(1%) saturate(4121%) hue-rotate(12deg) brightness(62%) contrast(79%);
   }
 `;
 
+export const CustomMenuIconsLayout = styled.nav`
+  width: 95%;
+  display: flex;
+  justify-content: space-between;
+`;
+
 export const HeaderTitleNunito = styled(Link)`
   position: absolute;
-  line-height: 48px;
-  left: 47.5%;
-  transform: translateX(-47.5%);
+  left: 50%;
+  transform: translateX(-50%);
   font-weight: bold;
   font-size: min(4.4vw, 32px);
   text-decoration: none;

--- a/client/src/components/common/menu-modal.tsx
+++ b/client/src/components/common/menu-modal.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import { slideXFromTo } from '@src/assets/styles/keyframe';
 import { BackgroundWrapper } from '@common/modal';
 
 import isOpenSliderMenuState from '@atoms/is-open-slider-menu';
+import isOpenRoomState from '@atoms/is-open-room';
 import userState from '@atoms/user';
 
 const MenuModalBox = styled.div`
@@ -25,6 +26,11 @@ const MenuModalBox = styled.div`
   animation-name: ${slideXFromTo(-300, 0)};
   animation-fill-mode: forward;
    ;
+`;
+
+const StyledLinkListLayout = styled.div`
+  display: flex;
+  flex-direction: column;
 `;
 
 const ProfileBox = styled.div`
@@ -94,11 +100,16 @@ const StyledLink = styled(Link)`
 function SliderMenu() {
   const user = useRecoilValue(userState);
   const [isOpenMenu, setIsOpenMenu] = useRecoilState(isOpenSliderMenuState);
+  const setIsOpenRoom = useSetRecoilState(isOpenRoomState);
+  const clickHandler = () => {
+    setIsOpenMenu(!isOpenMenu);
+    setIsOpenRoom(false);
+  };
   return (
     <>
-      <BackgroundWrapper />
+      <BackgroundWrapper onClick={() => setIsOpenMenu(!isOpenMenu)} />
       <MenuModalBox state={isOpenMenu}>
-        <div>
+        <StyledLinkListLayout onClick={clickHandler}>
           <StyledLink to={`/profile/${user.userId}`}>
             <ProfileBox>
               <ImageLayout src={user.profileUrl} alt="사용자" />
@@ -128,7 +139,7 @@ function SliderMenu() {
           <StyledLink to="/event">
             <LinkMenu>Event</LinkMenu>
           </StyledLink>
-        </div>
+        </StyledLinkListLayout>
 
         <button type="button" onClick={() => setIsOpenMenu(!isOpenMenu)}>close</button>
       </MenuModalBox>

--- a/client/src/components/common/menu-modal.tsx
+++ b/client/src/components/common/menu-modal.tsx
@@ -4,10 +4,12 @@ import { Link } from 'react-router-dom';
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import { slideXFromTo } from '@src/assets/styles/keyframe';
 import { BackgroundWrapper } from '@common/modal';
+import { HiOutlineLogout } from 'react-icons/hi';
 
 import isOpenSliderMenuState from '@atoms/is-open-slider-menu';
 import isOpenRoomState from '@atoms/is-open-room';
 import userState from '@atoms/user';
+import { signOutHandler } from '@utils/index';
 
 const MenuModalBox = styled.div`
   position: fixed;
@@ -31,6 +33,14 @@ const MenuModalBox = styled.div`
 const StyledLinkListLayout = styled.div`
   display: flex;
   flex-direction: column;
+`;
+
+const MenuFooter = styled.footer`
+  display: flex;
+  flex-direction: row-reverse;
+  align-items: center;
+  width: 100%;
+  border-top: 1px solid #B6B6B6;
 `;
 
 const ProfileBox = styled.div`
@@ -97,6 +107,25 @@ const StyledLink = styled(Link)`
     }
 `;
 
+const SignOutButton = styled.button`
+  display: flex;
+  align-items: center;
+  background: inherit ;
+  border:none;
+  box-shadow:none;
+  border-radius:0;
+  padding:0;
+  overflow:visible;
+  cursor:pointer;
+  margin: 10px 10px 10px 0;
+`;
+
+const SignOutText = styled.div`
+  font-size: 16px;
+  font-weight: bold;
+  margin-right: 10px;
+`;
+
 interface ILinkList {
   key: string,
   text: string,
@@ -147,8 +176,12 @@ function SliderMenu() {
           </StyledLink>
           {linkList.map(makeLinkListToStyledLink)}
         </StyledLinkListLayout>
-
-        <button type="button" onClick={() => setIsOpenMenu(!isOpenMenu)}>close</button>
+        <MenuFooter>
+          <SignOutButton onClick={signOutHandler}>
+            <SignOutText>Sign Out</SignOutText>
+            <HiOutlineLogout size="35" />
+          </SignOutButton>
+        </MenuFooter>
       </MenuModalBox>
     </>
   );

--- a/client/src/components/common/menu-modal.tsx
+++ b/client/src/components/common/menu-modal.tsx
@@ -97,6 +97,12 @@ const StyledLink = styled(Link)`
     }
 `;
 
+interface ILinkList {
+  key: string,
+  text: string,
+  link: string,
+}
+
 function SliderMenu() {
   const user = useRecoilValue(userState);
   const [isOpenMenu, setIsOpenMenu] = useRecoilState(isOpenSliderMenuState);
@@ -105,6 +111,21 @@ function SliderMenu() {
     setIsOpenMenu(!isOpenMenu);
     setIsOpenRoom(false);
   };
+
+  const makeLinkListToStyledLink = (list: ILinkList) => (
+    <StyledLink to={list.link} key={list.key}>
+      <LinkMenu>{list.text}</LinkMenu>
+    </StyledLink>
+  );
+
+  const linkList:ILinkList[] = [
+    { text: 'Search', link: '/search', key: 'search' },
+    { text: 'Message', link: '/chat-rooms', key: 'chat-rooms' },
+    { text: 'Invite', link: '/invite', key: 'invite' },
+    { text: 'Activity', link: '/activity', key: 'activity' },
+    { text: 'Event', link: '/event', key: 'event' },
+  ];
+
   return (
     <>
       <BackgroundWrapper onClick={() => setIsOpenMenu(!isOpenMenu)} />
@@ -124,21 +145,7 @@ function SliderMenu() {
               </ProfileInfo>
             </ProfileBox>
           </StyledLink>
-          <StyledLink to="/search">
-            <LinkMenu>Search</LinkMenu>
-          </StyledLink>
-          <StyledLink to="/chat-rooms">
-            <LinkMenu>Message</LinkMenu>
-          </StyledLink>
-          <StyledLink to="/invite">
-            <LinkMenu>Invite</LinkMenu>
-          </StyledLink>
-          <StyledLink to="/activity">
-            <LinkMenu>Activity</LinkMenu>
-          </StyledLink>
-          <StyledLink to="/event">
-            <LinkMenu>Event</LinkMenu>
-          </StyledLink>
+          {linkList.map(makeLinkListToStyledLink)}
         </StyledLinkListLayout>
 
         <button type="button" onClick={() => setIsOpenMenu(!isOpenMenu)}>close</button>

--- a/client/src/components/common/menu-modal.tsx
+++ b/client/src/components/common/menu-modal.tsx
@@ -8,6 +8,7 @@ import { HiOutlineLogout } from 'react-icons/hi';
 
 import isOpenSliderMenuState from '@atoms/is-open-slider-menu';
 import isOpenRoomState from '@atoms/is-open-room';
+import isOpenActiveFollowingModalState from '@atoms/is-open-active-following-modal';
 import userState from '@atoms/user';
 import { signOutHandler } from '@utils/index';
 
@@ -56,6 +57,7 @@ const ProfileBox = styled.div`
   cursor: default;
   background-color: #eeebe4e4;
   box-shadow: 0px 2px 4px rgb(0 0 0 / 25%);
+  cursor: pointer;
   }
 `;
 
@@ -93,7 +95,7 @@ const LinkMenu = styled.div`
   border-bottom: 1px solid #e6e6e6;
 
   &:hover {
-  cursor: default;
+  cursor: pointer;
   background-color: #eeebe4e4;
   box-shadow: 0px 2px 4px rgb(0 0 0 / 25%);
   }
@@ -120,6 +122,29 @@ const SignOutButton = styled.button`
   margin: 10px 10px 10px 0;
 `;
 
+const StyledButton = styled.button`
+  background: inherit ;
+  border:none;
+  box-shadow:none;
+  border-radius:0;
+  padding:0;
+  overflow:visible;
+
+  width: 100% - 10px;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  padding-left: 10px;
+  color: black;
+  border-bottom: 1px solid #e6e6e6;
+
+  &:hover {
+  cursor: pointer;
+  background-color: #eeebe4e4;
+  box-shadow: 0px 2px 4px rgb(0 0 0 / 25%);
+  }
+`;
+
 const SignOutText = styled.div`
   font-size: 16px;
   font-weight: bold;
@@ -136,6 +161,7 @@ function SliderMenu() {
   const user = useRecoilValue(userState);
   const [isOpenMenu, setIsOpenMenu] = useRecoilState(isOpenSliderMenuState);
   const setIsOpenRoom = useSetRecoilState(isOpenRoomState);
+  const setisOpenActiveFollowingModal = useSetRecoilState(isOpenActiveFollowingModalState);
   const clickHandler = () => {
     setIsOpenMenu(!isOpenMenu);
     setIsOpenRoom(false);
@@ -175,6 +201,9 @@ function SliderMenu() {
             </ProfileBox>
           </StyledLink>
           {linkList.map(makeLinkListToStyledLink)}
+          <StyledButton onClick={() => setisOpenActiveFollowingModal(true)}>
+            Active Following List
+          </StyledButton>
         </StyledLinkListLayout>
         <MenuFooter>
           <SignOutButton onClick={signOutHandler}>

--- a/client/src/components/event/event-header.tsx
+++ b/client/src/components/event/event-header.tsx
@@ -6,7 +6,7 @@ import { MdOutlineArrowBackIos } from 'react-icons/md';
 import { BiCalendarPlus } from 'react-icons/bi';
 import { useResetRecoilState, useSetRecoilState } from 'recoil';
 
-import { CustomtHeader, HeaderTitleNunito } from '@common/header';
+import { CustomtHeader, HeaderTitleNunito, CustomMenuIconsLayout } from '@common/header';
 import { makeIconToLink } from '@utils/index';
 import { isOpenEventRegisterModalState } from '@atoms/is-open-modal';
 import { nowCountState, nowFetchingState, nowItemsListState } from '@src/recoil/atoms/main-section-scroll';
@@ -42,13 +42,16 @@ function EventHeader() {
   return (
     <>
       <CustomtHeader>
-        {makeIconToLink(Icon)}
+
         <HeaderTitleNunito to="/event" onClick={() => { resetNowItemsList(); setNowCount(0); setNowFetching(true); }}>
           UPCOMING FOR EVERYONE
         </HeaderTitleNunito>
-        <EventAddButton>
-          <BiCalendarPlus onClick={changeModalState} size={48} />
-        </EventAddButton>
+        <CustomMenuIconsLayout>
+          {makeIconToLink(Icon)}
+          <EventAddButton>
+            <BiCalendarPlus onClick={changeModalState} size={48} />
+          </EventAddButton>
+        </CustomMenuIconsLayout>
       </CustomtHeader>
     </>
   );

--- a/client/src/components/invite-header.tsx
+++ b/client/src/components/invite-header.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { IconType } from 'react-icons';
 import { MdOutlineArrowBackIos } from 'react-icons/md';
 
-import { CustomtHeader, HeaderTitleNunito } from '@common/header';
+import { CustomtHeader, HeaderTitleNunito, CustomMenuIconsLayout } from '@common/header';
 import { makeIconToLink } from '@utils/index';
 
 interface IconAndLink {
@@ -18,7 +18,9 @@ function InviteHeader() {
 
   return (
     <CustomtHeader>
-      {makeIconToLink(Icon)}
+      <CustomMenuIconsLayout>
+        {makeIconToLink(Icon)}
+      </CustomMenuIconsLayout>
       <HeaderTitleNunito to="/invite">INVITE</HeaderTitleNunito>
       <div />
     </CustomtHeader>

--- a/client/src/components/left-sidebar.tsx
+++ b/client/src/components/left-sidebar.tsx
@@ -11,8 +11,13 @@ import userState from '@src/recoil/atoms/user';
 
 const ActiveFollowingListWrapper = styled.div`
   width: 100%;
+  height: 100%;
   display: flex;
   flex-direction: column;
+  @media (max-width: 1024px){
+    width: 80%;
+    margin-top: 20px;
+  }
 `;
 
 const ExceptionMessage = styled.div`

--- a/client/src/components/left-sidebar.tsx
+++ b/client/src/components/left-sidebar.tsx
@@ -17,12 +17,11 @@ const ActiveFollowingListWrapper = styled.div`
   @media (max-width: 1024px){
     width: 80%;
     margin-top: 20px;
-  }
+  };
 `;
 
 const ExceptionMessage = styled.div`
   position: relative;
-  top: 30vh;
   margin: auto;
   color: #a8a59b;
   font-size: 18px;

--- a/client/src/components/profile/followers-header.tsx
+++ b/client/src/components/profile/followers-header.tsx
@@ -1,24 +1,30 @@
 import React from 'react';
 import { MdOutlineArrowBackIos } from 'react-icons/md';
-import { Link, RouteComponentProps } from 'react-router-dom';
-import styled from 'styled-components';
+import { HiHome } from 'react-icons/hi';
+import { RouteComponentProps } from 'react-router-dom';
 
-import { CustomtHeader, HeaderTitleNunito } from '@common/header';
+import { CustomtHeader, HeaderTitleNunito, CustomMenuIconsLayout } from '@common/header';
+import { makeIconToLink } from '@utils/index';
+import { IconType } from 'react-icons';
 
-const LogoTitle = styled(Link)`
-  font-family: "Bangers";
-  font-size: 32px;
-  text-decoration: none;
-  color: black;
-  text-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
-`;
+interface IconAndLink {
+  Component:IconType,
+  key: string | number,
+  link: string,
+  size?: number,
+  color?: string,
+}
 
 function FollowersHeader({ history, location }: RouteComponentProps) {
+  const Icon: IconAndLink = { Component: HiHome, link: '/', key: 'main' };
+
   return (
     <CustomtHeader>
-      <MdOutlineArrowBackIos onClick={() => history.goBack()} size={48} />
       <HeaderTitleNunito to={location.pathname}>FOLLOWERS</HeaderTitleNunito>
-      <LogoTitle to="/">NOGARIHOUSE</LogoTitle>
+      <CustomMenuIconsLayout>
+        <MdOutlineArrowBackIos onClick={() => history.goBack()} size={48} />
+        {makeIconToLink(Icon)}
+      </CustomMenuIconsLayout>
     </CustomtHeader>
   );
 }

--- a/client/src/components/profile/following-header.tsx
+++ b/client/src/components/profile/following-header.tsx
@@ -1,24 +1,30 @@
 import React from 'react';
 import { MdOutlineArrowBackIos } from 'react-icons/md';
-import { Link, RouteComponentProps } from 'react-router-dom';
-import styled from 'styled-components';
+import { HiHome } from 'react-icons/hi';
+import { RouteComponentProps } from 'react-router-dom';
 
-import { CustomtHeader, HeaderTitleNunito } from '@common/header';
+import { CustomtHeader, HeaderTitleNunito, CustomMenuIconsLayout } from '@common/header';
+import { makeIconToLink } from '@utils/index';
+import { IconType } from 'react-icons';
 
-const LogoTitle = styled(Link)`
-  font-family: "Bangers";
-  font-size: 32px;
-  text-decoration: none;
-  color: black;
-  text-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
-`;
+interface IconAndLink {
+  Component:IconType,
+  key: string | number,
+  link: string,
+  size?: number,
+  color?: string,
+}
 
 function FollowingHeader({ history, location }: RouteComponentProps) {
+  const Icon: IconAndLink = { Component: HiHome, link: '/', key: 'main' };
+
   return (
     <CustomtHeader>
-      <MdOutlineArrowBackIos onClick={() => history.goBack()} size={48} />
       <HeaderTitleNunito to={location.pathname}>FOLLOWING</HeaderTitleNunito>
-      <LogoTitle to="/">NOGARIHOUSE</LogoTitle>
+      <CustomMenuIconsLayout>
+        <MdOutlineArrowBackIos onClick={() => history.goBack()} size={48} />
+        {makeIconToLink(Icon)}
+      </CustomMenuIconsLayout>
     </CustomtHeader>
   );
 }

--- a/client/src/components/profile/profile-header.tsx
+++ b/client/src/components/profile/profile-header.tsx
@@ -8,7 +8,7 @@ import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import { isOpenShareModalState } from '@atoms/is-open-modal';
 import userState from '@atoms/user';
-import { CustomtHeader, HeaderTitleNunito } from '@common/header';
+import { CustomtHeader, HeaderTitleNunito, CustomMenuIconsLayout } from '@common/header';
 import { makeIconToLink } from '@utils/index';
 
 interface IconAndLink {
@@ -43,14 +43,17 @@ function ProfileHeader({ match, history, location }: RouteComponentProps<{id: st
   return (
     <>
       <CustomtHeader>
-        <MdOutlineArrowBackIos onClick={() => history.goBack()} size={48} />
         <HeaderTitleNunito to={location.pathname}>
           Profile
         </HeaderTitleNunito>
-        <IconContainer>
-          <HiShare onClick={changeModalState} size={48} />
-          {(match.params.id === user.userId) && makeIconToLink(SettingIcon)}
-        </IconContainer>
+        <CustomMenuIconsLayout>
+          <MdOutlineArrowBackIos onClick={() => history.goBack()} size={48} />
+
+          <IconContainer>
+            <HiShare onClick={changeModalState} size={48} />
+            {(match.params.id === user.userId) && makeIconToLink(SettingIcon)}
+          </IconContainer>
+        </CustomMenuIconsLayout>
       </CustomtHeader>
     </>
   );

--- a/client/src/components/search/recent-search-header.tsx
+++ b/client/src/components/search/recent-search-header.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { IconType } from 'react-icons';
 import { MdOutlineArrowBackIos } from 'react-icons/md';
 
-import { CustomtHeader, HeaderTitleNunito } from '@common/header';
+import { CustomtHeader, HeaderTitleNunito, CustomMenuIconsLayout } from '@common/header';
 import { makeIconToLink } from '@utils/index';
 
 interface IconAndLink {
@@ -18,9 +18,10 @@ function RecentSearchHeader() {
 
   return (
     <CustomtHeader>
-      {makeIconToLink(Icon)}
+      <CustomMenuIconsLayout>
+        {makeIconToLink(Icon)}
+      </CustomMenuIconsLayout>
       <HeaderTitleNunito to="/search/recent">Recently Listened to</HeaderTitleNunito>
-      <div />
     </CustomtHeader>
   );
 }

--- a/client/src/components/search/search-header.tsx
+++ b/client/src/components/search/search-header.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { IconType } from 'react-icons';
 import { MdOutlineArrowBackIos, MdPersonPin } from 'react-icons/md';
 
-import { CustomtHeader, HeaderTitleNunito } from '@common/header';
+import { CustomtHeader, HeaderTitleNunito, CustomMenuIconsLayout } from '@common/header';
 import { makeIconToLink } from '@utils/index';
 
 interface IconAndLink {
@@ -21,7 +21,9 @@ function SearchHeader() {
 
   return (
     <CustomtHeader>
-      {Icons.map(makeIconToLink)}
+      <CustomMenuIconsLayout>
+        {Icons.map(makeIconToLink)}
+      </CustomMenuIconsLayout>
       <HeaderTitleNunito to="/search">Explore</HeaderTitleNunito>
     </CustomtHeader>
   );

--- a/client/src/components/sign/sign-header.tsx
+++ b/client/src/components/sign/sign-header.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { IconType } from 'react-icons';
-import { CustomtHeader } from '@common/header';
+import { CustomtHeader, CustomMenuIconsLayout } from '@common/header';
 import { MdOutlineArrowBackIos } from 'react-icons/md';
 
 import { makeIconToLink } from '@utils/index';
@@ -18,7 +18,9 @@ function SignHeader() {
 
   return (
     <CustomtHeader>
-      {makeIconToLink(Icon)}
+      <CustomMenuIconsLayout>
+        {makeIconToLink(Icon)}
+      </CustomMenuIconsLayout>
     </CustomtHeader>
   );
 }

--- a/client/src/hooks/useOutsideClick.tsx
+++ b/client/src/hooks/useOutsideClick.tsx
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+import { useSetRecoilState } from 'recoil';
+import isOpenRoomState from '@atoms/is-open-room';
+
+const useOutsideClick = (ref: any) => {
+  const setIsOpenRoom = useSetRecoilState(isOpenRoomState);
+
+  useEffect(() => {
+    function handleClickOutside(event:any):void {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        setIsOpenRoom(false);
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [ref]);
+};
+
+export default useOutsideClick;

--- a/client/src/hooks/useOutsideClick.tsx
+++ b/client/src/hooks/useOutsideClick.tsx
@@ -7,7 +7,8 @@ const useOutsideClick = (ref: any) => {
 
   useEffect(() => {
     function handleClickOutside(event:any):void {
-      if (ref.current && !ref.current.contains(event.target as Node)) {
+      if (ref.current && !ref.current.contains(event.target as Node)
+        && !event.target.closest('.open-room-button')) {
         setIsOpenRoom(false);
       }
     }

--- a/client/src/recoil/atoms/is-open-active-following-modal.ts
+++ b/client/src/recoil/atoms/is-open-active-following-modal.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export default atom<boolean>({
+  key: 'isOpenActiveFollowingModalState', // 해당 atom의 고유 key
+  default: false, // 기본값
+});

--- a/client/src/utils/index.tsx
+++ b/client/src/utils/index.tsx
@@ -51,6 +51,6 @@ export const isEmptyArray = (array: any[]) => !array.length;
 
 export const cookies = new Cookies();
 
-export const signOut = () => {
+export const removeAccessToken = async () => {
   cookies.remove('accessToken');
 };

--- a/client/src/utils/index.tsx
+++ b/client/src/utils/index.tsx
@@ -49,8 +49,13 @@ export function bindTrailingArgs(fn: any, ...boundArgs: any[]) {
 
 export const isEmptyArray = (array: any[]) => !array.length;
 
-export const cookies = new Cookies();
+const cookies = new Cookies();
 
-export const removeAccessToken = async () => {
+const removeAccessToken = async () => {
   cookies.remove('accessToken');
+};
+
+export const signOutHandler = async () => {
+  removeAccessToken();
+  window.location.reload();
 };

--- a/client/src/utils/index.tsx
+++ b/client/src/utils/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { IconType } from 'react-icons';
+import { Cookies } from 'react-cookie';
 
 interface IconAndLink {
     Component:IconType,
@@ -47,3 +48,9 @@ export function bindTrailingArgs(fn: any, ...boundArgs: any[]) {
 }
 
 export const isEmptyArray = (array: any[]) => !array.length;
+
+export const cookies = new Cookies();
+
+export const signOut = () => {
+  cookies.remove('accessToken');
+};

--- a/client/src/views/main-view.tsx
+++ b/client/src/views/main-view.tsx
@@ -65,7 +65,7 @@ const ActiveFollowingLayout = styled.div`
 `;
 
 const MainSectionLayout = styled.div`
-  @media (min-width: 1024px) {
+  @media (min-width: 1025px) {
     min-width: 500px;
   }
   position: relative;
@@ -112,7 +112,7 @@ const ActiveFollowingFooter = styled.footer`
   flex-direction: row-reverse;
   align-items: center;
   width: 100%;
-  @media (min-width: 1024px) {
+  @media (min-width: 1025px) {
     display: none;
   }
 `;

--- a/client/src/views/main-view.tsx
+++ b/client/src/views/main-view.tsx
@@ -9,6 +9,7 @@ import {
 } from 'recoil';
 import { useCookies } from 'react-cookie';
 import { Link } from 'react-router-dom';
+import { HiChevronDoubleLeft } from 'react-icons/hi';
 import styled from 'styled-components';
 
 import userState from '@atoms/user';
@@ -23,6 +24,7 @@ import ScrollBarStyle from '@styles/scrollbar-style';
 import LoadingSpinner from '@common/loading-spinner';
 import { getFollowingsList, getMyInfo } from '@src/api';
 import isOpenRoomState from '@atoms/is-open-room';
+import isOpenActiveFollowingModalState from '@atoms/is-open-active-following-modal';
 import { slideXFromTo } from '@src/assets/styles/keyframe';
 import useOutsideClick from '@src/hooks/useOutsideClick';
 
@@ -32,6 +34,7 @@ const MainLayout = styled.div`
   align-items: center;
   justify-content: center;
   height: 100vh;
+  max-height: -webkit-fill-available;
   width: 100vw;
 `;
 
@@ -44,20 +47,31 @@ const SectionLayout = styled.div`
 
 const ActiveFollowingLayout = styled.div`
   height: 80vh;
-  min-width: 240px;
+  min-width: 280px;
+  width: 20vw;
   margin: 10px;
-  flex-grow: 3;
   @media (max-width: 1024px) {
-    display: none;
+    position: fixed;
+    display: ${(props: { state: boolean }) => (props.state ? 'flex' : 'none')};
+    flex-direction: column;
+    justify-content: space-space-between;
+    align-items: center;
+    z-index: 100;
+    background-color: #F1F0E4;
+    width: 100vw;
+    min-width: 320px;
+    height: 85vh;
   }
 `;
 
 const MainSectionLayout = styled.div`
+  @media (min-width: 1024px) {
+    min-width: 500px;
+  }
   position: relative;
   height: 80vh;
-  width: 55vw;
+  width: 100%;
   min-width: 320px;
-  flex-grow: 12;
   margin: 10px;
   ${ScrollBarStyle};
 `;
@@ -65,14 +79,14 @@ const MainSectionLayout = styled.div`
 const RoomLayout = styled.div`
   @media (min-width: 768px) {
     height: 80vh;
-    width: 25vw;
+    width: 40vw;
+    min-width: 320px;
     margin: 10px;
-    flex-grow: 5;
   }
 
   @media (max-width: 768px) {
     position: fixed;
-    display: ${(props: { state : boolean}) => (props.state ? 'flex' : 'none')};;
+    display: ${(props: { state : boolean}) => (props.state ? 'flex' : 'none')};
     z-index: 100;
     width: 99vw;
     height: 85vh;
@@ -93,6 +107,29 @@ const ButtonLayout = styled.div`
   justify-content: space-between;
 `;
 
+const ActiveFollowingFooter = styled.footer`
+  display: flex;
+  flex-direction: row-reverse;
+  align-items: center;
+  width: 100%;
+  @media (min-width: 1024px) {
+    display: none;
+  }
+`;
+
+const CloseButton = styled.button`
+  display: flex;
+  align-items: center;
+  background: inherit ;
+  border:none;
+  box-shadow:none;
+  border-radius:0;
+  padding:0;
+  overflow:visible;
+  cursor:pointer;
+  margin: 10px 10px 10px 0;
+`;
+
 function MainView() {
   const [user, setUser] = useRecoilState(userState);
   const setFollowingList = useSetRecoilState(followingListState);
@@ -100,6 +137,7 @@ function MainView() {
   const [loading, setLoading] = useState(true);
   const [cookies, setCookie] = useCookies(['accessToken']);
   const isOpenRoom = useRecoilValue(isOpenRoomState);
+  const [isOpenActiveFollowingModal, setIsOpenActiveFollowingModal] = useRecoilState(isOpenActiveFollowingModalState);
   const RightSideBarLayoutRef = useRef<HTMLDivElement>(null);
 
   const updateUserState = useCallback(async (json) => {
@@ -142,8 +180,13 @@ function MainView() {
       <>
         <HeaderRouter />
         <SectionLayout>
-          <ActiveFollowingLayout>
+          <ActiveFollowingLayout state={isOpenActiveFollowingModal}>
             <LeftSideBar />
+            <ActiveFollowingFooter>
+              <CloseButton onClick={() => setIsOpenActiveFollowingModal(false)}>
+                <HiChevronDoubleLeft size="35" />
+              </CloseButton>
+            </ActiveFollowingFooter>
           </ActiveFollowingLayout>
           <MainSectionLayout>
             <MainRouter />

--- a/client/src/views/main-view.tsx
+++ b/client/src/views/main-view.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable no-unused-expressions */
 
 import React, {
-  useCallback, useEffect, useState,
+  useCallback, useEffect, useState, useRef,
 } from 'react';
 import {
   useRecoilState, useResetRecoilState, useRecoilValue, useSetRecoilState,
@@ -24,6 +24,7 @@ import LoadingSpinner from '@common/loading-spinner';
 import { getFollowingsList, getMyInfo } from '@src/api';
 import isOpenRoomState from '@atoms/is-open-room';
 import { slideXFromTo } from '@src/assets/styles/keyframe';
+import useOutsideClick from '@src/hooks/useOutsideClick';
 
 const MainLayout = styled.div`
   display: flex;
@@ -99,6 +100,7 @@ function MainView() {
   const [loading, setLoading] = useState(true);
   const [cookies, setCookie] = useCookies(['accessToken']);
   const isOpenRoom = useRecoilValue(isOpenRoomState);
+  const RightSideBarLayoutRef = useRef<HTMLDivElement>(null);
 
   const updateUserState = useCallback(async (json) => {
     const {
@@ -114,6 +116,8 @@ function MainView() {
 
     setCookie('accessToken', accessToken);
   }, []);
+
+  useOutsideClick(RightSideBarLayoutRef);
 
   useEffect(() => {
     getMyInfo()
@@ -144,7 +148,7 @@ function MainView() {
           <MainSectionLayout>
             <MainRouter />
           </MainSectionLayout>
-          <RoomLayout state={isOpenRoom}>
+          <RoomLayout state={isOpenRoom} ref={RightSideBarLayoutRef}>
             <RightSideBar />
           </RoomLayout>
         </SectionLayout>

--- a/client/src/views/main-view.tsx
+++ b/client/src/views/main-view.tsx
@@ -127,7 +127,7 @@ const CloseButton = styled.button`
   padding:0;
   overflow:visible;
   cursor:pointer;
-  margin: 10px 10px 10px 0;
+  margin: 10px 30px 10px 0;
 `;
 
 function MainView() {
@@ -180,7 +180,7 @@ function MainView() {
       <>
         <HeaderRouter />
         <SectionLayout>
-          <ActiveFollowingLayout state={isOpenActiveFollowingModal}>
+          <ActiveFollowingLayout state={isOpenActiveFollowingModal} onClick={() => setIsOpenActiveFollowingModal(false)}>
             <LeftSideBar />
             <ActiveFollowingFooter>
               <CloseButton onClick={() => setIsOpenActiveFollowingModal(false)}>


### PR DESCRIPTION
## 개요
✨ 로그아웃 기능 구현 & 반응형 마무리

## 작업사항
- 로그아웃 기능 구현
  - 디폴트 헤더와 슬라이딩 메뉴에서 버튼을 눌러 로그아웃을 할 수 있도록 했습니다. 
- 반응형 마무리
  - 헤더와 메인페이지 반응형을 마무리 했습니다.

## 변경로직
 - 로그아웃 : 엑세스 토큰을 제거하고 새로고침을 해주는 유틸함수를 작성해 버튼 클릭시 실행하도록 구현했습니다.
```ts
// utils/index.ts
import { Cookies } from 'react-cookie';

const cookies = new Cookies();

export const signOutHandler = () => {
  cookies.remove('accessToken');
  window.location.reload();
};
```

- 반응형
  - 필요한 버튼들을 추가해줬습니다.
  - 메인과 헤더 레이아웃을 틀에 맞게 변경해줬습니다.
  - 룸 모달 open시 모달 이외의 부분을 누르면 닫히도록 해줬습니다.
    - 🐛 RoomModal 버튼을 누르면 모달이 닫히지 않는 오류 해결 (커밋)
  - Active following List를 슬라이딩 메뉴에 추가하고, 내부 클릭시 원하는 동작을 하면서 바로 닫히도록 설정해주었습니다.
    - 🐛 활동중인 팔로잉 목록의 사람 클릭시 목록이 사라지지 않는 버그 수정(커밋)


### 변경후
1. 로그아웃

https://user-images.githubusercontent.com/59464537/143270281-bfe341e1-2e83-4ef8-9e81-b784365db774.mov

2. 반응형


https://user-images.githubusercontent.com/59464537/143270598-1ff964e6-aabc-4bb7-8e01-6aac6ccef306.mov

3. 추가한 Active following List


https://user-images.githubusercontent.com/59464537/143270798-b559d83d-165c-47bc-8713-585777054da1.mov


## 기타
1. 로그아웃
- 영상에서 보이는 것처럼 새로고침시 주소가 로그아웃을 했던 주소로 유지됩니다. 메인으로 리다이렉트 시켜주고 싶었는데 문제가 있어서 일단 새로고침을 적용해두었습니다. 좋은 리다이렉트 방법을.. 알고 계시는 분이 있을까요?

2. 모바일 룸 화면 외부 클릭시 닫힘
- 룸 버튼을 클릭하면 외부 클릭 이벤트와 겹쳐서 룸 모달이 닫히지 않고 계속 오픈되는 버그가 있었습니다. 일단 클래스 네임과 closest를 이용해 해결을 해두었는데, 크롱님 리뷰에서 지적해주신 부분처럼 dom에 직접 접근하는 방법이라.. 이렇게 해도 되나 고민입니다.
- 외부 클릭 감지는 useOutsideClick 훅으로 빼두었습니다.

3. 모바일 active following list
- 하단에 닫힘 버튼을 만든 이후에 활동중인 사람을 클릭했더니 사람 목록들이 사라지지 않는 이슈가 있었습니다. 일단은 사람 목록 포함 리스트 내부를 클릭하면 리스트가 닫히도록 설정해두었는데.. 버튼의 의미가 없어진 것 같기도 하고.. 애매한 상황입니다.
