### PR TITLE
알림기능 실시간 알림 반영

### DIFF
--- a/client/src/components/common/default-header.tsx
+++ b/client/src/components/common/default-header.tsx
@@ -187,7 +187,7 @@ function DefaultHeader() {
     if (!userSocket) return;
     userSocket.on('user:getActivity', () => setActivityChecked(true));
     return () => {
-      userSocket.emit('user:headerLeave');
+      userSocket.off('user:getActivity');
     };
   }, [userSocket]);
 

--- a/server/src/services/users-service.ts
+++ b/server/src/services/users-service.ts
@@ -198,7 +198,7 @@ class UserService {
 
   async getActivityList(userDocumentId: string, count: number) {
     const user = await Users.findById(userDocumentId, ['activity']);
-    const newActivityList = await Promise.all(user!.activity.reverse().slice(count, count + 10).map(async (activity: IActivity) => {
+    const newActivityList = await Promise.all(user!.activity.slice(count, count + 10).map(async (activity: IActivity) => {
       const detailFrom = await this.findUserByDocumentId(activity.from);
       const newFrom = { userId: detailFrom!.userId, userName: detailFrom!.userName, profileUrl: detailFrom!.profileUrl };
       return { ...activity, from: newFrom };
@@ -306,7 +306,7 @@ class UserService {
         date: new Date(),
         isChecked: false,
       };
-      await Users.findByIdAndUpdate(targetUserDocumentId, { $push: { activity: newActivity } });
+      await Users.findByIdAndUpdate(targetUserDocumentId, { $push: { activity: { $each: [newActivity], $position: 0 } } });
       return true;
     } catch (e) {
       return false;
@@ -324,7 +324,7 @@ class UserService {
         isChecked: false,
       };
       await Promise.all(user!.followers.map(async (userId: string) => {
-        await Users.findByIdAndUpdate(userId, { $push: { activity: newActivity } });
+        await Users.findByIdAndUpdate(userId, { $push: { activity: { $each: [newActivity], $position: 0 } } });
         return true;
       }));
       return true;
@@ -344,7 +344,7 @@ class UserService {
         isChecked: false,
       };
       await Promise.all(event!.participants.map(async (userId: string) => {
-        await Users.findOneAndUpdate({ userId }, { $push: { activity: newActivity } });
+        await Users.findOneAndUpdate({ userId }, { $push: { activity: { $each: [newActivity], $position: 0 } } });
         return true;
       }));
       return true;

--- a/server/src/sockets/index.ts
+++ b/server/src/sockets/index.ts
@@ -8,7 +8,7 @@ const server = new Server({
 });
 
 const roomNamespace = server.of('/room');
-const userNamespace = server.of('/user');
+export const userNamespace = server.of('/user');
 const chatNamespace = server.of('/chat');
 
 roomNamespace.on('connection', (socket: Socket) => roomHandler(socket, roomNamespace));

--- a/server/src/sockets/user.ts
+++ b/server/src/sockets/user.ts
@@ -18,7 +18,7 @@ interface IActiveFollowingUser {
 
 const socketUser = new Map();
 
-const activeUser = new Map();
+export const activeUser = new Map();
 
 export default function userHandler(socket : Socket, namespace : Namespace) {
   const handleUserJoin = ({


### PR DESCRIPTION
## 개요

오늘 오전 PR 알림기능에서 팔로우, 룸 생성, 이벤트 등록을 할 때 알림을 받을 사람에게 실시간으로 헤더 알림을 보여줍니다


## 구현 내용 
- `user:getActivity` emit 소켓 이벤트 등록
- 유저들에게 activity 를 삽입함과 동시에 소켓을 emit 해줍니다 따라서 서비스 로직에서 소켓을 참조하게 되었습니다.