### PR TITLE
♻️ client api 폴더 리팩토링

### DIFF
--- a/client/src/api/user/index.ts
+++ b/client/src/api/user/index.ts
@@ -1,0 +1,164 @@
+import {
+  getCredentialsOption, postCredentialsOption, postOption,
+} from '@api/util';
+import { IUserDetail } from '@src/interfaces';
+
+export const getUserInfo = async (userDocumentId: string) => {
+  try {
+    const response = await fetch(`${process.env.REACT_APP_API_URL}/api/user/${userDocumentId}?type=documentId`, getCredentialsOption());
+
+    if (!response.ok) throw new Error(`HTTP Error! status: ${response.status}`);
+
+    const json: { ok: boolean, userInfo: { profileUrl: string, userName: string, userId: string } } = await response.json();
+    return json;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+export const postSignIn = async (loginInfo: Object) => {
+  try {
+    const response = await fetch(`${process.env.REACT_APP_API_URL}/api/user/signin`,
+      postOption(loginInfo));
+
+    if (!response.ok) throw new Error(`HTTP Error! status: ${response.status}`);
+
+    const json: { accessToken?: string, result: boolean, msg: string } = await response.json();
+
+    return json;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+export const postSignUpUserInfo = async (postSignupUserInfoConfig: Object) => {
+  try {
+    const response = await fetch(`${process.env.REACT_APP_API_URL}/api/user/signup/userInfo`,
+      postOption(postSignupUserInfoConfig));
+
+    if (!response.ok) throw new Error(`HTTP Error! status: ${response.status}`);
+
+    const json: { ok: boolean, msg: string } = await response.json();
+
+    return json;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+export const postCheckMail = async (email: { email: string }) => {
+  try {
+    const response = await fetch(`${process.env.REACT_APP_API_URL}/api/user/signup/mail`, postOption(email));
+
+    if (!response.ok) throw new Error(`HTTP Error! status: ${response.status}`);
+
+    const json: { isUnique: boolean, verificationNumber: string } = await response.json();
+
+    return json;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+type TFindUsersById = {
+    _id: string;
+    userName: string;
+    description: string;
+    profileUrl: string;
+    userId: string;
+    type: string;
+}
+
+export const findUsersByIdList = async (findUserList: Array<string>) => {
+  try {
+    const response = await fetch(`${process.env.REACT_APP_API_URL}/api/user/info`, postCredentialsOption({ userList: findUserList }));
+
+    if (!response.ok) throw new Error(`HTTP Error! status: ${response.status}`);
+
+    const json: { ok: boolean, userList: Array<TFindUsersById>} = await response.json();
+
+    return json;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+export const getFollowingsList = async (userDocumentId: string) => {
+  try {
+    const response = await fetch(`${process.env.REACT_APP_API_URL}/api/user/my-followings/${userDocumentId}`, getCredentialsOption());
+
+    if (!response.ok) throw new Error(`HTTP Error! status: ${response.status}`);
+
+    const json: { followingList: Array<string> } = await response.json();
+
+    return json;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+type TGetMyInfo = {
+    ok: boolean,
+    accessToken?: string,
+    userDocumentId?: string,
+    profileUrl?: string,
+    userName?: string,
+    userId?: string,
+}
+
+export const getMyInfo = async () => {
+  try {
+    const response = await fetch(`${process.env.REACT_APP_API_URL}/api/user`, getCredentialsOption());
+
+    if (!response.ok) throw new Error(`HTTP Error! status: ${response.status}`);
+
+    const json: TGetMyInfo = await response.json();
+    return json;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+type TChangeProfileImage = { ok: boolean, newProfileUrl: string }
+
+export const changeProfileImage = async (userDocumentId: string, formData: FormData) => {
+  try {
+    const response = await fetch(`${process.env.REACT_APP_API_URL}/api/user/profile-image`, postCredentialsOption(formData));
+
+    if (!response.ok) throw new Error(`HTTP Error! status: ${response.status}`);
+
+    const json: TChangeProfileImage = await response.json();
+
+    return json;
+  } catch (e) {
+    console.log(e);
+  }
+};
+
+export const getUserExistenceByUserId = async (userId: string) => {
+  try {
+    const response = await fetch(`${process.env.REACT_APP_API_URL}/api/user/${userId}?type=userIdCheck`, getCredentialsOption());
+
+    if (!response.ok) throw new Error(`HTTP Error! status: ${response.status}`);
+
+    const json : { ok: boolean } = await response.json();
+
+    return json.ok;
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+export const getUserDetail = async (profileId: string) => {
+  try {
+    const response = await fetch(`${process.env.REACT_APP_API_URL}/api/user/${profileId}?type=userId`, getCredentialsOption());
+
+    if (!response.ok) throw new Error(`HTTP Error! status: ${response.status}`);
+
+    const json: { ok: boolean, userDetailInfo?: IUserDetail } = await response.json();
+
+    return json;
+  } catch (error) {
+    console.log(error);
+  }
+};

--- a/client/src/api/util.ts
+++ b/client/src/api/util.ts
@@ -1,0 +1,35 @@
+export const getCredentialsOption = (): RequestInit => (
+  {
+    method: 'get',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+export const getOption = (): RequestInit => (
+  {
+    method: 'get',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+export const postCredentialsOption = (body: any): RequestInit => (
+  {
+    method: 'post',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+export const postOption = (body: any): RequestInit => (
+  {
+    method: 'post',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });

--- a/client/src/views/profile-view.tsx
+++ b/client/src/views/profile-view.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components';
 import followingListState from '@atoms/following-list';
 import { isOpenChangeProfileImageModalState } from '@atoms/is-open-modal';
 import userState from '@atoms/user';
+import { getUserDetail } from '@api/user';
 import LoadingSpinner from '@common/loading-spinner';
 import DefaultButton from '@common/default-button';
 import useIsFollowingRef from '@hooks/useIsFollowingRef';
@@ -105,19 +106,16 @@ function ProfileView({ match }: RouteComponentProps<{id: string}>) {
 
   useEffect(() => {
     setLoading(true);
-    const getUserDetail = async () => {
-      const result = await fetch(`${process.env.REACT_APP_API_URL}/api/user/${profileId}?type=userId`, {
-        method: 'get',
-        credentials: 'include',
-      }).then((res) => res.json());
-      if (result.ok) {
-        userDetailInfo.current = result.userDetailInfo;
-        isFollowingRef.current = followingList.includes(result.userDetailInfo._id);
+    const fetchUserDetail = async () => {
+      const json = await getUserDetail(profileId);
+      if (json && json.ok) {
+        userDetailInfo.current = json.userDetailInfo;
+        isFollowingRef.current = followingList.includes(json.userDetailInfo!._id);
       }
       setLoading(false);
     };
 
-    getUserDetail();
+    fetchUserDetail();
   }, [isFollowingRef.current, profileId, user]);
 
   if (loading) {


### PR DESCRIPTION
## 개요
♻️ client api 폴더 리팩토링

## 작업사항
- get, post Request Init 을 만들어주는api / util 파일을 만들었습니다.
- 기존 api 폴더의 `index.ts` 에서 user 부분만 따로 분리해봤습니다.
- 아직 분리된 코드를 기존 파일에서 삭제하지는 않고 export 해서 실제로 사용하지는 않았습니다.
- export 해서 any 타입으로 사용된 부분을 리팩토링하기 위해서 return 되는 값의 타입을 명시해주었습니다.

## 기타
- 리팩토링 개선점 있으면 코멘트 부탁드려요! 