### PR TITLE
초대 페이지 구현

### DIFF
--- a/client/src/views/invite-view.tsx
+++ b/client/src/views/invite-view.tsx
@@ -1,7 +1,115 @@
-import React from 'react';
+import React, {
+  useCallback, useRef, useState,
+} from 'react';
+import { RouteComponentProps } from 'react-router-dom';
+import { useSetRecoilState } from 'recoil';
+import styled from 'styled-components';
 
-function InviteView() {
-  return (<></>);
+import toastListSelector from '@selectors/toast-list';
+import { CustomInputBox, CustomInputBar } from '@common/custom-inputbar';
+import { BackgroundWrapper } from '@common/modal';
+import DefaultButton from '@common/default-button';
+import LoadingSpinner from '@src/components/common/loading-spinner';
+import { testEmailValidation } from '@src/utils';
+
+const CustomBackgroundWrapper = styled(BackgroundWrapper)`
+  opacity: 0.4;
+`;
+
+const InviteBody = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+`;
+
+const InputTitle = styled.div`
+  width: max-content;
+  font-size: min(6vw, 40px);
+  text-align: center;
+`;
+
+function InviteView({ history }: RouteComponentProps) {
+  const [isDisabled, setIsDisabled] = useState(true);
+  const [loading, setLoading] = useState(false);
+  const inputEmailRef = useRef<HTMLInputElement>(null);
+  const setToastList = useSetRecoilState(toastListSelector);
+
+  const inputOnChange = useCallback(() => {
+    if (inputEmailRef.current?.value) {
+      setIsDisabled(false);
+    } else {
+      setIsDisabled(true);
+    }
+  }, []);
+
+  const fetchPostInviteMail = async (inputEmailValue: string) => {
+    const { isUnique } = await fetch(`${process.env.REACT_APP_API_URL}/api/user/invite`, {
+      method: 'POST',
+      credentials: 'include',
+      body: JSON.stringify({ email: inputEmailValue }),
+    }).then((res) => res.json()) as { isUnique: boolean };
+    if (isUnique) {
+      setLoading(false);
+      setToastList({
+        type: 'success',
+        title: '전송 완료',
+        description: '초대장이 발송되었습니다',
+      });
+      history.push('/');
+    } else {
+      setLoading(false);
+      setToastList({
+        type: 'warning',
+        title: '초대 에러',
+        description: '이미 존재하는 이메일입니다',
+      });
+    }
+  };
+
+  const onClickInviteButton = () => {
+    const inputEmailValue = inputEmailRef.current?.value as string;
+
+    if (testEmailValidation(inputEmailValue)) {
+      setLoading(true);
+      fetchPostInviteMail(inputEmailValue);
+    } else {
+      setToastList({
+        type: 'warning',
+        title: '초대 오류',
+        description: '올바른 형식의 이메일을 입력해주세요',
+      });
+    }
+  };
+
+  return (
+    <>
+      {loading && <CustomBackgroundWrapper><LoadingSpinner /></CustomBackgroundWrapper>}
+      <InviteBody>
+        <InputTitle> enter the email to invite </InputTitle>
+        <CustomInputBox>
+          <CustomInputBar
+            key="text"
+            ref={inputEmailRef}
+            onChange={inputOnChange}
+            type="text"
+            placeholder="E-mail Address"
+          />
+        </CustomInputBox>
+        <DefaultButton
+          buttonType="secondary"
+          size="medium"
+          onClick={onClickInviteButton}
+          isDisabled={isDisabled}
+        >
+          NEXT
+        </DefaultButton>
+      </InviteBody>
+    </>
+  );
 }
 
 export default InviteView;

--- a/client/src/views/invite-view.tsx
+++ b/client/src/views/invite-view.tsx
@@ -45,6 +45,9 @@ function InviteView({ history }: RouteComponentProps) {
     const { isUnique } = await fetch(`${process.env.REACT_APP_API_URL}/api/user/invite`, {
       method: 'POST',
       credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+      },
       body: JSON.stringify({ email: inputEmailValue }),
     }).then((res) => res.json()) as { isUnique: boolean };
     if (isUnique) {

--- a/client/src/views/invite-view.tsx
+++ b/client/src/views/invite-view.tsx
@@ -7,14 +7,9 @@ import styled from 'styled-components';
 
 import toastListSelector from '@selectors/toast-list';
 import { CustomInputBox, CustomInputBar } from '@common/custom-inputbar';
-import { BackgroundWrapper } from '@common/modal';
 import DefaultButton from '@common/default-button';
 import LoadingSpinner from '@src/components/common/loading-spinner';
 import { testEmailValidation } from '@src/utils';
-
-const CustomBackgroundWrapper = styled(BackgroundWrapper)`
-  opacity: 0.4;
-`;
 
 const InviteBody = styled.div`
   position: relative;
@@ -64,7 +59,7 @@ function InviteView({ history }: RouteComponentProps) {
       setLoading(false);
       setToastList({
         type: 'warning',
-        title: '초대 에러',
+        title: '초대장 에러',
         description: '이미 존재하는 이메일입니다',
       });
     }
@@ -79,36 +74,34 @@ function InviteView({ history }: RouteComponentProps) {
     } else {
       setToastList({
         type: 'warning',
-        title: '초대 오류',
+        title: '초대장 에러',
         description: '올바른 형식의 이메일을 입력해주세요',
       });
     }
   };
 
   return (
-    <>
-      {loading && <CustomBackgroundWrapper><LoadingSpinner /></CustomBackgroundWrapper>}
-      <InviteBody>
-        <InputTitle> enter the email to invite </InputTitle>
-        <CustomInputBox>
-          <CustomInputBar
-            key="text"
-            ref={inputEmailRef}
-            onChange={inputOnChange}
-            type="text"
-            placeholder="E-mail Address"
-          />
-        </CustomInputBox>
-        <DefaultButton
-          buttonType="secondary"
-          size="medium"
-          onClick={onClickInviteButton}
-          isDisabled={isDisabled}
-        >
-          NEXT
-        </DefaultButton>
-      </InviteBody>
-    </>
+    <InviteBody>
+      {loading && <LoadingSpinner />}
+      <InputTitle> enter the email to invite </InputTitle>
+      <CustomInputBox>
+        <CustomInputBar
+          key="text"
+          ref={inputEmailRef}
+          onChange={inputOnChange}
+          type="text"
+          placeholder="E-mail Address"
+        />
+      </CustomInputBox>
+      <DefaultButton
+        buttonType="secondary"
+        size="medium"
+        onClick={onClickInviteButton}
+        isDisabled={isDisabled}
+      >
+        NEXT
+      </DefaultButton>
+    </InviteBody>
   );
 }
 

