### PR TITLE
🐛  메세지 입력후 스크롤이 정상적으로 내려가지 않는 버그 수정

### DIFF
--- a/client/src/components/chat/detail-view/index.tsx
+++ b/client/src/components/chat/detail-view/index.tsx
@@ -52,7 +52,7 @@ function ChatRoomDetailView() {
 
   const addChattingLog = (chatLog: IChattingLog) => {
     dispatch({ type: 'ADD_CHATTING_LOG', payload: { chatLog } });
-    chattingLogDiv.current!.scrollTop = chattingLogDiv.current!.scrollHeight - chattingLogDiv.current!.clientHeight;
+    chattingLogDiv.current!.scrollTop = 0;
   };
 
   const onIntersect = async (entries: IntersectionObserverEntry[]) => {


### PR DESCRIPTION
- flex-direction 에서 column-reverse로 주면 scrollTop 값의 기준이 바뀐다는 사실... 알고계셨나요?
- 기본적인 상태에서는 스크롤의 최상단 부분의 scrollTop값이 0부터 해서 아래로 갈수록 숫자가 늘어나는데, flex-direction reverse를 해주면 맨 아래가 0, 위로 갈수록 숫자가 줄어들어 음수가 됩니다...ㄷㄷ
- 지금 채팅방은 column-reverse가 되어있기 때문에 최하단 부분의 scrollTop 값을 0으로 해줘야 했어요..!!
- 잘 내려갔던 경우는 뭔지 그게 더 궁금합니다 ㅋㅋㅋㅋ

ps) 코드 한줄만 바꿔서 원래 사용하던 PR 탬플릿은 적용하지 않았습니다 히히