### PR TITLE
Activity 기능 구현

### DIFF
--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -67,6 +67,7 @@ export const postRoomInfo = async (roomInfo: Object) => {
 
 export const deleteRoom = (roomDocumentId: string) => fetch(`${process.env.REACT_APP_API_URL}/api/room/${roomDocumentId}`, {
   method: 'DELETE',
+  credentials: 'include',
 });
 
 export const postEvent = async (eventInfo: Object) => {

--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -4,6 +4,7 @@ export const getRoomInfo = async (roomDocumentId: string) => {
       `${process.env.REACT_APP_API_URL}/api/room/${roomDocumentId}`,
       {
         method: 'get',
+        credentials: 'include',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -25,6 +26,7 @@ export const getUserInfo = async (userDocumentId: string) => {
       `${process.env.REACT_APP_API_URL}/api/user/${userDocumentId}?type=documentId`,
       {
         method: 'get',
+        credentials: 'include',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -47,6 +49,7 @@ export const postRoomInfo = async (roomInfo: Object) => {
   try {
     let response = await fetch(`${process.env.REACT_APP_API_URL}/api/room`, {
       method: 'post',
+      credentials: 'include',
       headers: {
         'Content-Type': 'application/json',
       },
@@ -70,6 +73,7 @@ export const postEvent = async (eventInfo: Object) => {
   try {
     const response = await fetch(`${process.env.REACT_APP_API_URL}/api/event`, {
       method: 'post',
+      credentials: 'include',
       headers: {
         'Content-Type': 'application/json',
       },
@@ -144,6 +148,7 @@ export const getSearchResult = async (searchInfo: {keyword:string, option:string
       `${process.env.REACT_APP_API_URL}/api/search/${option}?keyword=${keyword}&count=0`,
       {
         method: 'get',
+        credentials: 'include',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -163,6 +168,7 @@ export const findUsersByIdList = async (findUserList: Array<string>) => {
   try {
     let response = await fetch(`${process.env.REACT_APP_API_URL}/api/user/info`, {
       method: 'post',
+      credentials: 'include',
       headers: {
         'Content-Type': 'application/json',
       },
@@ -184,6 +190,7 @@ export const getChatRooms = async (userDocumentId: string) => {
       `${process.env.REACT_APP_API_URL}/api/chat-rooms/${userDocumentId}`,
       {
         method: 'get',
+        credentials: 'include',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -205,6 +212,7 @@ export const getFollowingsList = async (userDocumentId: string) => {
       `${process.env.REACT_APP_API_URL}/api/user/my-followings/${userDocumentId}`,
       {
         method: 'get',
+        credentials: 'include',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -224,6 +232,7 @@ export const postChatRoom = async (participants: Array<string>) => {
   try {
     let response = await fetch(`${process.env.REACT_APP_API_URL}/api/chat-rooms`, {
       method: 'post',
+      credentials: 'include',
       headers: {
         'Content-Type': 'application/json',
       },
@@ -261,6 +270,7 @@ export const getChattingLog = async (chatDocumentId: string) => {
       `${process.env.REACT_APP_API_URL}/api/chat-rooms/chat-log/${chatDocumentId}`,
       {
         method: 'get',
+        credentials: 'include',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -279,6 +289,7 @@ export const setUnCheckedMsg0 = async (chatDocumentId: string, userDocumentId: s
       `${process.env.REACT_APP_API_URL}/api/chat-rooms/setUnCheckedMsg/${chatDocumentId}/${userDocumentId}`,
       {
         method: 'get',
+        credentials: 'include',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -297,6 +308,7 @@ export const changeProfileImage = async (userDocumentId: string, formData: FormD
       `${process.env.REACT_APP_API_URL}/api/user/profile-image`,
       {
         method: 'post',
+        credentials: 'include',
         body: formData,
       },
     );
@@ -311,6 +323,7 @@ export const getRandomRoomDocumentId = async () => {
   try {
     const response = await fetch(`${process.env.REACT_APP_API_URL}/api/room/public/random`, {
       method: 'GET',
+      credentials: 'include',
       headers: {
         'Content-Type': 'application/json',
       },

--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -325,18 +325,21 @@ export const getRandomRoomDocumentId = async () => {
   }
 };
 
-export const deleteRefreshToken = async (userDocumentId: string) => {
+export const getIsActivityChecked = async () => {
   try {
-    let response = await fetch(`${process.env.REACT_APP_API_URL}/api/user/signout`, {
-      method: 'post',
+    const response = await fetch(`${process.env.REACT_APP_API_URL}/api/activity/isActivityChecked`, {
+      method: 'GET',
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ userDocumentId }),
+      credentials: 'include',
     });
-    response = await response.json();
-    return response;
+
+    if (!response.ok) throw new Error(`HTTP Error! status: ${response.status}`);
+
+    const json = await response.json();
+    return json;
   } catch (error) {
-    console.error(error);
+    console.log(error);
   }
 };

--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -343,3 +343,22 @@ export const getIsActivityChecked = async () => {
     console.log(error);
   }
 };
+
+export const getUnReadMsgCount = async () => {
+  try {
+    const response = await fetch(`${process.env.REACT_APP_API_URL}/api/chat-rooms/unReadMsgCount`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      credentials: 'include',
+    });
+
+    if (!response.ok) throw new Error(`HTTP Error! status: ${response.status}`);
+
+    const json = await response.json();
+    return json;
+  } catch (error) {
+    console.log(error);
+  }
+};

--- a/client/src/components/activity/activity-card.tsx
+++ b/client/src/components/activity/activity-card.tsx
@@ -1,0 +1,82 @@
+/* eslint-disable object-curly-newline */
+import React from 'react';
+import styled from 'styled-components';
+
+const ActivityCardLayout = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  position: relative;
+
+  height: max-content;
+  padding: 24px;
+  border-radius: 30px;
+
+  margin-left: 0.8%;
+
+  div:not(:last-child) {
+    margin-bottom: 10px;
+  }
+
+  &:hover {
+  background-color: #eeebe4e4;
+  box-shadow: 0px 2px 4px rgb(0 0 0 / 25%);
+  }
+`;
+
+const TimeDiv = styled.div`
+  font-size: 14px;
+  color: gray;
+`;
+
+const ImageLayout = styled.img`
+    width: 48px;
+    min-width: 48px;
+    height: 48px;
+    margin-right: 10px;
+    border-radius: 70%;
+    overflow: hidden;
+`;
+
+const UserNameDiv = styled.div`
+  font-size: 16px;
+  font-weight: bold;
+`;
+
+const DiscriptionDiv = styled.div`
+  font-size: 14px;
+  font-weight: 600;
+`;
+
+interface ActivityUser {
+  userId: string,
+  userName: string,
+  profileUrl: string,
+}
+
+interface ActivityCardProps {
+  type: 'follow' | 'event' | 'room',
+  clickDocumentId: string,
+  from: ActivityUser,
+  time: string,
+}
+
+const mapping = {
+  follow: '님이 팔로우 했습니다',
+  room: '님이 room을 생성했습니다. 참여하실래요?',
+  event: '이벤트 등록',
+};
+
+function ActivityCard({ type, clickDocumentId, from, time }: ActivityCardProps) {
+  console.log(type, clickDocumentId);
+  return (
+    <ActivityCardLayout>
+      <ImageLayout src="github.com/iHoHyeon.png" />
+      <UserNameDiv>{from.userName}</UserNameDiv>
+      <DiscriptionDiv>{mapping[type]}</DiscriptionDiv>
+      <TimeDiv>{time}</TimeDiv>
+    </ActivityCardLayout>
+  );
+}
+
+export default ActivityCard;

--- a/client/src/components/activity/activity-card.tsx
+++ b/client/src/components/activity/activity-card.tsx
@@ -2,11 +2,13 @@
 import React from 'react';
 import styled from 'styled-components';
 
+import { makeDateToHourMinute, makeDateToMonthDate } from '@utils/index';
+
 const ActivityCardLayout = styled.div`
   display: flex;
-  flex-direction: column;
-  align-items: flex-start;
+  flex-direction: row;
   position: relative;
+  justify-content: space-between;
 
   height: max-content;
   padding: 24px;
@@ -14,19 +16,10 @@ const ActivityCardLayout = styled.div`
 
   margin-left: 0.8%;
 
-  div:not(:last-child) {
-    margin-bottom: 10px;
-  }
-
   &:hover {
   background-color: #eeebe4e4;
   box-shadow: 0px 2px 4px rgb(0 0 0 / 25%);
   }
-`;
-
-const TimeDiv = styled.div`
-  font-size: 14px;
-  color: gray;
 `;
 
 const ImageLayout = styled.img`
@@ -38,14 +31,36 @@ const ImageLayout = styled.img`
     overflow: hidden;
 `;
 
-const UserNameDiv = styled.div`
+const UserNameSpan = styled.span`
   font-size: 16px;
   font-weight: bold;
 `;
 
-const DiscriptionDiv = styled.div`
-  font-size: 14px;
-  font-weight: 600;
+const DiscriptionSpan = styled.span`
+  font-size: min(16px, 4vw);
+  word-break: break-all;
+  width: calc(100% - 60px);
+`;
+
+const LeftSide = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  width: 80%;
+  overflow: hidden;
+`;
+
+const RightSide = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20%;
+  min-width: 20%;
+`;
+
+const TimeDiv = styled.div`
+  font-size: min(3vw, 14px);
+  color: gray;
 `;
 
 interface ActivityUser {
@@ -58,23 +73,32 @@ interface ActivityCardProps {
   type: 'follow' | 'event' | 'room',
   clickDocumentId: string,
   from: ActivityUser,
-  time: string,
+  date: Date,
 }
 
 const mapping = {
   follow: '님이 팔로우 했습니다',
   room: '님이 room을 생성했습니다. 참여하실래요?',
-  event: '이벤트 등록',
+  event: '님이 등록한 이벤트에 초대되셨습니다 !',
 };
 
-function ActivityCard({ type, clickDocumentId, from, time }: ActivityCardProps) {
-  console.log(type, clickDocumentId);
+const activityClickEvent = (type: string, clickDocumentId: string) => {
+  alert(`${type}, ${clickDocumentId}`);
+};
+
+function ActivityCard({ type, clickDocumentId, from, date }: ActivityCardProps) {
   return (
-    <ActivityCardLayout>
-      <ImageLayout src="github.com/iHoHyeon.png" />
-      <UserNameDiv>{from.userName}</UserNameDiv>
-      <DiscriptionDiv>{mapping[type]}</DiscriptionDiv>
-      <TimeDiv>{time}</TimeDiv>
+    <ActivityCardLayout onClick={() => activityClickEvent(type, clickDocumentId)}>
+      <LeftSide>
+        <ImageLayout src={from.profileUrl} />
+        <DiscriptionSpan>
+          <UserNameSpan>{from.userName}</UserNameSpan>
+          {mapping[type]}
+        </DiscriptionSpan>
+      </LeftSide>
+      <RightSide>
+        <TimeDiv>{date.getDate() === (new Date()).getDate() ? makeDateToHourMinute(date) : makeDateToMonthDate(date)}</TimeDiv>
+      </RightSide>
     </ActivityCardLayout>
   );
 }

--- a/client/src/components/activity/activity-card.tsx
+++ b/client/src/components/activity/activity-card.tsx
@@ -87,6 +87,7 @@ const activityClickEvent = (type: string, clickDocumentId: string) => {
 };
 
 function ActivityCard({ type, clickDocumentId, from, date }: ActivityCardProps) {
+  const time = new Date(date);
   return (
     <ActivityCardLayout onClick={() => activityClickEvent(type, clickDocumentId)}>
       <LeftSide>
@@ -97,7 +98,7 @@ function ActivityCard({ type, clickDocumentId, from, date }: ActivityCardProps) 
         </DiscriptionSpan>
       </LeftSide>
       <RightSide>
-        <TimeDiv>{date.getDate() === (new Date()).getDate() ? makeDateToHourMinute(date) : makeDateToMonthDate(date)}</TimeDiv>
+        <TimeDiv>{time.getDate() === (new Date()).getDate() ? makeDateToHourMinute(time) : makeDateToMonthDate(time)}</TimeDiv>
       </RightSide>
     </ActivityCardLayout>
   );

--- a/client/src/components/activity/activity-card.tsx
+++ b/client/src/components/activity/activity-card.tsx
@@ -32,7 +32,6 @@ const ImageLayout = styled.img`
 `;
 
 const UserNameSpan = styled.span`
-  font-size: 16px;
   font-weight: bold;
 `;
 

--- a/client/src/components/chat/chat-room-footer.tsx
+++ b/client/src/components/chat/chat-room-footer.tsx
@@ -66,6 +66,7 @@ export default function ChatRoomFooter({
       chatDocumentId,
     });
     chatSocket?.emit('chat:alertMsg', { participants, chatDocumentId });
+    chatSocket?.emit('chat:updateCount', participants);
     addChattingLog({
       userDocumentId: user.userDocumentId, userName: user.userName, profileUrl: user.profileUrl, message, date: makeDateToHourMinute(new Date()),
     });

--- a/client/src/components/common/default-header.tsx
+++ b/client/src/components/common/default-header.tsx
@@ -25,6 +25,7 @@ import { IconAndLink } from '@interfaces/index';
 import { getIsActivityChecked, getUnReadMsgCount } from '@api/index';
 import unReadMsgCountState from '@atoms/not-read-msg';
 import useChatSocket from '@utils/chat-socket';
+import useUserSocket from '@src/utils/user-socket';
 
 const CustomDefaultHeader = styled.nav`
   width: 100%;
@@ -155,7 +156,7 @@ function DefaultHeader() {
   const [isActivityChecked, setActivityChecked] = useState(false);
   const [unReadMsgCount, setUnReadMsgCount] = useRecoilState(unReadMsgCountState);
   const setNowCount = useSetRecoilState(nowCountState);
-  const chatSocket = useChatSocket();
+  const userSocket = useUserSocket();
 
   const leftSideIcons: IconAndLink[] = [
     { Component: HiSearch, link: '/search', key: 'search' },
@@ -182,12 +183,12 @@ function DefaultHeader() {
   }, [chatSocket]);
 
   useEffect(() => {
-    if (!chatSocket) return;
-    chatSocket.on('user:getActivity', () => setActivityChecked(true));
+    if (!userSocket) return;
+    userSocket.on('user:getActivity', () => setActivityChecked(true));
     return () => {
-      chatSocket.emit('user:headerLeave');
+      userSocket.emit('user:headerLeave');
     };
-  }, [chatSocket]);
+  }, [userSocket]);
 
   return (
     <>

--- a/client/src/components/common/default-header.tsx
+++ b/client/src/components/common/default-header.tsx
@@ -145,8 +145,8 @@ const MsgCount = styled.div`
   background-color: red;
 
   font-size: 12px;
+  color: white;
 `;
-
 function DefaultHeader() {
   const user = useRecoilValue(userState);
   const setNowFetching = useSetRecoilState(nowFetchingState);

--- a/client/src/components/common/default-header.tsx
+++ b/client/src/components/common/default-header.tsx
@@ -174,6 +174,11 @@ function DefaultHeader() {
 
   useEffect(() => {
     getUnReadMsgCount().then((res) => setUnReadMsgCount(res.unReadMsgCount));
+    chatSocket.emit('chat:viewJoin', user.userDocumentId);
+    chatSocket.on('chat:updateCount', () => setUnReadMsgCount((oldCount) => oldCount + 1));
+    return () => {
+      chatSocket.off('chat:updateCount');
+    };
   }, [chatSocket]);
 
   useEffect(() => {

--- a/client/src/components/common/default-header.tsx
+++ b/client/src/components/common/default-header.tsx
@@ -157,6 +157,7 @@ function DefaultHeader() {
   const [unReadMsgCount, setUnReadMsgCount] = useRecoilState(unReadMsgCountState);
   const setNowCount = useSetRecoilState(nowCountState);
   const userSocket = useUserSocket();
+  const chatSocket = useChatSocket();
 
   const leftSideIcons: IconAndLink[] = [
     { Component: HiSearch, link: '/search', key: 'search' },
@@ -174,7 +175,7 @@ function DefaultHeader() {
   }, [chatSocket]);
 
   useEffect(() => {
-    getUnReadMsgCount().then((res) => setUnReadMsgCount(res.unReadMsgCount));
+    getUnReadMsgCount().then((res: any) => setUnReadMsgCount(res.unReadMsgCount));
     chatSocket.emit('chat:viewJoin', user.userDocumentId);
     chatSocket.on('chat:updateCount', () => setUnReadMsgCount((oldCount) => oldCount + 1));
     return () => {

--- a/client/src/components/common/default-header.tsx
+++ b/client/src/components/common/default-header.tsx
@@ -22,7 +22,8 @@ import isOpenSliderMenuState from '@atoms/is-open-slider-menu';
 import isOpenRoomState from '@atoms/is-open-room';
 import SliderMenu from '@common/menu-modal';
 import { IconAndLink } from '@interfaces/index';
-import { getIsActivityChecked } from '@api/index';
+import { getIsActivityChecked, getUnReadMsgCount } from '@api/index';
+import unReadMsgCountState from '@atoms/not-read-msg';
 import useChatSocket from '@utils/chat-socket';
 
 const CustomDefaultHeader = styled.nav`
@@ -132,6 +133,19 @@ const ActiveDot = styled.div`
   border-radius: 10px;
 `;
 
+const MsgCount = styled.div`
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  border-radius: 20px;
+  right: 1%;
+  background-color: red;
+
+  font-size: 12px;
+`;
+
 function DefaultHeader() {
   const user = useRecoilValue(userState);
   const setNowFetching = useSetRecoilState(nowFetchingState);
@@ -139,12 +153,12 @@ function DefaultHeader() {
   const [isOpenMenu, setIsOpenMenu] = useRecoilState(isOpenSliderMenuState);
   const [isOpenRoom, setIsOpenRoom] = useRecoilState(isOpenRoomState);
   const [isActivityChecked, setActivityChecked] = useState(false);
+  const [unReadMsgCount, setUnReadMsgCount] = useRecoilState(unReadMsgCountState);
   const setNowCount = useSetRecoilState(nowCountState);
   const chatSocket = useChatSocket();
 
   const leftSideIcons: IconAndLink[] = [
     { Component: HiSearch, link: '/search', key: 'search' },
-    { Component: HiOutlinePaperAirplane, link: '/chat-rooms', key: 'chat' },
   ];
   const rightSideIcons: IconAndLink[] = [
     { Component: HiOutlineMail, link: '/invite', key: 'invite' },
@@ -156,7 +170,11 @@ function DefaultHeader() {
       if (res.isActivityChecked) setActivityChecked(true);
       else setActivityChecked(false);
     });
-  });
+  }, [chatSocket]);
+
+  useEffect(() => {
+    getUnReadMsgCount().then((res) => setUnReadMsgCount(res.unReadMsgCount));
+  }, [chatSocket]);
 
   useEffect(() => {
     if (!chatSocket) return;
@@ -182,6 +200,10 @@ function DefaultHeader() {
           <IconContainer>
             <Link to={`/profile/${user.userId}`}><ImageLayout src={user.profileUrl} alt="사용자" /></Link>
             {leftSideIcons.map(makeIconToLink)}
+            <Link to="/chat-rooms" style={{ position: 'relative' }}>
+              {unReadMsgCount > 0 ? <MsgCount><span style={{ margin: '5px' }}>{unReadMsgCount > 99 ? '99+' : unReadMsgCount}</span></MsgCount> : ''}
+              <HiOutlinePaperAirplane size={48} color="black" />
+            </Link>
           </IconContainer>
           <IconContainer>
             {rightSideIcons.map(makeIconToLink)}

--- a/client/src/hooks/useFetchItems.tsx
+++ b/client/src/hooks/useFetchItems.tsx
@@ -25,7 +25,9 @@ const useFetchItems = <T extends {}>(apiPath : string, nowItemType: string)
     if (nowFetching) {
       const fetchItems = async () => {
         try {
-          const newItemsList = await fetch(`${process.env.REACT_APP_API_URL}/api${apiPath}?count=${nowCount}`)
+          const newItemsList = await fetch(`${process.env.REACT_APP_API_URL}/api${apiPath}?count=${nowCount}`, {
+            credentials: 'include',
+          })
             .then((res) => res.json())
             .then((json) => json.items);
           setNowItemsList([...nowItemsList, ...newItemsList]);

--- a/client/src/recoil/atoms/not-read-msg.tsx
+++ b/client/src/recoil/atoms/not-read-msg.tsx
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export default atom<number>({
+  key: 'notReadMsgCount', // 해당 atom의 고유 key
+  default: 0,
+});

--- a/client/src/utils/user-socket.ts
+++ b/client/src/utils/user-socket.ts
@@ -1,0 +1,10 @@
+import { io, Socket } from 'socket.io-client';
+
+let userSocket : Socket | null = null;
+
+export default () => {
+  if (userSocket) return userSocket;
+  const url = process.env.REACT_APP_SOCKET_URL as string;
+  userSocket = io(`${url}/user`);
+  return userSocket;
+};

--- a/client/src/views/activity-view.tsx
+++ b/client/src/views/activity-view.tsx
@@ -1,7 +1,14 @@
 import React from 'react';
+import ActivityCard from '@components/activity/activity-card';
+
+const user1 = {
+  userId: 'userId',
+  userName: 'userName',
+  profileUrl: 'https://kr.object.ncloudstorage.com/nogarihouse/profile/puppy2.jpeg',
+};
 
 function ActivityView() {
-  return (<></>);
+  return (<ActivityCard type="follow" clickDocumentId="312" from={user1} date={new Date()} />);
 }
 
 export default ActivityView;

--- a/client/src/views/activity-view.tsx
+++ b/client/src/views/activity-view.tsx
@@ -1,14 +1,61 @@
-import React from 'react';
-import ActivityCard from '@components/activity/activity-card';
+import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
+import { useRecoilValue } from 'recoil';
 
-const user1 = {
-  userId: 'userId',
-  userName: 'userName',
-  profileUrl: 'https://kr.object.ncloudstorage.com/nogarihouse/profile/puppy2.jpeg',
-};
+import useFetchItems from '@hooks/useFetchItems';
+import { nowFetchingState } from '@atoms/main-section-scroll';
+import ActivityCard from '@components/activity/activity-card';
+import useItemFecthObserver from '@hooks/useItemFetchObserver';
+import LoadingSpinner from '@common/loading-spinner';
+
+interface ActivityUser {
+  userId: string,
+  userName: string,
+  profileUrl: string,
+}
+
+interface ActivityCardProps {
+  type: 'follow' | 'event' | 'room',
+  clickDocumentId: string,
+  from: ActivityUser,
+  date: Date,
+}
+
+const ObserverBlock = styled.div`
+  position: relative;
+  width: 100%;
+  height: 100px;
+`;
 
 function ActivityView() {
-  return (<ActivityCard type="follow" clickDocumentId="312" from={user1} date={new Date()} />);
+  const [nowItemList, nowItemType] = useFetchItems<ActivityCardProps>('/activity', 'activity');
+  const [loading, setLoading] = useState(true);
+  const nowFetching = useRecoilValue(nowFetchingState);
+  const [targetRef] = useItemFecthObserver(loading);
+
+  useEffect(() => {
+    if (nowItemList && nowItemType === 'activity') {
+      setLoading(false);
+    }
+  });
+
+  if (loading) {
+    return <LoadingSpinner />;
+  }
+
+  return (
+    <>
+      <ActivityCard
+        type={nowItemList[0].type}
+        clickDocumentId={nowItemList[0].clickDocumentId}
+        from={nowItemList[0].from}
+        date={nowItemList[0].date}
+      />
+      <ObserverBlock ref={targetRef}>
+        {nowFetching && <LoadingSpinner />}
+      </ObserverBlock>
+    </>
+  );
 }
 
 export default ActivityView;

--- a/client/src/views/activity-view.tsx
+++ b/client/src/views/activity-view.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable array-callback-return */
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { useRecoilValue } from 'recoil';
@@ -27,6 +28,26 @@ const ObserverBlock = styled.div`
   height: 100px;
 `;
 
+const ActivityDiv = styled.div`
+ div + div {
+   margin-bottom: 10px;
+ }
+`;
+
+export const makeActivityToCard = (activity: ActivityCardProps) => (
+  <ActivityCard
+    key={`${(new Date(activity.date)).getTime()}_${activity.from.userId}`}
+    type={activity.type}
+    clickDocumentId={activity.clickDocumentId}
+    from={activity.from}
+    date={activity.date}
+  />
+);
+
+export function ActivityCardList({ activityList }: { activityList: ActivityCardProps[] }) {
+  return <ActivityDiv>{activityList.map(makeActivityToCard)}</ActivityDiv>;
+}
+
 function ActivityView() {
   const [nowItemList, nowItemType] = useFetchItems<ActivityCardProps>('/activity', 'activity');
   const [loading, setLoading] = useState(true);
@@ -42,15 +63,10 @@ function ActivityView() {
   if (loading) {
     return <LoadingSpinner />;
   }
-
   return (
     <>
-      <ActivityCard
-        type={nowItemList[0].type}
-        clickDocumentId={nowItemList[0].clickDocumentId}
-        from={nowItemList[0].from}
-        date={nowItemList[0].date}
-      />
+      <ActivityCardList activityList={nowItemList} />
+
       <ObserverBlock ref={targetRef}>
         {nowFetching && <LoadingSpinner />}
       </ObserverBlock>

--- a/client/src/views/chat-room-detail-view.tsx
+++ b/client/src/views/chat-room-detail-view.tsx
@@ -125,6 +125,7 @@ function ChatRoomDetailView() {
     });
     return () => {
       chatSocket.emit('chat:leave', chatDocumentId);
+      chatSocket.off('chat:sendMsg');
     };
   }, [chatSocket]);
 

--- a/client/src/views/chat-rooms-view.tsx
+++ b/client/src/views/chat-rooms-view.tsx
@@ -78,7 +78,6 @@ function ChatRoomsViews() {
 
   useEffect(() => {
     if (!socket) return;
-    socket.emit('chat:viewJoin', userDocumentId);
     socket.on('chat:alertMsg', setNewRooms);
     socket.on('chat:makeChat', newChatRooms);
   }, [socket]);

--- a/client/src/views/chat-rooms-view.tsx
+++ b/client/src/views/chat-rooms-view.tsx
@@ -1,10 +1,11 @@
 /* eslint-disable no-underscore-dangle */
 
 import React, { useEffect, useState } from 'react';
-import { useRecoilValue } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import { useHistory } from 'react-router-dom';
 
 import userState from '@atoms/user';
+import unReadMsgCountState from '@atoms/not-read-msg';
 import ChatRoomListHeader from '@components/chat/chat-list-header';
 import ChatUserCard from '@components/chat/chat-user-card';
 import { ChatRoomsLayout, ChatUserCardWrap } from '@components/chat/style';
@@ -28,8 +29,10 @@ function ChatRoomsViews() {
   const { userDocumentId } = useRecoilValue(userState);
   const history = useHistory();
   const socket = useChatSocket();
+  const [unReadMsgCount, setUnReadMsgCount] = useRecoilState(unReadMsgCountState);
 
-  const clickEvent = (chatDocumentId: string, participantsInfo: Array<IUser>) => {
+  const chatUserCardClickEvent = (chatDocumentId: string, participantsInfo: Array<IUser>, unCheckedMsg: number) => {
+    setUnReadMsgCount(unReadMsgCount - unCheckedMsg);
     history.push({
       pathname: `/chat-rooms/${chatDocumentId}`,
       state: { participantsInfo },
@@ -90,7 +93,7 @@ function ChatRoomsViews() {
           return (
             <ChatUserCard
               key={chatRoom.chatDocumentId}
-              clickEvent={() => clickEvent(chatRoom.chatDocumentId, chatRoom.participants)}
+              clickEvent={() => chatUserCardClickEvent(chatRoom.chatDocumentId, chatRoom.participants, chatRoom.unCheckedMsg)}
               participantsInfo={chatRoom.participants}
               lastMsg={chatRoom.lastMsg}
               recentActive={date.getDate() === (new Date()).getDate() ? makeDateToHourMinute(date) : makeDateToMonthDate(date)}

--- a/client/src/views/chat-rooms-view.tsx
+++ b/client/src/views/chat-rooms-view.tsx
@@ -80,6 +80,10 @@ function ChatRoomsViews() {
     if (!socket) return;
     socket.on('chat:alertMsg', setNewRooms);
     socket.on('chat:makeChat', newChatRooms);
+    return () => {
+      socket.off('chat:alertMsg');
+      socket.off('chat:makeChat');
+    };
   }, [socket]);
 
   if (loading) return (<LoadingSpinner />);

--- a/client/src/views/main-view.tsx
+++ b/client/src/views/main-view.tsx
@@ -153,6 +153,7 @@ function MainView() {
     });
 
     setCookie('accessToken', accessToken);
+    setLoading(false);
   }, []);
 
   useOutsideClick(RightSideBarLayoutRef);
@@ -164,10 +165,8 @@ function MainView() {
           updateUserState(json);
         } else {
           resetUser();
+          setLoading(false);
         }
-      })
-      .then(() => {
-        setLoading(false);
       });
   }, []);
 

--- a/client/src/views/profile-view.tsx
+++ b/client/src/views/profile-view.tsx
@@ -108,7 +108,10 @@ function ProfileView({ match }: RouteComponentProps<{id: string}>) {
   useEffect(() => {
     setLoading(true);
     const getUserDetail = async () => {
-      const result = await fetch(`${process.env.REACT_APP_API_URL}/api/user/${profileId}?type=userId`).then((res) => res.json());
+      const result = await fetch(`${process.env.REACT_APP_API_URL}/api/user/${profileId}?type=userId`, {
+        method: 'get',
+        credentials: 'include',
+      }).then((res) => res.json());
       if (result.ok) {
         userDetailInfo.current = result.userDetailInfo;
         isFollowingRef.current = followingList.includes(result.userDetailInfo._id);

--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -4,6 +4,7 @@ import event from '@routes/event';
 import user from '@routes/user';
 import search from '@routes/search';
 import chats from '@routes/chats';
+import activity from '@routes/activity';
 
 // guaranteed to get dependencies
 export default () => {
@@ -13,6 +14,7 @@ export default () => {
   user(app);
   search(app);
   chats(app);
+  activity(app);
 
   return app;
 };

--- a/server/src/api/routes/activity.ts
+++ b/server/src/api/routes/activity.ts
@@ -1,0 +1,25 @@
+import {
+  Router, Request, Response,
+} from 'express';
+
+import authJWT from '@middlewares/auth';
+import usersService from '@services/users-service';
+
+const activityRouter = Router();
+
+export default (app: Router) => {
+  app.use('/activity', activityRouter);
+  activityRouter.use(authJWT);
+
+  activityRouter.get('/', async (req: Request, res: Response) => {
+    const { userDocumentId } = req.body;
+    try {
+      const { activity } = await usersService.findUserByDocumentId(userDocumentId);
+      const items = await usersService.makeItemToActivityInterface(activity);
+      res.json({ ok: true, items });
+    } catch (e) {
+      console.error(e);
+      res.json({ ok: false });
+    }
+  });
+};

--- a/server/src/api/routes/activity.ts
+++ b/server/src/api/routes/activity.ts
@@ -26,9 +26,7 @@ export default (app: Router) => {
     const { userDocumentId } = req.body;
     const { count } = req.query;
     try {
-      const user = await usersService.findUserByDocumentId(userDocumentId);
-      const activityList = user!.activity;
-      const items = await usersService.makeItemToActivityInterface(activityList, Number(count));
+      const items = await usersService.getActivityList(userDocumentId, Number(count));
       res.json({ ok: true, items });
     } catch (e) {
       console.error(e);

--- a/server/src/api/routes/activity.ts
+++ b/server/src/api/routes/activity.ts
@@ -13,10 +13,11 @@ export default (app: Router) => {
 
   activityRouter.get('/', async (req: Request, res: Response) => {
     const { userDocumentId } = req.body;
+    const { count } = req.query;
     try {
       const user = await usersService.findUserByDocumentId(userDocumentId);
       const activityList = user!.activity;
-      const items = await usersService.makeItemToActivityInterface(activityList);
+      const items = await usersService.makeItemToActivityInterface(activityList, Number(count));
       res.json({ ok: true, items });
     } catch (e) {
       console.error(e);

--- a/server/src/api/routes/activity.ts
+++ b/server/src/api/routes/activity.ts
@@ -14,8 +14,9 @@ export default (app: Router) => {
   activityRouter.get('/', async (req: Request, res: Response) => {
     const { userDocumentId } = req.body;
     try {
-      const { activity } = await usersService.findUserByDocumentId(userDocumentId);
-      const items = await usersService.makeItemToActivityInterface(activity);
+      const user = await usersService.findUserByDocumentId(userDocumentId);
+      const activityList = user!.activity;
+      const items = await usersService.makeItemToActivityInterface(activityList);
       res.json({ ok: true, items });
     } catch (e) {
       console.error(e);

--- a/server/src/api/routes/activity.ts
+++ b/server/src/api/routes/activity.ts
@@ -11,6 +11,17 @@ export default (app: Router) => {
   app.use('/activity', activityRouter);
   activityRouter.use(authJWT);
 
+  activityRouter.get('/isActivityChecked', async (req: Request, res: Response) => {
+    const { userDocumentId } = req.body;
+    try {
+      const isActivityChecked = await usersService.isActivityChecked(userDocumentId);
+      res.json({ ok: true, isActivityChecked });
+    } catch (e) {
+      console.log(e);
+      res.json({ ok: false });
+    }
+  });
+
   activityRouter.get('/', async (req: Request, res: Response) => {
     const { userDocumentId } = req.body;
     const { count } = req.query;

--- a/server/src/api/routes/chats.ts
+++ b/server/src/api/routes/chats.ts
@@ -2,6 +2,7 @@ import {
   Router, Request, Response,
 } from 'express';
 import chatService from '@services/chat-service';
+import authJWT from '@middlewares/auth';
 
 const chatRouter = Router();
 
@@ -15,6 +16,17 @@ export default (app: Router) => {
       const { chatDocumentId } = await chatService.makeChatRoom(participants);
 
       res.status(200).json({ chatDocumentId });
+    } catch (error) {
+      res.json({ ok: false });
+    }
+  });
+
+  chatRouter.get('/unReadMsgCount', authJWT, async (req: Request, res: Response) => {
+    const { userDocumentId } = req.body;
+    try {
+      const unReadMsgCount = await chatService.getUnReadMsgCount(userDocumentId);
+
+      res.json({ ok: false, unReadMsgCount });
     } catch (error) {
       res.json({ ok: false });
     }

--- a/server/src/api/routes/event.ts
+++ b/server/src/api/routes/event.ts
@@ -1,11 +1,13 @@
 import { Router, Request, Response } from 'express';
 
 import eventsService from '@services/events-service';
+import authJWT from '@middlewares/auth';
 
 const eventRouter = Router();
 
 export default (app: Router) => {
   app.use('/event', eventRouter);
+  eventRouter.use(authJWT);
 
   eventRouter.get('/', async (req:Request, res:Response) => {
     const { count } = req.query;

--- a/server/src/api/routes/event.ts
+++ b/server/src/api/routes/event.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response } from 'express';
 
 import eventsService from '@services/events-service';
+import usersService from '@services/users-service';
 import authJWT from '@middlewares/auth';
 
 const eventRouter = Router();
@@ -23,11 +24,13 @@ export default (app: Router) => {
   eventRouter.post('/', async (req: Request, res: Response) => {
     try {
       const {
-        title, participants, date, description,
+        title, participants, date, description, userDocumentId,
       } = req.body;
 
-      eventsService.setEvent(title, participants, date, description);
+      const eventDocumentId = await eventsService.setEvent(title, participants, date, description);
+      const activityAddResult = await usersService.addActivityTypeEvent(userDocumentId, eventDocumentId);
 
+      if (!activityAddResult) res.status(400).json({ ok: false });
       res.status(200).send('success!');
     } catch (error) {
       console.error(error);

--- a/server/src/api/routes/event.ts
+++ b/server/src/api/routes/event.ts
@@ -31,7 +31,7 @@ export default (app: Router) => {
       const activityAddResult = await usersService.addActivityTypeEvent(userDocumentId, eventDocumentId);
 
       if (!activityAddResult) res.status(400).json({ ok: false });
-      res.status(200).send('success!');
+      else res.status(200).send('success!');
     } catch (error) {
       console.error(error);
     }

--- a/server/src/api/routes/room.ts
+++ b/server/src/api/routes/room.ts
@@ -22,7 +22,7 @@ export default (app: Router) => {
       const activityAddResult = await usersService.addActivityTypeRoom(userDocumentId, roomId);
 
       if (!activityAddResult) res.status(400).json({ ok: false });
-      res.status(200).json(roomId);
+      else res.status(200).json(roomId);
     } catch (error) {
       console.error(error);
     }

--- a/server/src/api/routes/room.ts
+++ b/server/src/api/routes/room.ts
@@ -1,7 +1,9 @@
 import {
   Router, Request, Response,
 } from 'express';
+
 import RoomService from '@services/rooms-service';
+import usersService from '@services/users-service';
 
 const roomRouter = Router();
 
@@ -21,7 +23,10 @@ export default (app: Router) => {
         title, type, isAnonymous,
       } = req.body as unknown as Query;
 
-      const roomId = await RoomService.setRoom(title, type, isAnonymous);
+      const [roomId] = await RoomService.setRoom(title, type, isAnonymous);
+      const activityAddResult = await usersService.addActivityTypeRoom(userDocumentId, roomId);
+
+      if (!activityAddResult) res.status(400).json({ ok: false });
       res.status(200).json(roomId);
     } catch (error) {
       console.error(error);

--- a/server/src/api/routes/room.ts
+++ b/server/src/api/routes/room.ts
@@ -3,27 +3,22 @@ import {
 } from 'express';
 
 import RoomService from '@services/rooms-service';
+import authJWT from '@middlewares/auth';
 import usersService from '@services/users-service';
 
 const roomRouter = Router();
 
-interface Query {
-  title: string,
-  type: string,
-  userId: string,
-  isAnonymous: boolean
-}
-
 export default (app: Router) => {
   app.use('/room', roomRouter);
+  roomRouter.use(authJWT);
 
   roomRouter.post('/', async (req: Request, res: Response) => {
     try {
       const {
-        title, type, isAnonymous,
-      } = req.body as unknown as Query;
+        title, type, isAnonymous, userDocumentId,
+      } = req.body;
 
-      const [roomId] = await RoomService.setRoom(title, type, isAnonymous);
+      const roomId = await RoomService.setRoom(title, type, isAnonymous);
       const activityAddResult = await usersService.addActivityTypeRoom(userDocumentId, roomId);
 
       if (!activityAddResult) res.status(400).json({ ok: false });

--- a/server/src/api/routes/user.ts
+++ b/server/src/api/routes/user.ts
@@ -48,7 +48,9 @@ export default (app: Router) => {
     let result: boolean;
 
     if (type === 'follow') {
-      result = await usersService.followUser(userDocumentId, targetUserDocumentId);
+      [result] = await Promise.all(
+        [usersService.followUser(userDocumentId, targetUserDocumentId), usersService.addActivityTypeFollow(userDocumentId, targetUserDocumentId)],
+      );
       res.json({ ok: result });
     } else if (type === 'unfollow') {
       result = await usersService.unfollowUser(userDocumentId, targetUserDocumentId);

--- a/server/src/models/chats.ts
+++ b/server/src/models/chats.ts
@@ -7,7 +7,7 @@ interface IChattingLog {
   linkTo: string,
 }
 
-interface IUnReadMsg {
+export interface IUnReadMsg {
   userDocumentId: string,
   count: number,
 }

--- a/server/src/models/users.ts
+++ b/server/src/models/users.ts
@@ -9,7 +9,11 @@ export interface IUser {
 }
 
 export interface IActivity {
-    // 추가 설정 필요
+  type: 'follow' | 'event' | 'room',
+  clickDocumentId: string,
+  from: string,
+  date: Date,
+  isChecked: boolean,
 }
 
 export interface IRecentSearch {
@@ -101,6 +105,10 @@ const usersSchema = new Schema({
   joinDate: {
     type: Date,
     default: new Date(),
+  },
+  activity: {
+    type: [Object],
+    default: [],
   },
 });
 

--- a/server/src/services/chat-service.ts
+++ b/server/src/services/chat-service.ts
@@ -1,8 +1,9 @@
+/* eslint-disable prefer-destructuring */
 /* eslint-disable no-return-assign */
 /* eslint-disable no-return-await */
 /* eslint-disable no-underscore-dangle */
 import Users from '@models/users';
-import Chats from '@models/chats';
+import Chats, { IUnReadMsg } from '@models/chats';
 
 let instance: any = null;
 
@@ -73,6 +74,19 @@ class ChatService {
   async setUnCheckedMsg(chatDocumentId: string, userDocumentId: string) {
     await Chats.findOneAndUpdate({ _id: chatDocumentId, 'unReadMsg.userDocumentId': userDocumentId },
       { $set: { 'unReadMsg.$.count': 0 } });
+  }
+
+  async getUnReadMsgCount(userDocumentId: string) {
+    const { chatRooms } :any = await Users.findOne({ _id: userDocumentId }, ['chatRooms']);
+    let unReadMsgCount = 0;
+
+    await Promise.all(chatRooms.map(async (chatDocumentId: string) => {
+      const { unReadMsg } : any = await Chats.findOne({ _id: chatDocumentId }, ['unReadMsg']);
+      const count: number = unReadMsg[unReadMsg.findIndex((item: IUnReadMsg) => item.userDocumentId === userDocumentId)].count;
+      unReadMsgCount += count;
+      return count;
+    }));
+    return unReadMsgCount;
   }
 }
 

--- a/server/src/services/events-service.ts
+++ b/server/src/services/events-service.ts
@@ -38,14 +38,15 @@ export default {
     };
   },
 
-  setEvent: (title:string, participants:object, date:Date, description:string) => {
+  setEvent: async (title:string, participants:object, date:Date, description:string) => {
     const newEvent = new Events({
       title,
       participants,
       date: new Date(date),
       description,
     });
-    return newEvent.save();
+    await newEvent.save();
+    return newEvent._id;
   },
 
   searchEvent: async (keyword: string, count: number) => {

--- a/server/src/services/users-service.ts
+++ b/server/src/services/users-service.ts
@@ -283,6 +283,16 @@ class UserService {
       return false;
     }
   }
+
+  async isActivityChecked(userDocumentId: string) {
+    try {
+      const user = await Users.findOne({ _id: userDocumentId }, ['activity']);
+      if (!user || !user.activity) return false;
+      return user!.activity.findIndex((activity) => !activity.isChecked) > -1;
+    } catch (e) {
+      return false;
+    }
+  }
 }
 
 export default new UserService();

--- a/server/src/services/users-service.ts
+++ b/server/src/services/users-service.ts
@@ -2,7 +2,7 @@
 import nodemailer from 'nodemailer';
 import jwt from 'jsonwebtoken';
 
-import Users, { IUserTypesModel } from '@models/users';
+import Users, { IUserTypesModel, IActivity } from '@models/users';
 import RefreshTokens from '@models/refresh-token';
 import jwtUtils from '@utils/jwt-util';
 
@@ -193,6 +193,15 @@ class UserService {
       joinDate,
       profileUrl,
     };
+  }
+
+  async makeItemToActivityInterface(activityList: Array<IActivity>) {
+    const newActivityList = await Promise.all(activityList.map(async (activity: IActivity) => {
+      const detailFrom = await this.findUserByDocumentId(activity.from);
+      const newFrom = { userId: detailFrom!.userId, userName: detailFrom!.userName, profileUrl: detailFrom!.profileUrl };
+      return { ...activity, from: newFrom };
+    }));
+    return newActivityList;
   }
 
   async searchUsers(keyword: string, count: number) {

--- a/server/src/services/users-service.ts
+++ b/server/src/services/users-service.ts
@@ -2,7 +2,8 @@
 import nodemailer from 'nodemailer';
 import jwt from 'jsonwebtoken';
 
-import Users, { IUserTypesModel, IActivity, IUsers } from '@models/users';
+import Users, { IUserTypesModel, IActivity } from '@models/users';
+import Events from '@models/events';
 import RefreshTokens from '@models/refresh-token';
 import jwtUtils from '@utils/jwt-util';
 
@@ -322,6 +323,26 @@ class UserService {
       };
       await Promise.all(user!.followers.map(async (userId: string) => {
         await Users.findByIdAndUpdate(userId, { $push: { activity: newActivity } });
+        return true;
+      }));
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  async addActivityTypeEvent(userDocumentId: string, eventDocumentId: string) {
+    try {
+      const event = await Events.findById(eventDocumentId, ['participants']);
+      const newActivity = {
+        type: 'event',
+        clickDocumentId: eventDocumentId,
+        from: userDocumentId,
+        date: new Date(),
+        isChecked: false,
+      };
+      await Promise.all(event!.participants.map(async (userId: string) => {
+        await Users.findOneAndUpdate({ userId }, { $push: { activity: newActivity } });
         return true;
       }));
       return true;

--- a/server/src/services/users-service.ts
+++ b/server/src/services/users-service.ts
@@ -309,6 +309,26 @@ class UserService {
       return false;
     }
   }
+
+  async addActivityTypeRoom(userDocumentId: string, roomDocumentId: string) {
+    try {
+      const user = await Users.findById(userDocumentId, ['followers']);
+      const newActivity = {
+        type: 'room',
+        clickDocumentId: roomDocumentId,
+        from: userDocumentId,
+        date: new Date(),
+        isChecked: false,
+      };
+      await Promise.all(user!.followers.map(async (userId: string) => {
+        await Users.findByIdAndUpdate(userId, { $push: { activity: newActivity } });
+        return true;
+      }));
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
 }
 
 export default new UserService();

--- a/server/src/services/users-service.ts
+++ b/server/src/services/users-service.ts
@@ -195,8 +195,8 @@ class UserService {
     };
   }
 
-  async makeItemToActivityInterface(activityList: Array<IActivity>) {
-    const newActivityList = await Promise.all(activityList.map(async (activity: IActivity) => {
+  async makeItemToActivityInterface(activityList: Array<IActivity>, count: number) {
+    const newActivityList = await Promise.all(activityList.reverse().slice(count, count + 10).map(async (activity: IActivity) => {
       const detailFrom = await this.findUserByDocumentId(activity.from);
       const newFrom = { userId: detailFrom!.userId, userName: detailFrom!.userName, profileUrl: detailFrom!.profileUrl };
       return { ...activity, from: newFrom };

--- a/server/src/services/users-service.ts
+++ b/server/src/services/users-service.ts
@@ -293,6 +293,22 @@ class UserService {
       return false;
     }
   }
+
+  async addActivityTypeFollow(userDocumentId: string, targetUserDocumentId: string) {
+    try {
+      const newActivity = {
+        type: 'follow',
+        clickDocumentId: userDocumentId,
+        from: userDocumentId,
+        date: new Date(),
+        isChecked: false,
+      };
+      await Users.findByIdAndUpdate(targetUserDocumentId, { $push: { activity: newActivity } });
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
 }
 
 export default new UserService();

--- a/server/src/services/users-service.ts
+++ b/server/src/services/users-service.ts
@@ -196,12 +196,14 @@ class UserService {
     };
   }
 
-  async makeItemToActivityInterface(activityList: Array<IActivity>, count: number) {
-    const newActivityList = await Promise.all(activityList.reverse().slice(count, count + 10).map(async (activity: IActivity) => {
+  async getActivityList(userDocumentId: string, count: number) {
+    const user = await Users.findById(userDocumentId, ['activity']);
+    const newActivityList = await Promise.all(user!.activity.reverse().slice(count, count + 10).map(async (activity: IActivity) => {
       const detailFrom = await this.findUserByDocumentId(activity.from);
       const newFrom = { userId: detailFrom!.userId, userName: detailFrom!.userName, profileUrl: detailFrom!.profileUrl };
       return { ...activity, from: newFrom };
     }));
+    await Users.findByIdAndUpdate(userDocumentId, { activity: user!.activity.map((el) => ({ ...el, isChecked: true })) });
     return newActivityList;
   }
 

--- a/server/src/services/users-service.ts
+++ b/server/src/services/users-service.ts
@@ -2,7 +2,7 @@
 import nodemailer from 'nodemailer';
 import jwt from 'jsonwebtoken';
 
-import Users, { IUserTypesModel, IActivity } from '@models/users';
+import Users, { IUserTypesModel, IActivity, IUsers } from '@models/users';
 import RefreshTokens from '@models/refresh-token';
 import jwtUtils from '@utils/jwt-util';
 
@@ -286,9 +286,9 @@ class UserService {
 
   async isActivityChecked(userDocumentId: string) {
     try {
-      const user = await Users.findOne({ _id: userDocumentId }, ['activity']);
-      if (!user || !user.activity) return false;
-      return user!.activity.findIndex((activity) => !activity.isChecked) > -1;
+      const { activity } : any = await Users.findOne({ _id: userDocumentId }, ['activity']);
+      if (!activity) return false;
+      return activity.some((item: IActivity) => !item.isChecked);
     } catch (e) {
       return false;
     }

--- a/server/src/sockets/chat.ts
+++ b/server/src/sockets/chat.ts
@@ -80,6 +80,10 @@ export default function chatEventHandler(socket : Socket, namespace: Namespace) 
     });
   };
 
+  const updateCountHandler = (participants: Array<string>) => {
+    participants.forEach((userDocumentId: string) => socket.to(userDocumentId).emit('chat:updateCount'));
+  };
+
   socket.on('chat:roomJoin', chatRoomJoinHandler);
   socket.on('chat:viewJoin', chatViewJoinHandler);
   socket.on('chat:sendMsg', sendMsgHandler);
@@ -87,4 +91,5 @@ export default function chatEventHandler(socket : Socket, namespace: Namespace) 
   socket.on('chat:alertMsg', alertMsgHandler);
   socket.on('chat:makeChat', makeChatHandler);
   socket.on('chat:inviteRoom', inviteRoomHandler);
+  socket.on('chat:updateCount', updateCountHandler);
 }


### PR DESCRIPTION
## 개요
- Acitivity 페이지 구현
- 확인할 Activity가 있는 경우 헤더에 표시
- 안읽은 메세지 개수 헤더에 표시 구현
- 팔로우, 룸 생성, 이벤트 등록 시에 관련된 상대방에게 Acitivity 알림이 가도록 구현
## 작업사항
- Activity 컴포넌트 구현
- 확인할 Activity가 있는 경우 헤더에 표시
- 안읽은 메세지 개수 헤더에 표시 구현
- 
## 변경로직
- userModel에 activity array를 추가해주었습니다!!
- 있는줄 알았는데 없더라구요 ...ㅜ
- 로그인 / 회원가입을 제외한 api 호출에는 accessToken이 없으면 접근하지 못하도록 하기위해서 모든 fetch 요청에 `credential: include`를 해주었습니다.

### 변경후

- 안읽은 메세지 확인 및 확인할 Activity 있는경우 표시

https://user-images.githubusercontent.com/51700274/143281380-7ea93b34-881a-4c53-a783-019090541078.mov

## 사용방법
- 영상 참고해주세요 !

## DB 업데이트 관련
- 한 유저의 activity를 조회하는 과정에서 조회가 된다면 `isChecked`를 `true`로 변경해서 읽음 처리를 해결하려고 했는데 `User.activity` 배열의 모든 `isChecked`의 값을 변경해주는 메소드를 찾기가 어려워서 현재 해당하는 user의 기존 `acitivity` 배열을 copy 후 수동으로 `isChecked` 를 변경해주고 있습니다.. array<object> field 를 업데이트 하는 방법이 뭐가 있을까요 `isMic`업데이트를 참고하려고 했는데 잘 안되어서 오늘은 우선 임시로 마무리했습니다!

### 남은 기능
- activity 알림을 소켓 이벤트를 통해 실시간으로 변경하기
- activity-card 클릭 이벤트 등록