### PR TITLE
Toast popup 구현 및 인터페이스 리팩토링

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,12 +2,14 @@ import React from 'react';
 
 import Router from '@routes/index';
 import BodyModal from '@components/body-modal';
+import Toast from '@components/common/toast';
 
 function App() {
   return (
     <>
       <Router />
       <BodyModal />
+      <Toast />
     </>
   );
 }

--- a/client/src/assets/styles/keyframe.ts
+++ b/client/src/assets/styles/keyframe.ts
@@ -31,3 +31,8 @@ export const spinner = () => keyframes`
     from {transform: rotate(0deg); }
     to {transform: rotate(360deg);}
 `;
+
+export const toastXFromTo = () => keyframes`
+    from {transform: translateX(100%); }
+    to {transform: translateX(0);}
+`;

--- a/client/src/components/activity-header.tsx
+++ b/client/src/components/activity-header.tsx
@@ -1,17 +1,9 @@
 import React from 'react';
-import { IconType } from 'react-icons';
 import { MdOutlineArrowBackIos } from 'react-icons/md';
 
 import { CustomtHeader, HeaderTitleNunito } from '@common/header';
 import { makeIconToLink } from '@utils/index';
-
-interface IconAndLink {
-  Component:IconType,
-  key: string | number,
-  link: string,
-  size?: number,
-  color?: string,
-}
+import { IconAndLink } from '@interfaces/index';
 
 function ActivityHeader() {
   const Icon: IconAndLink = { Component: MdOutlineArrowBackIos, link: '/', key: 'main' };

--- a/client/src/components/chat/chat-new-header.tsx
+++ b/client/src/components/chat/chat-new-header.tsx
@@ -1,6 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-
-import styled from 'styled-components';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { useHistory } from 'react-router-dom';
 
@@ -8,48 +5,7 @@ import useChatSocket from '@utils/chat-socket';
 import { postChatRoom } from '@api/index';
 import selectedUserType from '@atoms/chat-selected-users';
 import userType from '@atoms/user';
-
-const ChatNewHeaderWrap = styled.div`
-  display: flex;
-  justify-content: center;
-  width: 100%;
-  background-color: #B6B6B6;
-`;
-
-const ChatNewHeader = styled.div`
-  width: 90%;
-  height: 80px;
-
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-
-  position: relative;
-
-  p{
-    position: absolute;
-    left: 50%;
-    transform: translateX(-50%);
-    width: auto;
-
-    font-weight: Bold;
-    font-size: min(4vw,28px);
-
-    margin: 0px;
-  }
-`;
-
-const BtnStyle = styled.button`
-  font-size: min(4vw,28px);
-
-  background-color: transparent;
-  border: none;
-  color: #58964F;
-
-  &:hover {
-    filter: invert(88%) sepia(1%) saturate(4121%) hue-rotate(12deg) brightness(62%) contrast(79%);
-  }
-`;
+import { NewHeaderWrap, NewHeader, BtnStyle } from './style';
 
 const DoneBtn = () => {
   const [selectedUserList, setSelectedUserList] = useRecoilState(selectedUserType);
@@ -79,6 +35,7 @@ const DoneBtn = () => {
 };
 
 const CancelBtn = () => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [selectedUserList, setSelectedUserList] = useRecoilState(selectedUserType);
   const history = useHistory();
 
@@ -92,13 +49,13 @@ const CancelBtn = () => {
 
 export default function NewChatRoomHeader() {
   return (
-    <ChatNewHeaderWrap>
-      <ChatNewHeader>
+    <NewHeaderWrap>
+      <NewHeader>
         <CancelBtn />
         <p>NEW MESSAGE</p>
         <DoneBtn />
-      </ChatNewHeader>
-    </ChatNewHeaderWrap>
+      </NewHeader>
+    </NewHeaderWrap>
 
   );
 }

--- a/client/src/components/chat/chat-user-card.tsx
+++ b/client/src/components/chat/chat-user-card.tsx
@@ -17,7 +17,7 @@ interface chatUserCardProps {
 type ProfileProps = { length: number };
 
 const ChatUserCardLayout = styled.div`
-  background-color: #FFFFFF;
+  background-color: #fff;
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.1);
   border-radius: 30px;
   margin-bottom: 10px;

--- a/client/src/components/chat/chat-user-card.tsx
+++ b/client/src/components/chat/chat-user-card.tsx
@@ -1,13 +1,8 @@
 import styled from 'styled-components';
-
-interface Participants{
-  userDocumentId: string,
-  userName: string,
-  profileUrl: string
-}
+import { IUser } from '@interfaces/index';
 
 interface chatUserCardProps {
-  participantsInfo: Array<Participants>,
+  participantsInfo: Array<IUser>,
   lastMsg: string,
   clickEvent(): void,
   recentActive: string,

--- a/client/src/components/chat/style.ts
+++ b/client/src/components/chat/style.ts
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import ScrollBarStyle from '@styles/scrollbar-style';
 
 export const ChatRoomsLayout = styled.div`
-  background-color: #FFFFFF;
+  background-color: #fff;
   border-radius: 30px;
 
   width: 100%;

--- a/client/src/components/chat/style.ts
+++ b/client/src/components/chat/style.ts
@@ -45,3 +45,46 @@ export const ChattingLog = styled.div`
 
   overflow-y: scroll;
 `;
+
+export const NewHeaderWrap = styled.div`
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  background-color: #B6B6B6;
+`;
+
+export const NewHeader = styled.div`
+  width: 90%;
+  height: 80px;
+
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  position: relative;
+
+  p{
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    width: auto;
+
+    font-weight: Bold;
+    font-size: min(4vw,28px);
+
+    margin: 0px;
+  }
+`;
+
+export const BtnStyle = styled.button`
+  font-size: min(4vw,28px);
+
+  background-color: transparent;
+  border: none;
+  color: #58964F;
+
+  &:hover {
+    filter: invert(88%) sepia(1%) saturate(4121%) hue-rotate(12deg) brightness(62%) contrast(79%);
+    cursor: pointer;
+  }
+`;

--- a/client/src/components/common/custom-inputbar.tsx
+++ b/client/src/components/common/custom-inputbar.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 export const CustomInputBar = styled.input`
   font-size: min(5vw, 30px);
   border: none;
-  background-color: #ffffff;
+  background-color: #fff;
   width: 100%;
   height: 60px;
   &:focus {

--- a/client/src/components/common/default-button.tsx
+++ b/client/src/components/common/default-button.tsx
@@ -18,24 +18,24 @@ const sizes = {
 
 const buttonTypes = {
   follow: {
-    color: '#FFFFFF',
+    color: '#fff',
     fontColor: '#586A9A',
   },
   following: {
     color: '#586A9A',
-    fontColor: '#FFFFFF',
+    fontColor: '#fff',
   },
   secondary: {
     color: '#4A6970',
-    fontColor: '#FFFFFF',
+    fontColor: '#fff',
   },
   active: {
     color: '#58964F',
-    fontColor: '#FFFFFF',
+    fontColor: '#fff',
   },
   thirdly: {
     color: '#9AACA1',
-    fontColor: '#FFFFFF',
+    fontColor: '#fff',
   },
 };
 

--- a/client/src/components/common/default-header.tsx
+++ b/client/src/components/common/default-header.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
-import { IconType } from 'react-icons';
 import {
   HiOutlinePaperAirplane, HiSearch, HiOutlineMail, HiOutlineCalendar, HiOutlineBell,
 } from 'react-icons/hi';
@@ -15,6 +14,7 @@ import { nowCountState, nowFetchingState, nowItemsListState } from '@atoms/main-
 import isOpenSliderMenuState from '@atoms/is-open-slider-menu';
 import isOpenRoomState from '@atoms/is-open-room';
 import SliderMenu from '@common/menu-modal';
+import { IconAndLink } from '@interfaces/index';
 
 const CustomDefaultHeader = styled.nav`
   position: relative;
@@ -84,14 +84,6 @@ const ImageLayout = styled.img`
     border-radius: 70%;
     overflow: hidden;
 `;
-
-interface IconAndLink {
-  Component:IconType,
-  key: string | number,
-  link: string,
-  size?: number,
-  color?: string,
-}
 
 function DefaultHeader() {
   const user = useRecoilValue(userState);

--- a/client/src/components/common/interest-item.tsx
+++ b/client/src/components/common/interest-item.tsx
@@ -1,12 +1,17 @@
 import { MouseEvent, useState } from 'react';
 import styled from 'styled-components';
 
-interface InterestItemLayoutProps {
+type TInterestItemLayoutProps = {
     selected : boolean,
 }
 
+interface IInterestItemProps {
+  text: string,
+  onClick: (e: MouseEvent) => void;
+}
+
 const InterestItemLayout = styled.div`
-  color: ${(props: InterestItemLayoutProps) => (props.selected ? 'white' : 'black')};
+  color: ${(props: TInterestItemLayoutProps) => (props.selected ? 'white' : 'black')};
   font-weight: ${(props) => (props.selected ? 'bold' : 'normal')};
   padding: 10px;
   background: ${(props) => (props.selected ? '#586A9A' : '#fff')};
@@ -16,12 +21,7 @@ const InterestItemLayout = styled.div`
   font-size: min(3vw, 16px);
 `;
 
-interface InterestItemProps {
-  text: string,
-  onClick: (e: MouseEvent) => void;
-}
-
-function InterestItem({ text, onClick } : InterestItemProps) {
+function InterestItem({ text, onClick } : IInterestItemProps) {
   const [selected, setSelected] = useState(false);
   const innerOnClick = (e: MouseEvent) => {
     onClick(e);

--- a/client/src/components/common/interest-item.tsx
+++ b/client/src/components/common/interest-item.tsx
@@ -9,7 +9,7 @@ const InterestItemLayout = styled.div`
   color: ${(props: InterestItemLayoutProps) => (props.selected ? 'white' : 'black')};
   font-weight: ${(props) => (props.selected ? 'bold' : 'normal')};
   padding: 10px;
-  background: ${(props) => (props.selected ? '#586A9A' : '#FFFFFF')};
+  background: ${(props) => (props.selected ? '#586A9A' : '#fff')};
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
   border-radius: 15px;
   width: max-content;

--- a/client/src/components/common/room-card.tsx
+++ b/client/src/components/common/room-card.tsx
@@ -14,21 +14,21 @@ const RoomCardProfileDiv = styled.div`
   position: relative;
 `;
 
-const RoomCardFirstProfile = styled.div.attrs((props: ProfileProps) => {
+const RoomCardFirstProfile = styled.div.attrs((props: IProfileProps) => {
   return { style: { background: `center / contain no-repeat url(${props.profileUrl})` } };
 })`
   position: absolute;
 
-  width: ${(props: ProfileProps) => (props.length === 1 ? 85 : 65)}px;
-  height: ${(props: ProfileProps) => (props.length === 1 ? 85 : 65)}px;
+  width: ${(props: IProfileProps) => (props.length === 1 ? 85 : 65)}px;
+  height: ${(props: IProfileProps) => (props.length === 1 ? 85 : 65)}px;
 
   border-radius: 25px;
 
-  background-size: ${(props: ProfileProps) => (props.length === 1 ? 120 : 100)}px;
+  background-size: ${(props: IProfileProps) => (props.length === 1 ? 120 : 100)}px;
   z-index: 2;
 `;
 
-const RoomCardSecondProfile = styled.div.attrs((props: ProfileProps) => {
+const RoomCardSecondProfile = styled.div.attrs((props: IProfileProps) => {
   if (props.length === 1) return ;
   return { style: { background: `center / contain no-repeat url(${props.profileUrl})` } };
 })`
@@ -100,7 +100,7 @@ const RoomCardLayout = styled.div`
   }
 `;
 
-interface ProfileProps {
+interface IProfileProps {
   profileUrl: string,
   length: number
 }

--- a/client/src/components/common/room-card.tsx
+++ b/client/src/components/common/room-card.tsx
@@ -88,7 +88,7 @@ const RoomCardInfo = styled.div`
 `;
 
 const RoomCardLayout = styled.div`
-  background-color: #FFFFFF;
+  background-color: #fff;
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
   border-radius: 30px;
   margin-left: 0.8%;

--- a/client/src/components/common/select.tsx
+++ b/client/src/components/common/select.tsx
@@ -1,0 +1,70 @@
+import styled from 'styled-components';
+
+export const SelectDiv = styled.div`
+  width: 90%;
+  height: 50px;
+
+  position: relative;
+
+  p {
+    position: absolute;
+    margin: 15px 20px 0px 30px;
+
+    font-size: 20px;
+    font-weight: bold;
+  }
+
+  &::-webkit-scrollbar {
+    width: 5px;
+    height: 8px;
+    background: #ffffff;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    border-radius: 8px;
+    background-color: #DCD9CD;
+
+    &:hover {
+      background-color: #CECABB;
+    }
+  }
+`;
+
+export const SelectInputBar = styled.input`
+  position: absolute;
+  top: 11px;
+  left: 90px;
+
+  width: 300px;
+  height: 30px;
+
+  border: none;
+  font-size: 18px;
+  font-family: 'Nunito';
+
+  &:focus {
+    outline: none;
+  }
+`;
+
+export const SelectedUserDiv = styled.div`
+  margin: 0% 15% 0% 15%;
+
+
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+`;
+
+export const SelectUserComponent = styled.div`
+  margin: 0px 10px 5px 0px;
+  padding: 0px 10px;
+  background-color: #F1F0E4;
+  border-radius: 30px;
+
+  line-height: 30px;
+  font-family: 'Nunito';
+  color: #819C88;
+
+  cursor: pointer;
+`;

--- a/client/src/components/common/select.tsx
+++ b/client/src/components/common/select.tsx
@@ -17,7 +17,7 @@ export const SelectDiv = styled.div`
   &::-webkit-scrollbar {
     width: 5px;
     height: 8px;
-    background: #ffffff;
+    background: #fff;
   }
 
   &::-webkit-scrollbar-thumb {

--- a/client/src/components/common/small-checkbox.tsx
+++ b/client/src/components/common/small-checkbox.tsx
@@ -7,7 +7,7 @@ export interface CheckBoxProps {
   roomType?: string,
 }
 
-interface SmallCheckboxProps extends CheckBoxProps{
+interface ISmallCheckboxProps extends CheckBoxProps{
   id?: string,
   isDisabled?: boolean,
 }
@@ -45,7 +45,7 @@ const CheckBox = styled.input`
 
 function SmallCheckbox({
   id, isDisabled, onChange, checked,
-}: SmallCheckboxProps) {
+}: ISmallCheckboxProps) {
   return (
     <CheckBox type="checkbox" id={id} disabled={isDisabled} checked={checked} onChange={onChange} />
   );

--- a/client/src/components/common/toast.tsx
+++ b/client/src/components/common/toast.tsx
@@ -108,7 +108,7 @@ function Toast() {
   useEffect(() => {
     const interval = setInterval(() => {
       if (toastList.length) {
-        deleteToast(toastList[0].id);
+        deleteToast(toastList[0].id as number);
       }
     }, 1000);
 
@@ -133,7 +133,7 @@ function Toast() {
           return (
             <Notification key={i} style={{ backgroundColor }}>
               {/* eslint-disable-next-line react/jsx-no-bind */}
-              <NotificationButton onClick={deleteToast.bind(null, toastItem.id)}>X</NotificationButton>
+              <NotificationButton onClick={deleteToast.bind(null, toastItem.id as number)}>X</NotificationButton>
               <NotificationContentLayout>
                 <Icon size={36} />
                 <div>

--- a/client/src/components/common/toast.tsx
+++ b/client/src/components/common/toast.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/no-array-index-key */
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useRecoilState } from 'recoil';
 import styled from 'styled-components';
 import {
@@ -78,13 +78,15 @@ const NotificationButton = styled.button`
 
 function Toast() {
   const [toastList, setToastList] = useRecoilState(toastListState);
-
+  const [isStop, setStop] = useState(false);
   const deleteToast = (id: number) => {
     const newToastList = toastList.filter((toast) => (toast.id !== id));
     setToastList(newToastList);
   };
 
   useEffect(() => {
+    if (isStop) return;
+
     const interval = setInterval(() => {
       if (toastList.length) {
         deleteToast(toastList[0].id as number);
@@ -94,7 +96,7 @@ function Toast() {
     return () => {
       clearInterval(interval);
     };
-  }, [toastList]);
+  }, [toastList, isStop]);
 
   const TypeWithIcon = {
     success: { component: MdCheckCircle, color: '#5cb85c' },
@@ -110,7 +112,7 @@ function Toast() {
           const Icon : IconType = TypeWithIcon[toastItem.type].component;
           const backgroundColor = TypeWithIcon[toastItem.type].color;
           return (
-            <Notification key={i} style={{ backgroundColor }}>
+            <Notification key={i} style={{ backgroundColor }} onMouseOver={() => setStop(true)} onMouseOut={() => setStop(false)}>
               {/* eslint-disable-next-line react/jsx-no-bind */}
               <NotificationButton onClick={deleteToast.bind(null, toastItem.id as number)}>X</NotificationButton>
               <NotificationContentLayout>

--- a/client/src/components/common/toast.tsx
+++ b/client/src/components/common/toast.tsx
@@ -1,0 +1,152 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable react/no-array-index-key */
+import React, { useEffect } from 'react';
+import { useRecoilState } from 'recoil';
+import styled from 'styled-components';
+import {
+  MdCheckCircle, MdError, MdInfo, MdWarning,
+} from 'react-icons/md';
+
+import toastListState from '@atoms/toast-list';
+import { toastXFromTo } from '@styles/keyframe';
+import { IconType } from 'react-icons';
+
+const NotificationContainer = styled.div`
+  font-size: 14px;
+  box-sizing: border-box;
+  position: fixed;
+
+  top: 12px;
+  right: 12px;
+  transition: transform .6s ease-in-out;
+  animation: ${toastXFromTo} .7s;
+`;
+
+const Notification = styled.div`
+  background: #fff;
+  transition: .3s ease;
+  position: relative;
+  pointer-events: auto;
+  overflow: hidden;
+  margin: 0 0 6px;
+  padding: 30px;
+  margin-bottom: 15px;
+  width: 300px;
+  max-height: 100px;
+  border-radius: 3px 3px 3px 3px;
+  box-shadow: 0 0 10px #999;
+  color: #000;
+  opacity: .9;
+  background-position: 15px;
+  background-repeat: no-repeat;
+
+  height: 50px;
+  width: 365px;
+  color: #fff;
+  padding: 20px 15px 10px 10px;
+
+  &:hover {
+    box-shadow: 0 0 12px #fff;
+    opacity: 1;
+    cursor: pointer  
+  }
+`;
+
+const NotificationContentLayout = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+`;
+
+const NotificationTitle = styled.p`
+  font-weight: 700;
+  font-size: 16px;
+  text-align: left;
+  margin-top: 0;
+  margin-bottom: 6px;
+  width: 300px;
+  height: 18px;
+`;
+
+const NotificationMessage = styled.p`
+  margin: 0;
+  text-align: left;
+  height: 18px;
+  margin-left: -1px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const NotificationButton = styled.button`
+  position: relative;
+  right: -.3em;
+  top: -.3em;
+  float: right;
+  font-weight: 700;
+  color: #fff;
+  outline: none;
+  border: none;
+  text-shadow: 0 1px 0 #fff;
+  opacity: .8;
+  line-height: 1;
+  font-size: 16px;
+  padding: 0;
+  cursor: pointer;
+  background: 0 0;
+  border: 0;
+`;
+
+function Toast() {
+  const [toastList, setToastList] = useRecoilState(toastListState);
+
+  const deleteToast = (id: number) => {
+    const newToastList = toastList.filter((toast) => (toast.id !== id));
+    setToastList(newToastList);
+  };
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      if (toastList.length) {
+        deleteToast(toastList[0].id);
+      }
+    }, 1000);
+
+    return () => {
+      clearInterval(interval);
+    };
+  }, [toastList]);
+
+  const TypeWithIcon = {
+    success: { component: MdCheckCircle, color: '#5cb85c' },
+    danger: { component: MdError, color: '#d9534f' },
+    info: { component: MdInfo, color: '#5bc0de' },
+    warning: { component: MdWarning, color: '#f0ad4e' },
+  };
+
+  return (
+    <NotificationContainer>
+      {
+        toastList.map((toastItem, i) => {
+          const Icon : IconType = TypeWithIcon[toastItem.type].component;
+          const backgroundColor = TypeWithIcon[toastItem.type].color;
+          return (
+            <Notification key={i} style={{ backgroundColor }}>
+              {/* eslint-disable-next-line react/jsx-no-bind */}
+              <NotificationButton onClick={deleteToast.bind(null, toastItem.id)}>X</NotificationButton>
+              <NotificationContentLayout>
+                <Icon size={36} />
+                <div>
+                  <NotificationTitle>{toastItem.title}</NotificationTitle>
+                  <NotificationMessage>{toastItem.description}</NotificationMessage>
+                </div>
+              </NotificationContentLayout>
+            </Notification>
+          );
+        })
+        }
+    </NotificationContainer>
+  );
+}
+
+export default Toast;

--- a/client/src/components/common/toast.tsx
+++ b/client/src/components/common/toast.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable react/no-array-index-key */
 import React, { useEffect } from 'react';
 import { useRecoilState } from 'recoil';
@@ -13,43 +12,30 @@ import { IconType } from 'react-icons';
 
 const NotificationContainer = styled.div`
   font-size: 14px;
-  box-sizing: border-box;
   position: fixed;
 
   top: 12px;
   right: 12px;
-  transition: transform .6s ease-in-out;
-  animation: ${toastXFromTo} .7s;
 `;
 
 const Notification = styled.div`
-  background: #fff;
-  transition: .3s ease;
   position: relative;
-  pointer-events: auto;
-  overflow: hidden;
+  top: 12px;
+  right: 12px;
   margin: 0 0 6px;
-  padding: 30px;
-  margin-bottom: 15px;
   width: 300px;
-  max-height: 100px;
-  border-radius: 3px 3px 3px 3px;
+  border-radius: 3px;
   box-shadow: 0 0 10px #999;
   color: #000;
   opacity: .9;
-  background-position: 15px;
-  background-repeat: no-repeat;
 
   height: 50px;
   width: 365px;
   color: #fff;
   padding: 20px 15px 10px 10px;
 
-  &:hover {
-    box-shadow: 0 0 12px #fff;
-    opacity: 1;
-    cursor: pointer  
-  }
+  transition: transform .6s ease-in-out;
+  animation: ${toastXFromTo} .7s;
 `;
 
 const NotificationContentLayout = styled.div`
@@ -59,7 +45,7 @@ const NotificationContentLayout = styled.div`
 `;
 
 const NotificationTitle = styled.p`
-  font-weight: 700;
+  font-weight: bold;
   font-size: 16px;
   text-align: left;
   margin-top: 0;
@@ -73,9 +59,6 @@ const NotificationMessage = styled.p`
   text-align: left;
   height: 18px;
   margin-left: -1px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 `;
 
 const NotificationButton = styled.button`
@@ -83,18 +66,14 @@ const NotificationButton = styled.button`
   right: -.3em;
   top: -.3em;
   float: right;
-  font-weight: 700;
-  color: #fff;
-  outline: none;
-  border: none;
-  text-shadow: 0 1px 0 #fff;
-  opacity: .8;
-  line-height: 1;
-  font-size: 16px;
   padding: 0;
-  cursor: pointer;
-  background: 0 0;
   border: 0;
+  font-size: 16px;
+  font-weight: bold;
+  color: #fff;
+
+  background: transparent;
+  cursor: pointer;
 `;
 
 function Toast() {

--- a/client/src/components/common/user-card.tsx
+++ b/client/src/components/common/user-card.tsx
@@ -8,7 +8,7 @@ import DefaultButton from '@common/default-button';
 import useIsFollowingRef from '@hooks/useIsFollowingRef';
 import LoadingSpinner from './loading-spinner';
 
-interface UserCardProps {
+interface IUserCardProps {
   cardType: 'follow' | 'me' | 'others';
   userData: {
     _id: string,
@@ -20,7 +20,7 @@ interface UserCardProps {
   },
 }
 
-interface sizeProps {
+interface ISizeProps {
   sizeType : 'follow' |'me' |'others'
 }
 
@@ -37,7 +37,7 @@ const UserCardLayout = styled.div`
   border-radius: 30px;
   margin-left: 0.8%;
   width: 99%;
-  height: ${(props: sizeProps) => sizes[props.sizeType].cardLayoutSize}px;
+  height: ${(props: ISizeProps) => sizes[props.sizeType].cardLayoutSize}px;
   color: black;
   text-decoration: none;
 
@@ -68,23 +68,23 @@ const UserDescLayout = styled.div`
 
 const UserName = styled.div`
   font-weight: bold;
-  font-size: ${(props: sizeProps) => sizes[props.sizeType].userNameSize}px;
+  font-size: ${(props: ISizeProps) => sizes[props.sizeType].userNameSize}px;
   margin-bottom:3px;
   user-select: none;
 `;
 
 const UserId = styled.div`
-  font-size: ${(props: sizeProps) => sizes[props.sizeType].descriptionSize}px;
+  font-size: ${(props: ISizeProps) => sizes[props.sizeType].descriptionSize}px;
   margin-bottom:3px;
   user-select: none;
 `;
 
 const UserDescription = styled.div`
-  font-size: ${(props: sizeProps) => sizes[props.sizeType].descriptionSize}px;
+  font-size: ${(props: ISizeProps) => sizes[props.sizeType].descriptionSize}px;
   user-select: none;
 `;
 
-export default function UserCard({ cardType, userData }: UserCardProps) {
+export default function UserCard({ cardType, userData }: IUserCardProps) {
   const [loading, setLoading] = useState(false);
   const [isFollowingRef, fetchFollow] = useIsFollowingRef(setLoading, userData.isFollow);
   const history = useHistory();

--- a/client/src/components/common/user-image.tsx
+++ b/client/src/components/common/user-image.tsx
@@ -1,8 +1,7 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 
-interface userImageProps {
+interface IUserImageProps {
   src: string,
   size: 'default' | 'others'
 }
@@ -13,14 +12,14 @@ const sizes = {
 };
 
 const ImageLayout = styled.img`
-  width: ${(props:userImageProps) => (sizes[props.size].widthSize)}px;
-  height: ${(props:userImageProps) => (sizes[props.size].heightSize)}px;;
+  width: ${(props:IUserImageProps) => (sizes[props.size].widthSize)}px;
+  height: ${(props:IUserImageProps) => (sizes[props.size].heightSize)}px;;
   border-radius: 30%;
   overflow: hidden;
   background-color: #6F8A87;
 `;
 
-function UserImage(props : userImageProps) {
+function UserImage(props : IUserImageProps) {
   return (
     // eslint-disable-next-line react/destructuring-assignment
     <ImageLayout src={props.src} size={props.size} />

--- a/client/src/components/event/event-header.tsx
+++ b/client/src/components/event/event-header.tsx
@@ -1,7 +1,5 @@
-/* eslint-disable max-len */
 import React from 'react';
 import styled from 'styled-components';
-import { IconType } from 'react-icons';
 import { MdOutlineArrowBackIos } from 'react-icons/md';
 import { BiCalendarPlus } from 'react-icons/bi';
 import { useResetRecoilState, useSetRecoilState } from 'recoil';
@@ -10,14 +8,7 @@ import { CustomtHeader, HeaderTitleNunito } from '@common/header';
 import { makeIconToLink } from '@utils/index';
 import { isOpenEventRegisterModalState } from '@atoms/is-open-modal';
 import { nowCountState, nowFetchingState, nowItemsListState } from '@src/recoil/atoms/main-section-scroll';
-
-interface IconAndLink {
-  Component:IconType,
-  key: string | number,
-  link: string,
-  size?: number,
-  color?: string,
-}
+import { IconAndLink } from '@interfaces/index';
 
 const EventAddButton = styled.div`
   position: relative;

--- a/client/src/components/event/event-register-modal.tsx
+++ b/client/src/components/event/event-register-modal.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { useRecoilState, useResetRecoilState, useSetRecoilState } from 'recoil';
 
 import { isOpenEventRegisterModalState } from '@atoms/is-open-modal';
+import toastListSelector from '@selectors/toast-list';
 import { ModalBox, BackgroundWrapper } from '@common/modal';
 import { postEvent } from '@api/index';
 import { nowCountState, nowFetchingState, nowItemsListState } from '@src/recoil/atoms/main-section-scroll';
@@ -136,6 +137,7 @@ function EventRegisterModal() {
   const setNowFetching = useSetRecoilState(nowFetchingState);
   const resetNowItemsList = useResetRecoilState(nowItemsListState);
   const setNowCount = useSetRecoilState(nowCountState);
+  const setToastList = useSetRecoilState(toastListSelector);
 
   const changeModalState = () => {
     setIsOpenModal(!isOpenModal);
@@ -151,22 +153,29 @@ function EventRegisterModal() {
     }
   };
 
-  const publishButtonHandler = () => {
-    const eventInfo = {
-      title: inputTitleRef.current?.value,
-      participants: selectedList,
-      date: new Date(`${inputDateRef.current?.value} ${inputTimeRef.current?.value}`),
-      description: textDescRef.current?.value,
-    };
+  const publishButtonHandler = async () => {
+    try {
+      const eventInfo = {
+        title: inputTitleRef.current?.value,
+        participants: selectedList,
+        date: new Date(`${inputDateRef.current?.value} ${inputTimeRef.current?.value}`),
+        description: textDescRef.current?.value,
+      };
 
-    postEvent(eventInfo)
-      .then(() => alert('이벤트 등록이 완료되었습니다.'))
-      .catch((err) => console.error(err));
+      await postEvent(eventInfo);
+      setToastList({
+        type: 'success',
+        title: '등록 성공',
+        description: `${inputTitleRef.current?.value} 이벤트가 등록되었습니다!`,
+      });
 
-    changeModalState();
-    resetNowItemsList();
-    setNowCount(0);
-    setNowFetching(true);
+      changeModalState();
+      resetNowItemsList();
+      setNowCount(0);
+      setNowFetching(true);
+    } catch (error) {
+      console.error(error);
+    }
   };
 
   if (isOpenModal) {

--- a/client/src/components/invite-header.tsx
+++ b/client/src/components/invite-header.tsx
@@ -1,17 +1,9 @@
 import React from 'react';
-import { IconType } from 'react-icons';
 import { MdOutlineArrowBackIos } from 'react-icons/md';
 
 import { CustomtHeader, HeaderTitleNunito } from '@common/header';
 import { makeIconToLink } from '@utils/index';
-
-interface IconAndLink {
-  Component:IconType,
-  key: string | number,
-  link: string,
-  size?: number,
-  color?: string,
-}
+import { IconAndLink } from '@interfaces/index';
 
 function InviteHeader() {
   const Icon: IconAndLink = { Component: MdOutlineArrowBackIos, link: '/', key: 'main' };

--- a/client/src/components/left-sidebar.tsx
+++ b/client/src/components/left-sidebar.tsx
@@ -1,11 +1,14 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, {
   MouseEvent, useEffect, useRef, useState,
 } from 'react';
 import styled from 'styled-components';
+import { io, Socket } from 'socket.io-client';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import ActiveFollowingCard from '@common/active-following-card';
-import { io, Socket } from 'socket.io-client';
-import { useRecoilValue } from 'recoil';
+import { IToast } from '@atoms/toast-list';
+import toastListSelector from '@selectors/toast-list';
 import followingListState from '@src/recoil/atoms/following-list';
 import userState from '@src/recoil/atoms/user';
 
@@ -35,6 +38,7 @@ interface IActiveFollowingUser {
 function LeftSideBar() {
   const user = useRecoilValue(userState);
   const followingList = useRecoilValue(followingListState);
+  const setToastList = useSetRecoilState(toastListSelector);
   const [activeFollowingList, setActiveFollowingList] = useState<IActiveFollowingUser[]>([]);
   const userSocketRef = useRef<Socket | null>(null);
 
@@ -68,7 +72,14 @@ function LeftSideBar() {
       deleteLeaveActiveFollowing(leaveUserDocumentId);
     });
     userSocketRef.current.on('user:hands', (handsData: { from: Partial<IActiveFollowingUser>, to: string }) => {
-      if (handsData.to === user.userDocumentId) alert(`${handsData.from.userName}님이 손을 흔들었습니다.`);
+      if (handsData.to === user.userDocumentId) {
+        const newToast: IToast = {
+          type: 'info',
+          title: '반가운 인사',
+          description: `${handsData.from.userName}님이 손을 흔들었습니다!`,
+        };
+        setToastList(newToast);
+      }
     });
   }, [user]);
 

--- a/client/src/components/profile/profile-header.tsx
+++ b/client/src/components/profile/profile-header.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import { IconType } from 'react-icons';
 import { MdOutlineArrowBackIos, MdSettings } from 'react-icons/md';
 import { HiShare } from 'react-icons/hi';
 import { RouteComponentProps } from 'react-router-dom';
@@ -10,14 +9,7 @@ import { isOpenShareModalState } from '@atoms/is-open-modal';
 import userState from '@atoms/user';
 import { CustomtHeader, HeaderTitleNunito } from '@common/header';
 import { makeIconToLink } from '@utils/index';
-
-interface IconAndLink {
-  Component:IconType,
-  key: string | number,
-  link: string,
-  size?: number,
-  color?: string,
-}
+import { IconAndLink } from '@interfaces/index';
 
 const IconContainer = styled.div`
   display: flex;

--- a/client/src/components/room/follower-select-room-header.tsx
+++ b/client/src/components/room/follower-select-room-header.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
-import { IoClose } from 'react-icons/io5';
 
 import userState from '@atoms/user';
 import roomViewState from '@atoms/room-view-type';
@@ -9,57 +8,10 @@ import { isOpenRoomModalState } from '@atoms/is-open-modal';
 import roomDoucumentIdState from '@atoms/room-document-id';
 import { makeDateToHourMinute } from '@utils/index';
 import useChatSocket from '@utils/chat-socket';
+import { NewHeaderWrap, NewHeader, BtnStyle } from '@components/chat/style';
 
-const HeaderStyle = styled.div`
-
-  width: 100%;
-  height: 80px;
-
-  position: relative;
-
-  p {
-    width: 250px;
-
-    position: absolute;
-    top: 25px;
-    left: 50%;
-    transform: translateX(-50%);
-
-    font-family: 'Nunito';
-    font-weight: Bold;
-    font-size: 32px;
-
-    margin: 0px;
-  }
-`;
-
-const BtnStyle = css`
-  position: absolute;
-  transform: translateY(23px);
-
-  font-size: 20px;
-
-  border: none;
-`;
-
-const CanCelBtnStyle = styled(IoClose)`
-  left: 5%;
-
-  &:hover {
-    cursor: pointer;
-  }
-
-  ${BtnStyle};
-`;
-
-const DoneBtnStyle = styled.button`
-  right: 5%;
-  background-color: #F1F0E4;
-  &:hover {
-    cursor: pointer;
-  }
-
-  ${BtnStyle};
+const CustomNewHeaderWrap = styled(NewHeaderWrap)`
+  background-color: transparent;
 `;
 
 export default function FollowerSelectRoomHeader({ onClick, selectedUsers }: any) {
@@ -91,10 +43,12 @@ export default function FollowerSelectRoomHeader({ onClick, selectedUsers }: any
   };
 
   return (
-    <HeaderStyle>
-      <CanCelBtnStyle size={40} onClick={cancelEvent} />
-      <p>START A ROOM</p>
-      <DoneBtnStyle onClick={submitEventHandler}>Done</DoneBtnStyle>
-    </HeaderStyle>
+    <CustomNewHeaderWrap>
+      <NewHeader>
+        <BtnStyle onClick={cancelEvent}>Cancel</BtnStyle>
+        <p>START A ROOM</p>
+        <BtnStyle onClick={submitEventHandler}>Done</BtnStyle>
+      </NewHeader>
+    </CustomNewHeaderWrap>
   );
 }

--- a/client/src/components/room/follower-select-room-header.tsx
+++ b/client/src/components/room/follower-select-room-header.tsx
@@ -28,7 +28,7 @@ export default function FollowerSelectRoomHeader({ onClick, selectedUsers }: any
   const submitEventHandler = () => {
     const inviteInfo = {
       participants: selectedUsers,
-      message: `${user.userName}님이 노가리 방으로 초대했습니다!`,
+      message: `${user.userName}님이 노가리 방으로 초대했습니다! \n 메세지를 눌러 참여하세요!`,
       userInfo: {
         userDocumentId: user.userDocumentId,
         userName: user.userName,

--- a/client/src/components/room/follower-select-room-modal.tsx
+++ b/client/src/components/room/follower-select-room-modal.tsx
@@ -1,19 +1,17 @@
 /* eslint-disable */
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useRef } from 'react';
 import styled from 'styled-components';
-import { useSetRecoilState, useRecoilValue } from 'recoil';
+import { useSetRecoilState } from 'recoil';
 
 import { isOpenRoomModalState } from '@atoms/is-open-modal';
-import followState from '@atoms/following-list';
 import UserCardList from '@components/common/user-card-list';
 import FollowerSelectRoomHeader from '@components/room/follower-select-room-header';
 import { BackgroundWrapper, ModalBox } from '@common/modal';
 import {
   SelectDiv, SelectInputBar, SelectedUserDiv, SelectUserComponent,
 } from '@common/select';
-import { findUsersByIdList } from '@api/index';
 import { hiddenScroll } from '@styles/scrollbar-style';
-import { IUser } from '@interfaces/index';
+import useSelectUser from '@src/hooks/useSelectUser';
 
 const Layout = styled.div`
   background-color: #F1F0E4;
@@ -45,47 +43,8 @@ const CustomInputTitle = styled.p`
 
 function FollowerSelectModal() {
   const setIsOpenRoomModal = useSetRecoilState(isOpenRoomModalState);
-  const followingList = useRecoilValue(followState);
-  const [selectedUsers, setSelectedUsers] = useState<Array<IUser>>([]);
-  const [allUserList, setAllUserList] = useState([]);
-  const [filteredUserList, setFilteredUserList] = useState([]);
-  const inputBarRef = useRef(null);
-  const selectedUserDivRef = useRef(null);
-
-  const addSelectedUser = (e: any) => {
-    const userCardDiv = e.target.closest('.userCard');
-    const profileUrl = userCardDiv.querySelector('img');
-    if (!userCardDiv || !profileUrl) return;
-    const userName = userCardDiv?.getAttribute('data-username');
-    (inputBarRef!.current as any).value = '';
-    setSelectedUsers([...selectedUsers, { userDocumentId: userCardDiv?.getAttribute('data-id'), userName, profileUrl: profileUrl.getAttribute('src') }]);
-  };
-
-  const deleteUser = (e: any) => {
-    setSelectedUsers(selectedUsers.filter((user: any) => user.userDocumentId !== e.target.getAttribute('data-id')));
-    (inputBarRef!.current as any).value = '';
-  };
-
-  const searchUser = () => {
-    const searchWord = (inputBarRef.current as any).value;
-    const selectedUserIds = selectedUsers.map((user: any) => user.userDocumentId);
-    setFilteredUserList(allUserList
-      .filter((user: any) => (user.userId.indexOf(searchWord) > -1 || user.userName.indexOf(searchWord) > -1) && selectedUserIds.indexOf(user._id) === -1));
-  };
-
-  useEffect(() => {
-    findUsersByIdList(followingList).then((res: any) => {
-      const selectedUserIds = selectedUsers.map((user: any) => user.userDocumentId);
-      setAllUserList(res.userList);
-      setFilteredUserList(res.userList.filter((user: any) => selectedUserIds.indexOf(user._id) === -1));
-    });
-  }, [followingList]);
-
-  useEffect(() => {
-    const selectedUserIds = selectedUsers.map((user: any) => user.userDocumentId);
-    setFilteredUserList(allUserList.filter((user: any) => selectedUserIds.indexOf(user._id) === -1));
-
-  }, [selectedUsers]);
+  const inputBarRef = useRef<HTMLInputElement>(null);
+  const [selectedUsers, filteredUserList, searchUser, deleteUser, addSelectedUser] = useSelectUser(inputBarRef);
 
   return (
     <>
@@ -97,7 +56,7 @@ function FollowerSelectModal() {
             <CustomInputTitle>ADD : </CustomInputTitle>
             <CustomSelectInputBar ref={inputBarRef} onChange={searchUser} />
           </SelectDiv>
-          <SelectedUserDiv ref={selectedUserDivRef}>
+          <SelectedUserDiv>
             {selectedUsers.map((user: any) => (
               <SelectUserComponent key={user.userDocumentId} data-id={user.userDocumentId} onClick={deleteUser}>
                 {user.userName}

--- a/client/src/components/room/follower-select-room-modal.tsx
+++ b/client/src/components/room/follower-select-room-modal.tsx
@@ -1,37 +1,19 @@
 /* eslint-disable */
 import React, { useEffect, useState, useRef } from 'react';
 import styled from 'styled-components';
-import { useSetRecoilState, useRecoilValue, useRecoilState } from 'recoil';
+import { useSetRecoilState, useRecoilValue } from 'recoil';
 
 import { isOpenRoomModalState } from '@atoms/is-open-modal';
 import followState from '@atoms/following-list';
 import UserCardList from '@components/common/user-card-list';
 import FollowerSelectRoomHeader from '@components/room/follower-select-room-header';
-import { BackgroundWrapper } from '@common/modal';
+import { BackgroundWrapper, ModalBox } from '@common/modal';
+import {
+  SelectDiv, SelectInputBar, SelectedUserDiv, SelectUserComponent,
+} from '@common/select';
 import { findUsersByIdList } from '@api/index';
 import { hiddenScroll } from '@styles/scrollbar-style';
-import { slideYFromTo } from '@styles/keyframe';
 import { IUser } from '@interfaces/index';
-
-const ModalBox = styled.div`
-  position: absolute;
-  width: 50%;
-  height: 50%;
-  top: 20%;
-  display: flex;
-  flex-direction: column;
-  background-color: #F1F0E4;
-  border-radius: 32px;
-  margin-left: 25%;
-  box-shadow: rgb(0 0 0 / 55%) 0px 10px 25px;
-  z-index: 990;
-  opacity: 1;
-
-  animation-duration: 0.5s;
-  animation-timing-function: ease-out;
-  animation-name: ${slideYFromTo(300, 0)};
-  animation-fill-mode: forward;
-`;
 
 const Layout = styled.div`
   background-color: #F1F0E4;
@@ -46,75 +28,19 @@ const Layout = styled.div`
   ${hiddenScroll}
 `;
 
-const SelectDiv = styled.div`
-  width: 90%;
-  height: 50px;
-
-  position: relative;
-
-  p {
-    position: absolute;
-    margin: 15px 20px 0px 30px;
-
-    font-size: 20px;
-    font-weight: bold;
-  }
-
-  &::-webkit-scrollbar {
-    width: 5px;
-    height: 8px;
-    background: #ffffff;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    border-radius: 8px;
-    background-color: #DCD9CD;
-
-    &:hover {
-      background-color: #CECABB;
-    }
-  }
+const CustomModalBox = styled(ModalBox)`
+  width: calc(50% + 112px);
+  padding: 0;
 `;
 
-const SelectInputBar = styled.input`
-  position: absolute;
-  top: 11px;
-  left: 90px;
-
-  width: 300px;
-  height: 30px;
-
-  border: none;
-  font-size: 18px;
-  font-family: 'Nunito';
-
+const CustomSelectInputBar = styled(SelectInputBar)`
   background-color: #F1F0E4;
-
-  &:focus {
-    outline: none;
-  }
+  font-size: min(4vw, 18px);
+  height: min(6vw, 30px);
 `;
 
-const SelectedUserDiv = styled.div`
-  margin: 0% 15% 0% 15%;
-
-
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-`;
-
-const SelectUserComponent = styled.div`
-  margin: 0px 10px 5px 0px;
-  padding: 0px 10px;
-  background-color: #F1F0E4;
-  border-radius: 30px;
-
-  line-height: 30px;
-  font-family: 'Nunito';
-  color: #819C88;
-
-  cursor: default;
+const CustomInputTitle = styled.p`
+  font-size: min(4vw, 20px) !important;
 `;
 
 function FollowerSelectModal() {
@@ -164,12 +90,12 @@ function FollowerSelectModal() {
   return (
     <>
       <BackgroundWrapper onClick={() => setIsOpenRoomModal(false)} />
-      <ModalBox>
+      <CustomModalBox>
       <FollowerSelectRoomHeader onClick={() => setIsOpenRoomModal(false)} selectedUsers={selectedUsers} />
         <Layout>
           <SelectDiv>
-            <p>ADD : </p>
-            <SelectInputBar ref={inputBarRef} onChange={searchUser} />
+            <CustomInputTitle>ADD : </CustomInputTitle>
+            <CustomSelectInputBar ref={inputBarRef} onChange={searchUser} />
           </SelectDiv>
           <SelectedUserDiv ref={selectedUserDivRef}>
             {selectedUsers.map((user: any) => (
@@ -180,7 +106,7 @@ function FollowerSelectModal() {
           </SelectedUserDiv>
           <UserCardList cardType="others" userList={filteredUserList} clickEvent={addSelectedUser} />
         </Layout>
-      </ModalBox>
+      </CustomModalBox>
     </>
   );
 }

--- a/client/src/components/room/in-room-user-box.tsx
+++ b/client/src/components/room/in-room-user-box.tsx
@@ -1,11 +1,8 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import React, {
-  Ref, RefObject, useEffect, useRef, useState,
-} from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
   FiMic, FiMicOff,
 } from 'react-icons/fi';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilState } from 'recoil';
 import { Link } from 'react-router-dom';
 
 import { getUserInfo } from '@api/index';
@@ -41,7 +38,7 @@ export function InRoomOtherUserBox({
     if (!ref.current || !isMicOn) return;
     const soundMeter = new SoundMeter(audioCtxRef.current);
     let meterRefresh: any = null;
-    soundMeter.connectToSource(isAnonymous as boolean, stream as MediaStream, (e: any) => {
+    soundMeter.connectToSource(isAnonymous as boolean, stream as MediaStream, () => {
       meterRefresh = setInterval(() => {
         const num = Number(soundMeter.instant.toFixed(2));
         if (num > 0.02 && ref) {

--- a/client/src/components/room/right-sidebar.tsx
+++ b/client/src/components/room/right-sidebar.tsx
@@ -13,7 +13,7 @@ const RoomModalLayout = styled.div`
   flex-direction: column;
   justify-content: space-around;
   align-items: center;
-  background-color: #ffffff;
+  background-color: #fff;
   border-radius: 30px;
   width: 100%;
   height: 100%;

--- a/client/src/components/search/recent-search-header.tsx
+++ b/client/src/components/search/recent-search-header.tsx
@@ -1,17 +1,9 @@
 import React from 'react';
-import { IconType } from 'react-icons';
 import { MdOutlineArrowBackIos } from 'react-icons/md';
 
 import { CustomtHeader, HeaderTitleNunito } from '@common/header';
 import { makeIconToLink } from '@utils/index';
-
-interface IconAndLink {
-  Component:IconType,
-  key: string | number,
-  link: string,
-  size?: number,
-  color?: string,
-}
+import { IconAndLink } from '@interfaces/index';
 
 function RecentSearchHeader() {
   const Icon: IconAndLink = { Component: MdOutlineArrowBackIos, link: '/search', key: 'search' };

--- a/client/src/components/search/search-header.tsx
+++ b/client/src/components/search/search-header.tsx
@@ -1,17 +1,9 @@
 import React from 'react';
-import { IconType } from 'react-icons';
 import { MdOutlineArrowBackIos, MdPersonPin } from 'react-icons/md';
 
 import { CustomtHeader, HeaderTitleNunito } from '@common/header';
 import { makeIconToLink } from '@utils/index';
-
-interface IconAndLink {
-  Component:IconType,
-  key: string | number,
-  link: string,
-  size?: number,
-  color?: string,
-}
+import { IconAndLink } from '@interfaces/index';
 
 function SearchHeader() {
   const Icons: IconAndLink[] = [

--- a/client/src/components/sign/sign-header.tsx
+++ b/client/src/components/sign/sign-header.tsx
@@ -1,17 +1,9 @@
 import React from 'react';
-import { IconType } from 'react-icons';
 import { CustomtHeader } from '@common/header';
 import { MdOutlineArrowBackIos } from 'react-icons/md';
 
 import { makeIconToLink } from '@utils/index';
-
-interface IconAndLink {
-  Component:IconType,
-  key: string | number,
-  link: string,
-  size?: number,
-  color?: string,
-}
+import { IconAndLink } from '@interfaces/index';
 
 function SignHeader() {
   const Icon: IconAndLink = { Component: MdOutlineArrowBackIos, link: '/', key: 'main' };

--- a/client/src/components/sign/sign-title.tsx
+++ b/client/src/components/sign/sign-title.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 
-interface SignTitleProps {
+type TSignTitleProps = {
   title: string;
 }
 
@@ -14,7 +14,7 @@ const TitleDiv = styled.div`
 
 function SignTitle({
   title,
-}: SignTitleProps) {
+}: TSignTitleProps) {
   return (
     <TitleDiv>{ title }</TitleDiv>
   );

--- a/client/src/hooks/useRtc.tsx
+++ b/client/src/hooks/useRtc.tsx
@@ -19,10 +19,6 @@ export interface IRTC {
   isAnonymous?: boolean
 }
 
-export interface IParticipant extends IRTC {
-    mic?: boolean,
-  }
-
 export const useLocalStream = (): [MutableRefObject<MediaStream | null>, RefObject<HTMLVideoElement | null>, () => Promise<void>] => {
   const myStreamRef = useRef<MediaStream | null>(null);
   const myVideoRef = useRef<HTMLVideoElement | null>(null);

--- a/client/src/hooks/useSelectUser.tsx
+++ b/client/src/hooks/useSelectUser.tsx
@@ -1,0 +1,58 @@
+/* eslint-disable */
+import { useEffect, useState, RefObject } from 'react';
+import { useRecoilValue } from 'recoil';
+
+import followState from '@atoms/following-list';
+import { findUsersByIdList } from '@api/index';
+import { IUser } from '@interfaces/index';
+
+const useSelectUser = (inputBarRef: RefObject<HTMLInputElement>): any => {
+  const followingList = useRecoilValue(followState);
+  const [selectedUsers, setSelectedUsers] = useState<Array<IUser>>([]);
+  const [filteredUserList, setFilteredUserList] = useState([]);
+  const [allUserList, setAllUserList] = useState([]);
+
+  useEffect(() => {
+    findUsersByIdList(followingList).then((res: any) => {
+      const selectedUserIds = selectedUsers.map((user: any) => user.userDocumentId);
+      setAllUserList(res.userList);
+      setFilteredUserList(res.userList.filter((user: any) => selectedUserIds.indexOf(user._id) === -1));
+    });
+  }, [followingList]);
+
+  useEffect(() => {
+    const selectedUserIds = selectedUsers.map((user: any) => user.userDocumentId);
+    setFilteredUserList(allUserList.filter((user: any) => selectedUserIds.indexOf(user._id) === -1));
+  }, [selectedUsers]);
+
+  const addSelectedUser = (e: any) => {
+    const userCardDiv = e.target.closest('.userCard');
+    const profileUrl = userCardDiv.querySelector('img');
+    if (!userCardDiv || !profileUrl) return;
+    const userName = userCardDiv?.getAttribute('data-username');
+    inputBarRef.current!.value = '';
+    setSelectedUsers([...selectedUsers,
+        {
+          userDocumentId: userCardDiv?.getAttribute('data-id'),
+          userName,
+          profileUrl: profileUrl.getAttribute('src'),
+        }]);
+  };
+
+  const deleteUser = (e: any) => {
+    setSelectedUsers(selectedUsers.filter((user: any) => user.userDocumentId !== e.target.getAttribute('data-id')));
+    inputBarRef.current!.value = '';
+  };
+
+  const searchUser = () => {
+    const searchWord = inputBarRef.current!.value;
+    const selectedUserIds = selectedUsers.map((user: any) => user.userDocumentId);
+    setFilteredUserList(allUserList
+        .filter((user: any) => (user.userId.indexOf(searchWord) > -1 || user.userName.indexOf(searchWord) > -1)
+        && selectedUserIds.indexOf(user._id) === -1));
+  };
+
+  return [selectedUsers, filteredUserList, searchUser, deleteUser, addSelectedUser];
+};
+
+export default useSelectUser;

--- a/client/src/interfaces/index.ts
+++ b/client/src/interfaces/index.ts
@@ -1,3 +1,5 @@
+import { IconType } from 'react-icons';
+
 export interface IUser {
   userDocumentId: string,
   userName: string,
@@ -37,4 +39,12 @@ export interface IUserDetail {
   followers: string[],
   joinDate: string,
   profileUrl: string
+}
+
+export interface IconAndLink {
+  Component:IconType,
+  key: string | number,
+  link: string,
+  size?: number,
+  color?: string,
 }

--- a/client/src/recoil/atoms/toast-list.ts
+++ b/client/src/recoil/atoms/toast-list.ts
@@ -1,0 +1,13 @@
+import { atom } from 'recoil';
+
+export interface IToast {
+    id: number,
+    type: 'success' | 'danger' | 'info' | 'warning',
+    title: string,
+    description: string,
+}
+
+export default atom<IToast[]>({
+  key: 'toastListState', // 해당 atom의 고유 key
+  default: [],
+});

--- a/client/src/recoil/atoms/toast-list.ts
+++ b/client/src/recoil/atoms/toast-list.ts
@@ -1,7 +1,7 @@
 import { atom } from 'recoil';
 
 export interface IToast {
-    id: number,
+    id?: number,
     type: 'success' | 'danger' | 'info' | 'warning',
     title: string,
     description: string,

--- a/client/src/recoil/selectors/toast-list.ts
+++ b/client/src/recoil/selectors/toast-list.ts
@@ -1,0 +1,20 @@
+import { selector } from 'recoil';
+import toastList, { IToast } from '@atoms/toast-list';
+import { deepCopy } from '@src/utils';
+
+const toastListSelector = selector({
+  key: 'toastListSelector',
+  get: ({ get }) => {
+    const newToastList = deepCopy(get(toastList));
+    return newToastList;
+  },
+  set: ({ set, get }, toastListItem) => {
+    const newToastList = deepCopy(get(toastList));
+    const item = toastListItem as IToast;
+    item.id = newToastList.length;
+    newToastList.push(item);
+    set(toastList, newToastList);
+  },
+});
+
+export default toastListSelector;

--- a/client/src/utils/index.tsx
+++ b/client/src/utils/index.tsx
@@ -1,14 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { IconType } from 'react-icons';
 
-interface IconAndLink {
-    Component:IconType,
-    key: string | number,
-    link: string,
-    size?: number,
-    color?: string,
-  }
+import { IconAndLink } from '@interfaces/index';
 
 interface Params {
   [key: string]: any

--- a/client/src/views/chat-rooms-new-view.tsx
+++ b/client/src/views/chat-rooms-new-view.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable no-underscore-dangle */
 import React, { useEffect, useState, useRef } from 'react';
-import styled from 'styled-components';
 import { useRecoilValue, useRecoilState } from 'recoil';
 
 import NewChatRoomHeader from '@src/components/chat/chat-new-header';
@@ -9,75 +8,9 @@ import UserCardList from '@components/common/user-card-list';
 import { findUsersByIdList } from '@api/index';
 import followType from '@atoms/following-list';
 import selectedUserType from '@atoms/chat-selected-users';
-
-const SelectDiv = styled.div`
-  width: 90%;
-  height: 50px;
-
-  position: relative;
-
-  p {
-    position: absolute;
-    margin: 15px 20px 0px 30px;
-
-    font-size: 20px;
-    font-weight: bold;
-  }
-
-  &::-webkit-scrollbar {
-    width: 5px;
-    height: 8px;
-    background: #ffffff;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    border-radius: 8px;
-    background-color: #DCD9CD;
-
-    &:hover {
-      background-color: #CECABB;
-    }
-  }
-`;
-
-const SelectInputBar = styled.input`
-  position: absolute;
-  top: 11px;
-  left: 90px;
-
-  width: 300px;
-  height: 30px;
-
-  border: none;
-  font-size: 18px;
-  font-family: 'Nunito';
-
-  &:focus {
-    outline: none;
-  }
-`;
-
-const SelectedUserDiv = styled.div`
-  margin: 0% 15% 0% 15%;
-
-
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-`;
-
-const SelectUserComponent = styled.div`
-  margin: 0px 10px 5px 0px;
-  padding: 0px 10px;
-  background-color: #F1F0E4;
-  border-radius: 30px;
-
-  line-height: 30px;
-  font-family: 'Nunito';
-  color: #819C88;
-
-  cursor: default;
-`;
+import {
+  SelectDiv, SelectInputBar, SelectedUserDiv, SelectUserComponent,
+} from '@common/select';
 
 function ChatRoomsNewView() {
   const followingList = useRecoilValue(followType);

--- a/client/src/views/chat-rooms-view.tsx
+++ b/client/src/views/chat-rooms-view.tsx
@@ -12,16 +12,11 @@ import LoadingSpinner from '@common/loading-spinner';
 import { getChatRooms } from '@api/index';
 import { makeDateToHourMinute, makeDateToMonthDate } from '@utils/index';
 import useChatSocket from '@src/utils/chat-socket';
-
-interface IChatUserType {
-  userDocumentId: string,
-  userName: string,
-  profileUrl: string,
-}
+import { IUser } from '@interfaces/index';
 
 interface IChatRoom {
   chatDocumentId: string,
-  participants: Array<IChatUserType>,
+  participants: Array<IUser>,
   lastMsg: string,
   recentActive: Date,
   unCheckedMsg: number,
@@ -34,7 +29,7 @@ function ChatRoomsViews() {
   const history = useHistory();
   const socket = useChatSocket();
 
-  const clickEvent = (chatDocumentId: string, participantsInfo: Array<IChatUserType>) => {
+  const clickEvent = (chatDocumentId: string, participantsInfo: Array<IUser>) => {
     history.push({
       pathname: `/chat-rooms/${chatDocumentId}`,
       state: { participantsInfo },

--- a/client/src/views/room-in-view.tsx
+++ b/client/src/views/room-in-view.tsx
@@ -1,6 +1,4 @@
-import React, {
-  useEffect, useState, RefObject,
-} from 'react';
+import React, { useEffect, useState, RefObject } from 'react';
 import { useSetRecoilState, useResetRecoilState } from 'recoil';
 import { FiPlus, FiMic, FiMicOff } from 'react-icons/fi';
 
@@ -38,9 +36,7 @@ function InRoomModal() {
   useEffect(() => {
     getRoomInfo(roomDocumentId)
       .then((res: any) => {
-        if (!res) {
-          setRoomView('notFoundRoomView');
-        }
+        if (!res) setRoomView('notFoundRoomView');
         setRoomInfo(res);
       });
 

--- a/client/src/views/room-select-view.tsx
+++ b/client/src/views/room-select-view.tsx
@@ -27,10 +27,6 @@ const CheckboxLayout = styled.div`
   width: 100%;
 `;
 
-const ModeButton = styled(RoomTypeCheckBox)`
- display: inline;
-`;
-
 function SelectModeRoomModal() {
   const [modeType, setModeType] = useState<string>('known');
   const setViewAnonymous = useSetRecoilState(viewAnonymous);
@@ -53,12 +49,12 @@ function SelectModeRoomModal() {
   return (
     <>
       <ModalLayout>
-        <h2> Please select the room mode. </h2>
+        <h2> Select the visiting mode </h2>
         <CheckboxLayout>
             {/* eslint-disable-next-line react/jsx-no-bind */}
-            <ModeButton checkBoxName="known" onClick={typeHandler.bind(null, 'known')} roomType={modeType} />
+            <RoomTypeCheckBox checkBoxName="known" onClick={typeHandler.bind(null, 'known')} roomType={modeType} />
             {/* eslint-disable-next-line react/jsx-no-bind */}
-            <ModeButton checkBoxName="unknown" onClick={typeHandler.bind(null, 'unknown')} roomType={modeType} />
+            <RoomTypeCheckBox checkBoxName="unknown" onClick={typeHandler.bind(null, 'unknown')} roomType={modeType} />
         </CheckboxLayout>
         <ButtonLayout>
           <DefaultButton buttonType="secondary" size="medium" onClick={submitButtonHandler}>

--- a/client/src/views/signin-view.tsx
+++ b/client/src/views/signin-view.tsx
@@ -1,8 +1,10 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import React, { useRef, useState } from 'react';
+import { useSetRecoilState } from 'recoil';
 import { useHistory } from 'react-router-dom';
 import { useCookies } from 'react-cookie';
 
+import toastListSelector from '@selectors/toast-list';
 import SignHeader from '@components/sign/sign-header';
 import SignTitle from '@components/sign/sign-title';
 import SignBody from '@components/sign/sign-body';
@@ -14,6 +16,7 @@ function SignInView() {
   const inputEmailRef = useRef<HTMLInputElement>(null);
   const inputPasswordRef = useRef<HTMLInputElement>(null);
   const [isDisabled, setIsDisabled] = useState(true);
+  const setToastList = useSetRecoilState(toastListSelector);
   const [cookies, setCookie] = useCookies(['accessToken']);
   const history = useHistory();
 
@@ -35,7 +38,11 @@ function SignInView() {
       setCookie('accessToken', json.accessToken);
       history.replace('/');
     } else {
-      alert('로그인 정보를 확인하세요.');
+      setToastList({
+        type: 'warning',
+        title: '로그인 에러',
+        description: '로그인 정보를 확인하세요',
+      });
     }
   };
 

--- a/client/src/views/signup-info-view.tsx
+++ b/client/src/views/signup-info-view.tsx
@@ -2,8 +2,10 @@ import React, {
   MouseEvent, useCallback, useRef, useState,
 } from 'react';
 import styled from 'styled-components';
+import { useSetRecoilState } from 'recoil';
 import { useHistory, useLocation } from 'react-router-dom';
 
+import toastListSelector from '@selectors/toast-list';
 import SignHeader from '@components/sign/sign-header';
 import SignTitle from '@components/sign/sign-title';
 import SignBody from '@components/sign/sign-body';
@@ -39,6 +41,7 @@ function SignupInfoView() {
   const inputPasswordCheckRef = useRef<HTMLInputElement>(null);
   const inputFullNameRef = useRef<HTMLInputElement>(null);
   const inputIdRef = useRef<HTMLInputElement>(null);
+  const setToastList = useSetRecoilState(toastListSelector);
   const [isDisabled, setIsDisabled] = useState(true);
   const history = useHistory();
   const location = useLocation();
@@ -74,7 +77,11 @@ function SignupInfoView() {
       postSignUpUserInfo(userInfo)
         .then(() => { history.replace('/'); });
     } else {
-      alert('비밀번호를 확인해주세요');
+      setToastList({
+        type: 'warning',
+        title: '로그인 에러',
+        description: '비밀번호를 확인해주세요',
+      });
     }
   };
 

--- a/client/src/views/signup-view.tsx
+++ b/client/src/views/signup-view.tsx
@@ -1,7 +1,9 @@
 import React, { useCallback, useRef, useState } from 'react';
+import { useSetRecoilState } from 'recoil';
 import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 
+import toastListSelector from '@selectors/toast-list';
 import SignHeader from '@components/sign/sign-header';
 import { BackgroundWrapper } from '@common/modal';
 import LoadingSpinner from '@common/loading-spinner';
@@ -20,6 +22,7 @@ function SignUpView() {
   const inputEmailRef = useRef<HTMLInputElement>(null);
   const inputVerificationRef = useRef<HTMLInputElement>(null);
   const verificationNumberRef = useRef<string>();
+  const setToastList = useSetRecoilState(toastListSelector);
   const [isEmailInputView, setIsEmailInputView] = useState(true);
   const [isDisabled, setIsDisabled] = useState(true);
   const [loading, setLoading] = useState(false);
@@ -49,7 +52,11 @@ function SignUpView() {
       setIsEmailInputView(false);
     } else {
       setLoading(false);
-      alert('이미 존재하는 이메일입니다');
+      setToastList({
+        type: 'warning',
+        title: '로그인 에러',
+        description: '이미 존재하는 이메일입니다',
+      });
     }
   };
 
@@ -60,7 +67,11 @@ function SignUpView() {
       setLoading(true);
       fetchPostMail(inputEmailValue);
     } else {
-      alert('올바른 이메일을 입력해주세요');
+      setToastList({
+        type: 'warning',
+        title: '로그인 에러',
+        description: '올바른 이메일을 입력해주세요',
+      });
     }
   };
 
@@ -70,7 +81,11 @@ function SignUpView() {
     if (inputVerificationValue === (verificationNumberRef.current?.toString())) {
       history.replace('/signup/info', { email: emailState.current });
     } else {
-      alert('인증번호를 확인하세요.');
+      setToastList({
+        type: 'warning',
+        title: '로그인 에러',
+        description: '인증번호를 확인하세요.',
+      });
     }
   };
 


### PR DESCRIPTION
## 개요
- Toast popup 구현
- 기존 alert 함수 정리
- interface 리팩토링

## 변경로직
- app.tsx에 toast를 추가해줬습니다.
- interface 리팩토링은 공통적인 부분은 별도로 빼주고 prefix가 맞지 않는 부분을 수정 했습니다.

### 변경후

https://user-images.githubusercontent.com/55152516/143276988-03a87a4f-4d51-4e6b-a67f-b7353c376fb0.mov

### 사용법

1. import toastListSelector from '@selectors/toast-list'; 셀럭터를 불러옵니다.
2. const setToastList = useSetRecoilState(toastListSelector); 를 선언합니다.
3. alert() 대신 아래 양식에 맞게 입력합니다.

```js
      setToastList({
        type: 'success', // 'success', 'danger', 'info', 'warning'
        title: '등록 성공',
        description: `${inputTitleRef.current?.value} 이벤트가 등록되었습니다!`,
      });

```

### 기타
- 각 페이지별 헤더가 별도로 구현되어있는데 코드가 중복됩니다 나중에 공통으로 만들어도 좋을 거 같습니다
- toast popup은 현재 위치가 적당한지 궁금합니다!
- 아직 mobile 은 적용이 안되어있습니다 ㅎㅎ