--- a/server/src/api/routes/user.ts
+++ b/server/src/api/routes/user.ts
@@ -164,14 +164,17 @@ export default (app: Router) => {
 
   userRouter.post('/invite', authJWT, async (req: Request, res: Response) => {
     const { userDocumentId, email } = req.body;
+    try {
+      const isUnique: boolean = await usersService.isUniqueEmail(email);
 
-    const isUnique: boolean = await usersService.isUniqueEmail(email);
-
-    if (isUnique) {
-      const result = await usersService.sendInviteMail(userDocumentId, email);
-      res.json({ ok: result, isUnique });
-    } else {
-      res.json({ isUnique });
+      if (isUnique) {
+        const result = await usersService.sendInviteMail(userDocumentId, email);
+        res.json({ ok: result, isUnique });
+      } else {
+        res.json({ ok: false, isUnique });
+      }
+    } catch (e) {
+      res.json({ ok: false, isUnique: false });
     }
   });
 };

--- a/server/src/api/routes/user.ts
+++ b/server/src/api/routes/user.ts
@@ -161,4 +161,17 @@ export default (app: Router) => {
       res.json({ ok: false });
     }
   });
+
+  userRouter.post('/invite', authJWT, async (req: Request, res: Response) => {
+    const { userDocumentId, email } = req.body;
+
+    const isUnique: boolean = await usersService.isUniqueEmail(email);
+
+    if (isUnique) {
+      const result = await usersService.sendInviteMail(userDocumentId, email);
+      res.json({ ok: result, isUnique });
+    } else {
+      res.json({ isUnique });
+    }
+  });
 };

--- a/server/src/services/users-service.ts
+++ b/server/src/services/users-service.ts
@@ -154,11 +154,49 @@ class UserService {
     await transporter.sendMail({
       from: 'hyunee169@gmail.com',
       to: email,
-      subject: '인증번호입니다.',
-      text: VerificationNumber,
+      subject: '노가리하우스 인증번호입니다',
+      html: `
+      <h1>인증번호<h1>
+      <h3>아래의 인증번호를 회원가입 화면에 입력해주세요</h3>
+      <h2>${VerificationNumber}</h2>
+      `,
     });
 
     return VerificationNumber;
+  }
+
+  async sendInviteMail(userDocumentId: string, email: string) {
+    const transporter = nodemailer.createTransport({
+      service: 'gmail',
+      port: 587,
+      host: 'smtp.gmail.com',
+      secure: false,
+      requireTLS: true,
+      auth: {
+        user: 'hyunee169@gmail.com',
+        pass: process.env.GMAIL_PASS,
+      },
+    });
+
+    const user = await Users.findById(userDocumentId);
+    const inviteLink = 'https://nogarihouse.nemne.dev/signup';
+
+    await transporter.sendMail({
+      from: 'hyunee169@gmail.com',
+      to: email,
+      subject: '노가리하우스로 초대합니다.',
+      html: `
+      <h1>${user!.userName}님이 노가리 하우스로 초대하셨습니다.</h1>
+      
+      <div><a href=${inviteLink}>🐟 Nogari House 바로가기 🐟</a></div>
+      
+      <div>언제 어디서나 편하게 노가리를 깔 수 있는곳! 노가리 하우스🏖로 놀러오세요</div>
+      <div>다양한 주제로 다양한 사람들과 노라기를 깔 수 있습니다! 🎤</div>
+      <div>아직 나의 목소리를 공개하기 수줍다고요? 그럼 익명 음성 채팅 기능을 활용해보세요! 😎</div>
+      <div>클럽하우*는 모바일만 지원이 됐죠? 노가리 하우스는 웹에서도 지원이 됩니다! 🛠️</div>
+      <div>만약 이번에 만난 사람들과 더 노가릴 까고 싶다면? 팔로우 하세요! 🙌</div>
+      <div>가입하기 귀찮으시다고요? 그럼 SNS를 통해 간단히 회원가입해보세요!🤝</div>`,
+    });
   }
 
   makeItemToUserInterface(


### PR DESCRIPTION
## 개요
- 초대 메일 발송페이지 구현
## 작업사항
- sign up 에서 이메일 발송하는 로직과 동일하게 발송
- 이메일 내용에는 회원가입 페이지로 이동할 수 있는 링크가 포함되어 있습니다.
- 이메일 내용을 text에서 html로 변경했습니다


### 변경후

초대 이메일
![image](https://user-images.githubusercontent.com/74816327/143399988-8b42c522-c62d-48e0-af88-3775b0983230.png)

인증번호 이메일
![image](https://user-images.githubusercontent.com/74816327/143400030-65abe073-8d4c-4a5d-9d63-33ae59dfeced.png)


## 기타
- email 인증 없이 회원가입을 해주고 싶었는데 방법 고민을 좀 해봐야겠네요
